### PR TITLE
feat(langfuse): OTLP trace + eval-score integration for agents

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -401,6 +401,7 @@ var webApplication = new Syringe()
 - Run multi-step agentic workloads with O(n) token cost via [Iterative Agent Loop](iterative-agent-loop.md)
 - Use [GitHub Copilot](copilot.md) as a free local-dev AI provider with web search
 - Plug Needlr agent results directly into [Microsoft.Extensions.AI.Evaluation](evaluation.md) — no flattening, no adapters
+- Send agent traces and eval scores to [Langfuse](langfuse.md) with a single call
 !!! info "Read More on Dev Leader"
     - [Getting Started with Needlr: Fluent DI for .NET Applications](https://www.devleader.ca/2026/02/05/getting-started-with-needlr-fluent-di-for-net-applications)
     - [Automatic Dependency Injection in C#: The Complete Guide to Needlr](https://www.devleader.ca/2026/02/03/automatic-dependency-injection-in-c-the-complete-guide-to-needlr)

--- a/docs/langfuse.md
+++ b/docs/langfuse.md
@@ -1,0 +1,246 @@
+# Langfuse
+
+Send Needlr agent telemetry and `Microsoft.Extensions.AI.Evaluation` scores to
+[Langfuse](https://langfuse.com) so agent runs and evals show up on the Langfuse
+dashboard — with a single call.
+
+Needlr already emits OpenTelemetry traces and metrics using the GenAI semantic
+conventions (`gen_ai.*`), which Langfuse understands natively. The
+`NexusLabs.Needlr.AgentFramework.Langfuse` package adds the missing piece: an OTLP
+exporter pointed at Langfuse, per-scenario trace grouping, and a bridge that turns
+evaluator metrics into Langfuse scores.
+
+## Quick Start
+
+Install the package and start a session from environment variables:
+
+```bash
+export LANGFUSE_PUBLIC_KEY="pk-lf-..."
+export LANGFUSE_SECRET_KEY="sk-lf-..."
+# Optional — defaults to Langfuse Cloud (EU). Set for self-hosted or other regions:
+# export LANGFUSE_HOST="http://localhost:3000"
+```
+
+```csharp
+using NexusLabs.Needlr.AgentFramework.Evaluation;
+using NexusLabs.Needlr.AgentFramework.Langfuse;
+
+// 1. Start export (no-ops cleanly when credentials are absent).
+using var langfuse = LangfuseTelemetry.Start(LangfuseOptions.FromEnvironment());
+
+// 2. One Langfuse trace per eval scenario.
+using (var scenario = langfuse.BeginScenario(
+    name: "trip-planner: NYC -> Tokyo",
+    sessionId: runId,
+    tags: ["regression"]))
+{
+    // Agent telemetry produced here nests under the scenario trace.
+    var run = await runner.RunAsync(config, hooks, cancellationToken);
+
+    var inputs = run.Diagnostics!.ToEvaluationInputs();
+    var result = await new EfficiencyEvaluator(tokenBudget: 200_000).EvaluateAsync(
+        inputs.Messages, inputs.ModelResponse, additionalContext: [new AgentRunDiagnosticsContext(run.Diagnostics!)]);
+
+    // 3. Evaluator metrics become Langfuse scores on this trace.
+    await result.RecordLangfuseScoresAsync(scenario);
+}
+
+langfuse.Flush();
+```
+
+That is the entire integration. When `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY`
+are not set (or no `Host`/`Region` target is chosen), the session is disabled and
+every call becomes a no-op, so the same code runs unchanged in credential-less CI.
+
+### Even shorter: evaluate and record in one call
+
+`EvaluateAndRecordAsync` runs a set of evaluators and records every resulting metric
+as a score, collapsing the per-test boilerplate:
+
+```csharp
+using (var scenario = langfuse.BeginScenario("trip-planner", sessionId: runId))
+{
+    var run = await runner.RunAsync(config, hooks, cancellationToken);
+    var inputs = run.Diagnostics!.ToEvaluationInputs();
+
+    await scenario.EvaluateAndRecordAsync(
+        evaluators: [new EfficiencyEvaluator(tokenBudget: 200_000), new IterationCoherenceEvaluator(maxIterations: 20)],
+        messages: inputs.Messages,
+        modelResponse: inputs.ModelResponse,
+        additionalContext: [new AgentRunDiagnosticsContext(run.Diagnostics!)]);
+}
+```
+
+Two runnable examples live under `src/Examples/AgentFramework/`:
+
+- `LangfuseEvaluationApp` — the full flow with no LLM or Langfuse credentials required (no-ops cleanly without keys).
+- `LangfuseConformanceApp` — a small Langfuse-supported eval that **reads the trace and scores back** from a live Langfuse (local Docker by default) to prove ingestion. Not part of CI; run it by hand after standing Langfuse up. Run it with the `resiliency` argument to instead prove **graceful degradation when Langfuse is unreachable** (no server required): the eval still passes and every dropped score is surfaced.
+
+## What appears in Langfuse
+
+| Needlr telemetry | Langfuse |
+|---|---|
+| `agent.chat` / `agent.chat.stream` spans | Generations with model + token usage |
+| `agent.tool {name}` spans | Tool-call observations |
+| `gen_ai.usage.*` tags | Token usage / cost on each generation |
+| Scenario root span | The trace (named, with session id, tags, metadata) |
+| Evaluator metrics (via `RecordLangfuseScoresAsync`) | Scores attached to the trace |
+
+## Scores
+
+Langfuse does **not** ingest scores through OpenTelemetry span attributes — scores
+are sent to the Langfuse Scores API. `RecordLangfuseScoresAsync` (and the
+`ILangfuseScenario.RecordEvaluationAsync` / `RecordScoreAsync` methods) handle this
+for you, keyed by the scenario's trace id. The mapping is:
+
+| MEAI metric | Langfuse score type |
+|---|---|
+| `NumericMetric` | `NUMERIC` |
+| `BooleanMetric` | `BOOLEAN` (`1`/`0`) |
+| `StringMetric` | `CATEGORICAL` |
+
+Each metric's `Reason` is sent as the score comment. Metrics whose value is unset
+are skipped. Scores can be recorded while the scenario is still open — Langfuse
+links them to the trace once it arrives.
+
+Score names are sent verbatim by default (preserving the evaluator's authored metric
+name). For cleaner dashboard filtering and grouping, enable
+`NormalizeScoreNames` to send `snake_case` names (e.g. `all_tool_calls_succeeded`) —
+this is the recommended shape unless you specifically want the authored names.
+
+### Score-upload failures are non-fatal by default
+
+A score is a dashboard write that happens *after* an eval has already produced its
+verdict, so a transient Langfuse outage must not turn a green eval red. By default
+(`ScoreFailureMode.NonFatal`) a failed upload increments `ILangfuseSession.ScoresFailed`
+and invokes `ScoreErrorCallback` (wire it to your logger) but does **not** throw. Set
+`ScoreFailureMode.Strict` if a missing score should hard-fail the caller.
+
+```csharp
+var options = LangfuseOptions.FromEnvironment();
+options.ScoreErrorCallback = e => logger.LogWarning(e.Exception, "Langfuse score {Name} not recorded", e.ScoreName);
+```
+
+### Span enrichment
+
+When exporting, a span processor sets two things Langfuse cares about so they don't
+depend on implicit inference:
+
+- `langfuse.observation.type` = `generation` on `agent.chat` / `agent.chat.stream`
+  spans and `span` on `agent.tool` spans.
+- `langfuse.observation.usage_details` (JSON) projected from Needlr's `gen_ai.usage.*`
+  tags, so `input`, `output`, `cache_read_input_tokens`, and `reasoning_tokens` land
+  reliably. When a span *also* carries MEAI's `gen_ai.usage.*` attributes, the explicit
+  `langfuse.observation.usage_details` **cleanly replaces** them — Langfuse does not sum
+  the two, so there is no double-counting. (Langfuse derives **cost** from a model-price
+  table; register prices for your model names if you want cost populated. Note that
+  provider/SDK model names such as Copilot's will not match Langfuse's built-in table,
+  so `costDetails` stays empty until you add a custom model definition.)
+
+!!! note "Trace-level filtering is by trace, not by observation"
+    Trace-level attributes (`name`, `tags`, `metadata`) are set on the scenario root span,
+    which is what Langfuse uses to build the trace. `session.id` and `user.id` are also
+    propagated to child spans (via baggage) so you can filter observations by them. Filtering
+    individual *observations* by `tags`/`metadata` is not supported — those live at the trace
+    level, which matches the per-scenario grouping model.
+
+## Composing with MEAI OpenTelemetry
+
+Needlr's diagnostics middleware and MEAI's `OpenTelemetryChatClient` /
+`UseOpenTelemetry()` can both create spans for the same chat call. To get the
+richest `gen_ai` spans without duplicates, enable MEAI's OpenTelemetry and set
+Needlr's chat-completion activity mode to enrich the parent span:
+
+```csharp
+.UsingAgentFramework(af => af
+    .ConfigureMetrics(o => o.ChatCompletionActivityMode = ChatCompletionActivityMode.EnrichParent)
+    .UsingDiagnostics())
+```
+
+See [GenAI Token Metrics](gen-ai-token-metrics.md) for how Needlr and MEAI share
+the `gen_ai.client.token.usage` histogram.
+
+## Configuration
+
+`LangfuseOptions.FromEnvironment()` reads `LANGFUSE_PUBLIC_KEY`,
+`LANGFUSE_SECRET_KEY`, and `LANGFUSE_HOST`. All values can also be set in code.
+
+| Option | Default | Description |
+|---|---|---|
+| `PublicKey` / `SecretKey` | _(from env)_ | Langfuse API keys. Both required to export. |
+| `Host` | _(unset)_ | Base URL (e.g. `http://localhost:3000`). One of `Host` or `Region` is **required**. |
+| `Region` | _(unset)_ | Langfuse Cloud region: `Eu`, `Us`, `Jp`, `Hipaa`. Setting it is an explicit opt-in to cloud export. |
+| `Enabled` | `true` | Set `false` to force a no-op even with credentials. |
+| `ServiceName` | `needlr-agent` | OpenTelemetry `service.name` resource attribute. |
+| `IncludeMetrics` | `false` | Export Needlr's `gen_ai` metrics. Off by default — see note below. |
+| `ScoreFailureMode` | `NonFatal` | `NonFatal` records a failed score upload (counter + callback) without throwing; `Strict` throws. |
+| `ScoreErrorCallback` | _(none)_ | Invoked with a `LangfuseScoreError` when a score upload fails under `NonFatal`. |
+| `NormalizeScoreNames` | `false` | When `true`, score names are normalised to `snake_case` for consistent dashboard filtering. |
+| `DiagnosticsCallback` | _(none)_ | Receives library diagnostic messages (e.g. the "no export target" warning). Wire to your logger. |
+| `SamplingRatio` | `1.0` | Head-based trace sampling ratio (eval workloads want `1.0`). |
+| `AgentActivitySourceName` | `NexusLabs.Needlr.AgentFramework` | Needlr agent span source to export. |
+| `GenAiMeterName` | `Experimental.Microsoft.Extensions.AI` | Meter owning `gen_ai.client.token.usage`. |
+| `AdditionalActivitySources` / `AdditionalMeters` | _(empty)_ | Extra sources/meters to export. |
+
+!!! warning "Cloud export is opt-in (no silent egress)"
+    Providing only API keys is **not** enough to export — you must also set an explicit target
+    (`Host` for self-hosted, or `Region` for Langfuse Cloud). This prevents accidentally sending
+    traces (which may include prompts, agent outputs, and customer data) to Langfuse Cloud. When
+    keys are present but no target is set, export is disabled and `DiagnosticsCallback` receives a
+    one-line explanation.
+
+!!! warning "OTLP metrics are not ingested by Langfuse (as of v3.x)"
+    Langfuse's OTLP metrics endpoint accepts requests (returns HTTP 200) but does **not**
+    ingest the data, and there is no metrics read API — exported metrics are silently
+    discarded. `IncludeMetrics` is therefore `false` by default. Token usage already rides
+    on the generation spans (see below), so you lose nothing. Enable it only when pointing
+    the exporter at a backend that ingests OTLP metrics.
+
+If you customised Needlr's telemetry source names via `ConfigureMetrics(...)`, set
+the matching `AgentActivitySourceName` / `AgentMeterName` / `GenAiMeterName` so those
+streams are exported.
+
+### ASP.NET Core and generic hosts
+
+For applications that already call `AddOpenTelemetry()`, register Langfuse export on
+the host pipeline instead of starting a standalone session:
+
+```csharp
+builder.Services.AddNeedlrLangfuse(options =>
+{
+    options.ServiceName = "my-agent-service";
+});
+```
+
+This wires the OTLP exporter into the host's tracer and meter providers so they
+share the application lifecycle, and registers an `ILangfuseScoreClient` for scoring
+request traces by id:
+
+```csharp
+public sealed class MyHandler(ILangfuseScoreClient scores)
+{
+    public async Task HandleAsync(/* ... */)
+    {
+        var traceId = System.Diagnostics.Activity.Current?.TraceId.ToString();
+        if (traceId is not null)
+        {
+            await scores.RecordScoreAsync(traceId, "helpfulness", value: true);
+        }
+    }
+}
+```
+
+When Langfuse is not configured, a disabled no-op `ILangfuseScoreClient` is registered,
+so injection always succeeds and host code never needs to branch on configuration.
+
+## Langfuse Cloud vs self-hosted
+
+- **Cloud**: leave `Host` unset and set `Region` explicitly (`Eu`, `Us`, `Jp`, or `Hipaa`).
+- **Self-hosted**: set `Host` to your deployment, e.g. `http://localhost:3000`.
+  The OpenTelemetry endpoint requires Langfuse `v3.22.0` or newer.
+
+One of `Host` or `Region` must be set — there is no default cloud target, so traces
+are never sent to Langfuse Cloud unless you opt in.
+
+Langfuse ingests OTLP over **HTTP** (`HTTP/protobuf`); gRPC is not supported, so the
+exporter is always configured for HTTP.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,7 @@ nav:
     - Pipeline Metrics: pipeline-metrics.md
     - GenAI Token Metrics: gen-ai-token-metrics.md
     - Evaluation: evaluation.md
+    - Langfuse: langfuse.md
     - Testing Tool Integrations: testing-tools.md
     - Workspace: workspace.md
   - Advanced:

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -56,9 +56,10 @@
     <!-- ASP.NET packages -->
     <PackageVersion Include="Microsoft.AspNetCore.SignalR" Version="1.2.0" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.0" />
-    <!-- OpenTelemetry SDK (test-only — used to verify gen_ai histogram bucket-boundary flow end-to-end) -->
     <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <!-- Testing packages -->
     <PackageVersion Include="xunit.v3" Version="3.0.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.3" />

--- a/src/Examples/AgentFramework/LangfuseConformanceApp/LangfuseConformanceApp.csproj
+++ b/src/Examples/AgentFramework/LangfuseConformanceApp/LangfuseConformanceApp.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.AI" />
+    <PackageReference Include="Microsoft.Extensions.AI.Evaluation" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\NexusLabs.Needlr.AgentFramework\NexusLabs.Needlr.AgentFramework.csproj" />
+    <ProjectReference Include="..\..\..\NexusLabs.Needlr.AgentFramework.Workflows\NexusLabs.Needlr.AgentFramework.Workflows.csproj" />
+    <ProjectReference Include="..\..\..\NexusLabs.Needlr.AgentFramework.Evaluation\NexusLabs.Needlr.AgentFramework.Evaluation.csproj" />
+    <ProjectReference Include="..\..\..\NexusLabs.Needlr.AgentFramework.Langfuse\NexusLabs.Needlr.AgentFramework.Langfuse.csproj" />
+    <ProjectReference Include="..\..\..\NexusLabs.Needlr.Injection.Reflection\NexusLabs.Needlr.Injection.Reflection.csproj" />
+    <ProjectReference Include="..\..\..\NexusLabs.Needlr.Generators\NexusLabs.Needlr.Generators.csproj"
+      OutputItemType="Analyzer"
+      ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\..\NexusLabs.Needlr.Generators.Attributes\NexusLabs.Needlr.Generators.Attributes.csproj" />
+  </ItemGroup>
+
+  <Import Project="..\..\..\NexusLabs.Needlr.Generators\build\NexusLabs.Needlr.Generators.targets" />
+
+</Project>

--- a/src/Examples/AgentFramework/LangfuseConformanceApp/Program.cs
+++ b/src/Examples/AgentFramework/LangfuseConformanceApp/Program.cs
@@ -1,0 +1,449 @@
+// =============================================================================
+// LangfuseConformanceApp
+// -----------------------------------------------------------------------------
+// A SMALL, RUNNABLE Langfuse-supported eval that ALSO verifies the data actually
+// landed in Langfuse by reading it back through the public API.
+//
+// Why this exists: unit tests cannot prove that traces/scores are ingested and
+// GET-readable by a real Langfuse server (one Langfuse endpoint even returns 200
+// for data it silently discards). This example closes that gap end to end.
+//
+// ── ASSUMPTIONS (adjust for your environment) ───────────────────────────────
+//   1. A Langfuse instance is reachable at LANGFUSE_HOST. Default: http://localhost:3000
+//      Stand one up locally with the official docker compose:
+//        https://langfuse.com/self-hosting/docker-compose
+//      (clone langfuse, `docker compose up`, create a project, copy its keys).
+//   2. LANGFUSE_PUBLIC_KEY / LANGFUSE_SECRET_KEY belong to a project on that instance.
+//   3. Verified against self-hosted Langfuse v3.x. Langfuse Cloud also works — set
+//      LANGFUSE_HOST to your region URL (e.g. https://cloud.langfuse.com) + keys.
+//   4. Ingestion is asynchronous, so this app POLLS the read APIs for up to ~30s.
+//
+// This app is NOT part of CI — it requires a live server. Run it by hand after
+// standing Langfuse up. It exits 0 on success, non-zero on any mismatch.
+//
+// ── RESILIENCY MODE (no server required) ─────────────────────────────────────
+// Run with the argument `resiliency` to prove the opposite case: that an eval
+// still PASSES when Langfuse is unreachable. It points the exporter + score
+// client at a dead port, runs a scenario, and asserts the run completes (exit 0)
+// while every dropped score is surfaced via ScoresFailed + ScoreErrorCallback:
+//
+//     dotnet run --project src/Examples/AgentFramework/LangfuseConformanceApp -- resiliency
+// =============================================================================
+
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.AI.Evaluation;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+using NexusLabs.Needlr.AgentFramework;
+using NexusLabs.Needlr.AgentFramework.Diagnostics;
+using NexusLabs.Needlr.AgentFramework.Evaluation;
+using NexusLabs.Needlr.AgentFramework.Iterative;
+using NexusLabs.Needlr.AgentFramework.Langfuse;
+using NexusLabs.Needlr.AgentFramework.Workflows.Diagnostics;
+using NexusLabs.Needlr.AgentFramework.Workspace;
+using NexusLabs.Needlr.Injection;
+using NexusLabs.Needlr.Injection.Reflection;
+
+Console.WriteLine("=== Needlr → Langfuse Conformance Check ===");
+Console.WriteLine();
+
+// Two modes:
+//   (default)      live read-back conformance — requires a running Langfuse.
+//   "resiliency"   Langfuse-down resiliency — points at a dead port, needs NO server,
+//                  and proves an eval still passes when score uploads fail.
+if (args.Length > 0 && string.Equals(args[0], "resiliency", StringComparison.OrdinalIgnoreCase))
+{
+    return await RunResiliencyCheckAsync();
+}
+
+var publicKey = Environment.GetEnvironmentVariable("LANGFUSE_PUBLIC_KEY");
+var secretKey = Environment.GetEnvironmentVariable("LANGFUSE_SECRET_KEY");
+var host = Environment.GetEnvironmentVariable("LANGFUSE_HOST") ?? "http://localhost:3000";
+
+if (string.IsNullOrWhiteSpace(publicKey) || string.IsNullOrWhiteSpace(secretKey))
+{
+    Console.WriteLine("This conformance check requires a LIVE Langfuse instance.");
+    Console.WriteLine("Set the following environment variables and re-run:");
+    Console.WriteLine("  LANGFUSE_PUBLIC_KEY=pk-lf-...");
+    Console.WriteLine("  LANGFUSE_SECRET_KEY=sk-lf-...");
+    Console.WriteLine($"  LANGFUSE_HOST={host}  (default; override for Cloud or a different port)");
+    Console.WriteLine();
+    Console.WriteLine("Stand up a local instance with: https://langfuse.com/self-hosting/docker-compose");
+    return 2;
+}
+
+Console.WriteLine($"[setup] Langfuse host: {host}");
+Console.WriteLine();
+
+// ── Build a Needlr agent with diagnostics + a credential-free mock LLM ───────
+var configuration = new ConfigurationBuilder().Build();
+
+var serviceProvider = new Syringe()
+    .UsingReflection()
+    .UsingAgentFramework(af => af
+        .Configure(opts => opts.ChatClientFactory = _ => new MockChatClient())
+        .UsingDiagnostics())
+    .BuildServiceProvider(configuration);
+
+var loop = serviceProvider.GetRequiredService<IIterativeAgentLoop>();
+var diagnosticsAccessor = serviceProvider.GetRequiredService<IAgentDiagnosticsAccessor>();
+
+// ── Start Langfuse export (Host is set, so this is an explicit, enabled target) ─
+var options = new LangfuseOptions
+{
+    PublicKey = publicKey,
+    SecretKey = secretKey,
+    Host = host,
+    ServiceName = "needlr-langfuse-conformance",
+    ScoreFailureMode = LangfuseScoreFailureMode.Strict, // a conformance check WANTS hard failures
+    DiagnosticsCallback = msg => Console.WriteLine($"[langfuse] {msg}"),
+};
+
+using var langfuse = LangfuseTelemetry.Start(options);
+if (!langfuse.IsEnabled)
+{
+    Console.WriteLine("[error] Langfuse export did not enable — check keys/host.");
+    return 2;
+}
+
+var runId = $"conformance-{DateTimeOffset.UtcNow:yyyyMMdd-HHmmss}";
+string? traceId;
+IReadOnlyList<string> expectedScoreNames;
+
+using (var scenario = langfuse.BeginScenario(
+    name: "conformance: cached-summary",
+    sessionId: runId,
+    tags: ["conformance"]))
+{
+    traceId = scenario.TraceId;
+    Console.WriteLine($"[run] Scenario trace id: {traceId}");
+
+    var loopOptions = new IterativeLoopOptions
+    {
+        Instructions = "You summarise cached prompt content.",
+        PromptFactory = _ => "Summarize the cached prompt content.",
+        Tools = [],
+        MaxIterations = 1,
+        IsComplete = _ => true,
+        LoopName = "conformance-demo",
+    };
+
+    IAgentRunDiagnostics? diagnostics;
+    using (diagnosticsAccessor.BeginCapture())
+    {
+        await loop.RunAsync(
+            loopOptions,
+            new IterativeContext { Workspace = new InMemoryWorkspace() },
+            CancellationToken.None);
+        diagnostics = diagnosticsAccessor.LastRunDiagnostics;
+    }
+
+    if (diagnostics is null)
+    {
+        Console.WriteLine("[error] No diagnostics captured.");
+        return 2;
+    }
+
+    // One-liner: run the evaluators and record every metric as a Langfuse score.
+    var inputs = diagnostics.ToEvaluationInputs();
+    var results = await scenario.EvaluateAndRecordAsync(
+        evaluators:
+        [
+            new EfficiencyEvaluator(tokenBudget: 200_000),
+            new IterationCoherenceEvaluator(maxIterations: 20),
+        ],
+        messages: inputs.Messages,
+        modelResponse: inputs.ModelResponse,
+        additionalContext: [new AgentRunDiagnosticsContext(diagnostics)]);
+
+    expectedScoreNames = results
+        .SelectMany(r => r.Metrics.Values)
+        .Where(HasValue)
+        .Select(m => m.Name)
+        .Distinct(StringComparer.Ordinal)
+        .ToList();
+
+    Console.WriteLine($"[run] Recorded {expectedScoreNames.Count} score(s).");
+}
+
+// Scenario disposed (root span ended); flush so the trace is exported now.
+langfuse.Flush(TimeSpan.FromSeconds(10));
+Console.WriteLine("[run] Flushed telemetry. Verifying read-back from Langfuse...");
+Console.WriteLine();
+
+if (string.IsNullOrEmpty(traceId))
+{
+    Console.WriteLine("[error] No trace id was produced.");
+    return 2;
+}
+
+using var http = new HttpClient { BaseAddress = new Uri(host.TrimEnd('/') + "/") };
+http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+    "Basic", Convert.ToBase64String(Encoding.UTF8.GetBytes($"{publicKey}:{secretKey}")));
+
+var traceFound = await PollAsync(
+    description: "trace",
+    attempts: 15,
+    delay: TimeSpan.FromSeconds(2),
+    probe: async () => await GetSucceedsAsync(http, $"api/public/traces/{traceId}"));
+
+var foundScoreNames = await PollForScoresAsync(http, traceId, expectedScoreNames.Count, attempts: 15, delay: TimeSpan.FromSeconds(2));
+
+Console.WriteLine();
+var missing = expectedScoreNames.Where(n => !foundScoreNames.Contains(n)).ToList();
+var passed = traceFound && missing.Count == 0;
+
+Console.WriteLine($"  trace GET-readable:  {(traceFound ? "PASS" : "FAIL")}");
+Console.WriteLine($"  scores GET-readable: {(missing.Count == 0 ? "PASS" : "FAIL")} ({foundScoreNames.Count}/{expectedScoreNames.Count})");
+if (missing.Count > 0)
+{
+    Console.WriteLine($"  missing scores: {string.Join(", ", missing)}");
+}
+
+Console.WriteLine();
+if (passed)
+{
+    Console.WriteLine("CONFORMANCE PASSED — trace and all scores are readable from Langfuse.");
+    return 0;
+}
+
+Console.WriteLine("CONFORMANCE FAILED — see above. (Increase the poll window if your instance is slow.)");
+return 1;
+
+// ── Resiliency mode: prove an eval survives Langfuse being unreachable ───────
+// Points the exporter and score client at a dead local port (no server needed),
+// runs a real scenario, and asserts the eval completes (exit 0) while the score
+// failures are surfaced via ScoresFailed + ScoreErrorCallback (never swallowed).
+static async Task<int> RunResiliencyCheckAsync()
+{
+    Console.WriteLine("[mode] Resiliency: simulating Langfuse DOWN (dead port, no server required).");
+    Console.WriteLine();
+
+    const string deadHost = "http://127.0.0.1:1";
+    var callbackFired = 0;
+
+    var options = new LangfuseOptions
+    {
+        PublicKey = "pk-lf-resiliency",
+        SecretKey = "sk-lf-resiliency",
+        Host = deadHost,
+        ServiceName = "needlr-langfuse-resiliency",
+        ScoreFailureMode = LangfuseScoreFailureMode.NonFatal,
+        ScoreErrorCallback = _ => Interlocked.Increment(ref callbackFired),
+    };
+
+    var serviceProvider = new Syringe()
+        .UsingReflection()
+        .UsingAgentFramework(af => af
+            .Configure(opts => opts.ChatClientFactory = _ => new MockChatClient())
+            .UsingDiagnostics())
+        .BuildServiceProvider(new ConfigurationBuilder().Build());
+
+    var loop = serviceProvider.GetRequiredService<IIterativeAgentLoop>();
+    var diagnosticsAccessor = serviceProvider.GetRequiredService<IAgentDiagnosticsAccessor>();
+
+    using var langfuse = LangfuseTelemetry.Start(options);
+    if (!langfuse.IsEnabled)
+    {
+        Console.WriteLine("[error] Expected export to be ENABLED (keys + host set).");
+        return 1;
+    }
+
+    var recordedScores = 0;
+    using (var scenario = langfuse.BeginScenario("resiliency: cached-summary", sessionId: "resiliency-run", tags: ["resiliency"]))
+    {
+        var loopOptions = new IterativeLoopOptions
+        {
+            Instructions = "You summarise cached prompt content.",
+            PromptFactory = _ => "Summarize the cached prompt content.",
+            Tools = [],
+            MaxIterations = 1,
+            IsComplete = _ => true,
+            LoopName = "resiliency-demo",
+        };
+
+        IAgentRunDiagnostics? diagnostics;
+        using (diagnosticsAccessor.BeginCapture())
+        {
+            await loop.RunAsync(
+                loopOptions,
+                new IterativeContext { Workspace = new InMemoryWorkspace() },
+                CancellationToken.None);
+            diagnostics = diagnosticsAccessor.LastRunDiagnostics;
+        }
+
+        if (diagnostics is null)
+        {
+            Console.WriteLine("[error] No diagnostics captured.");
+            return 1;
+        }
+
+        var inputs = diagnostics.ToEvaluationInputs();
+        var results = await scenario.EvaluateAndRecordAsync(
+            evaluators: [new EfficiencyEvaluator(tokenBudget: 200_000)],
+            messages: inputs.Messages,
+            modelResponse: inputs.ModelResponse,
+            additionalContext: [new AgentRunDiagnosticsContext(diagnostics)]);
+
+        recordedScores = results.SelectMany(r => r.Metrics.Values).Count(HasValue);
+    }
+
+    langfuse.Flush(TimeSpan.FromSeconds(2));
+
+    // The eval reached this point without throwing — that alone proves NonFatal worked.
+    // The failures must still be surfaced (not silently swallowed): counter + callback.
+    var resilient =
+        recordedScores > 0 &&
+        langfuse.ScoresFailed == recordedScores &&
+        callbackFired == recordedScores;
+
+    Console.WriteLine();
+    Console.WriteLine($"  scores attempted:          {recordedScores}");
+    Console.WriteLine($"  ScoresFailed (session):    {langfuse.ScoresFailed}");
+    Console.WriteLine($"  ScoreErrorCallback fired:  {callbackFired}");
+    Console.WriteLine();
+
+    if (resilient)
+    {
+        Console.WriteLine("RESILIENCY PASSED — the eval completed despite Langfuse being down,");
+        Console.WriteLine("and every dropped score was surfaced (counter + callback), not swallowed.");
+        return 0;
+    }
+
+    Console.WriteLine("RESILIENCY FAILED — failures were not surfaced as expected.");
+    return 1;
+}
+
+static bool HasValue(EvaluationMetric metric) => metric switch
+{
+    NumericMetric nm => nm.Value.HasValue,
+    BooleanMetric bm => bm.Value.HasValue,
+    StringMetric sm => !string.IsNullOrEmpty(sm.Value),
+    _ => false,
+};
+
+static async Task<bool> GetSucceedsAsync(HttpClient http, string path)
+{
+    using var response = await http.GetAsync(path);
+    return response.IsSuccessStatusCode;
+}
+
+static async Task<bool> PollAsync(string description, int attempts, TimeSpan delay, Func<Task<bool>> probe)
+{
+    for (var i = 1; i <= attempts; i++)
+    {
+        if (await probe())
+        {
+            Console.WriteLine($"[verify] {description} found (attempt {i}).");
+            return true;
+        }
+
+        await Task.Delay(delay);
+    }
+
+    Console.WriteLine($"[verify] {description} NOT found after {attempts} attempts.");
+    return false;
+}
+
+static async Task<HashSet<string>> PollForScoresAsync(HttpClient http, string traceId, int expectedCount, int attempts, TimeSpan delay)
+{
+    var found = new HashSet<string>(StringComparer.Ordinal);
+
+    for (var i = 1; i <= attempts; i++)
+    {
+        found = await GetScoreNamesAsync(http, traceId);
+        if (found.Count >= expectedCount)
+        {
+            Console.WriteLine($"[verify] scores found (attempt {i}): {found.Count}.");
+            return found;
+        }
+
+        await Task.Delay(delay);
+    }
+
+    return found;
+}
+
+static async Task<HashSet<string>> GetScoreNamesAsync(HttpClient http, string traceId)
+{
+    var names = new HashSet<string>(StringComparer.Ordinal);
+
+    using var response = await http.GetAsync($"api/public/v3/scores?traceId={Uri.EscapeDataString(traceId)}&limit=100");
+    if (!response.IsSuccessStatusCode)
+    {
+        return names;
+    }
+
+    using var stream = await response.Content.ReadAsStreamAsync();
+    using var json = await JsonDocument.ParseAsync(stream);
+    if (!json.RootElement.TryGetProperty("data", out var data) || data.ValueKind != JsonValueKind.Array)
+    {
+        return names;
+    }
+
+    foreach (var score in data.EnumerateArray())
+    {
+        // Defensive: filter client-side by traceId in case the server ignores the query param.
+        if (score.TryGetProperty("traceId", out var tid) && tid.GetString() != traceId)
+        {
+            continue;
+        }
+
+        if (score.TryGetProperty("name", out var name) && name.GetString() is { } n)
+        {
+            names.Add(n);
+        }
+    }
+
+    return names;
+}
+
+internal sealed class MockChatClient : IChatClient
+{
+    private readonly ChatClientMetadata _metadata = new(
+        providerName: "mock-provider",
+        providerUri: new Uri("https://api.example.com:443"),
+        defaultModelId: "mock-model");
+
+    public Task<ChatResponse> GetResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        var response = new ChatResponse(
+            [new ChatMessage(ChatRole.Assistant, "Mock summary of the cached prompt content.")])
+        {
+            ModelId = "mock-model",
+            Usage = new UsageDetails
+            {
+                InputTokenCount = 4000,
+                OutputTokenCount = 180,
+                TotalTokenCount = 4180,
+                CachedInputTokenCount = 2500,
+                ReasoningTokenCount = 90,
+            },
+        };
+        return Task.FromResult(response);
+    }
+
+    public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default) =>
+        throw new NotSupportedException("Streaming is not used in this example.");
+
+    public void Dispose()
+    {
+    }
+
+    public object? GetService(Type serviceType, object? serviceKey = null)
+    {
+        ArgumentNullException.ThrowIfNull(serviceType);
+        return serviceType == typeof(ChatClientMetadata) ? _metadata : null;
+    }
+}

--- a/src/Examples/AgentFramework/LangfuseEvaluationApp/LangfuseEvaluationApp.csproj
+++ b/src/Examples/AgentFramework/LangfuseEvaluationApp/LangfuseEvaluationApp.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.AI" />
+    <PackageReference Include="Microsoft.Extensions.AI.Evaluation" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\NexusLabs.Needlr.AgentFramework\NexusLabs.Needlr.AgentFramework.csproj" />
+    <ProjectReference Include="..\..\..\NexusLabs.Needlr.AgentFramework.Workflows\NexusLabs.Needlr.AgentFramework.Workflows.csproj" />
+    <ProjectReference Include="..\..\..\NexusLabs.Needlr.AgentFramework.Evaluation\NexusLabs.Needlr.AgentFramework.Evaluation.csproj" />
+    <ProjectReference Include="..\..\..\NexusLabs.Needlr.AgentFramework.Langfuse\NexusLabs.Needlr.AgentFramework.Langfuse.csproj" />
+    <ProjectReference Include="..\..\..\NexusLabs.Needlr.Injection.Reflection\NexusLabs.Needlr.Injection.Reflection.csproj" />
+    <ProjectReference Include="..\..\..\NexusLabs.Needlr.Generators\NexusLabs.Needlr.Generators.csproj"
+      OutputItemType="Analyzer"
+      ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\..\NexusLabs.Needlr.Generators.Attributes\NexusLabs.Needlr.Generators.Attributes.csproj" />
+  </ItemGroup>
+
+  <Import Project="..\..\..\NexusLabs.Needlr.Generators\build\NexusLabs.Needlr.Generators.targets" />
+
+</Project>

--- a/src/Examples/AgentFramework/LangfuseEvaluationApp/Program.cs
+++ b/src/Examples/AgentFramework/LangfuseEvaluationApp/Program.cs
@@ -1,0 +1,214 @@
+// =============================================================================
+// LangfuseEvaluationApp
+// -----------------------------------------------------------------------------
+// Demonstrates how little code it takes to send Needlr agent telemetry AND
+// Microsoft.Extensions.AI.Evaluation scores to Langfuse.
+//
+// The Langfuse integration is just three calls:
+//   1. LangfuseTelemetry.Start(...)        -> exports gen_ai traces/metrics
+//   2. session.BeginScenario(...)          -> one Langfuse trace per eval scenario
+//   3. scenario.RecordEvaluationAsync(...) -> evaluator metrics become Langfuse scores
+//
+// Everything else here is an ordinary Needlr agent run + evaluation. A mock
+// chat client is used so the example runs with no LLM credentials, and the
+// Langfuse calls no-op cleanly when LANGFUSE_PUBLIC_KEY / LANGFUSE_SECRET_KEY
+// are not set — so this example always runs end to end.
+// =============================================================================
+
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+using NexusLabs.Needlr.AgentFramework;
+using NexusLabs.Needlr.AgentFramework.Diagnostics;
+using NexusLabs.Needlr.AgentFramework.Evaluation;
+using NexusLabs.Needlr.AgentFramework.Iterative;
+using NexusLabs.Needlr.AgentFramework.Langfuse;
+using NexusLabs.Needlr.AgentFramework.Workflows.Diagnostics;
+using NexusLabs.Needlr.AgentFramework.Workspace;
+using NexusLabs.Needlr.Injection;
+using NexusLabs.Needlr.Injection.Reflection;
+
+Console.WriteLine("=== Needlr → Langfuse Evaluation Example ===");
+Console.WriteLine();
+
+// ── Wire a Needlr agent with diagnostics and a credential-free mock client ──
+var configuration = new ConfigurationBuilder().Build();
+
+var serviceProvider = new Syringe()
+    .UsingReflection()
+    .UsingAgentFramework(af => af
+        .Configure(opts => opts.ChatClientFactory = _ => new MockChatClient())
+        .UsingDiagnostics())
+    .BuildServiceProvider(configuration);
+
+var loop = serviceProvider.GetRequiredService<IIterativeAgentLoop>();
+var diagnosticsAccessor = serviceProvider.GetRequiredService<IAgentDiagnosticsAccessor>();
+
+// ── Start Langfuse export (call #1) ─────────────────────────────────────────
+var langfuseOptions = LangfuseOptions.FromEnvironment();
+langfuseOptions.ServiceName = "needlr-langfuse-demo";
+langfuseOptions.ScoreErrorCallback = error =>
+    Console.WriteLine($"[langfuse] score '{error.ScoreName}' was not recorded: {error.Exception.Message}");
+langfuseOptions.DiagnosticsCallback = message => Console.WriteLine($"[langfuse] {message}");
+
+using var langfuse = LangfuseTelemetry.Start(langfuseOptions);
+
+if (langfuse.IsEnabled)
+{
+    Console.WriteLine("[langfuse] Export ENABLED — traces and scores will be sent to Langfuse.");
+}
+else
+{
+    Console.WriteLine("[langfuse] Export DISABLED (no credentials or no target).");
+    Console.WriteLine("[langfuse] Set LANGFUSE_PUBLIC_KEY and LANGFUSE_SECRET_KEY, plus a target —");
+    Console.WriteLine("[langfuse] LANGFUSE_HOST (self-hosted) or a Region (cloud) — to send this run to Langfuse.");
+}
+
+Console.WriteLine();
+
+var runId = $"demo-{DateTimeOffset.UtcNow:yyyyMMdd-HHmmss}";
+IAgentRunDiagnostics? diagnostics;
+
+// ── One Langfuse trace per scenario (call #2) ───────────────────────────────
+using (var scenario = langfuse.BeginScenario(
+    name: "eval: cached-summary",
+    sessionId: runId,
+    tags: ["demo", "efficiency", "coherence"],
+    metadata: new Dictionary<string, string> { ["suite"] = "needlr-langfuse-demo" }))
+{
+    Console.WriteLine($"[run] Scenario trace id: {scenario.TraceId ?? "(export disabled)"}");
+
+    var loopOptions = new IterativeLoopOptions
+    {
+        Instructions = "You summarise cached prompt content.",
+        PromptFactory = _ => "Summarize the cached prompt content.",
+        Tools = [],
+        MaxIterations = 1,
+        IsComplete = _ => true,
+        LoopName = "langfuse-eval-demo",
+    };
+
+    // Agent telemetry produced here nests under the scenario trace above.
+    using (diagnosticsAccessor.BeginCapture())
+    {
+        await loop.RunAsync(
+            loopOptions,
+            new IterativeContext { Workspace = new InMemoryWorkspace() },
+            CancellationToken.None);
+        diagnostics = diagnosticsAccessor.LastRunDiagnostics;
+    }
+
+    if (diagnostics is null)
+    {
+        Console.WriteLine("[run] No diagnostics captured — cannot evaluate.");
+        return 1;
+    }
+
+    // ── Score the run with deterministic Needlr evaluators (no LLM needed) ──
+    var evalInputs = diagnostics.ToEvaluationInputs();
+    var diagnosticsContext = new AgentRunDiagnosticsContext(diagnostics);
+
+    var efficiency = await new EfficiencyEvaluator(tokenBudget: 200_000).EvaluateAsync(
+        evalInputs.Messages,
+        evalInputs.ModelResponse,
+        additionalContext: [diagnosticsContext]);
+
+    var coherence = await new IterationCoherenceEvaluator(maxIterations: 20).EvaluateAsync(
+        evalInputs.Messages,
+        evalInputs.ModelResponse,
+        additionalContext: [diagnosticsContext]);
+
+    PrintMetrics("EfficiencyEvaluator", efficiency);
+    PrintMetrics("IterationCoherenceEvaluator", coherence);
+
+    // ── Project evaluator metrics to Langfuse scores (call #3) ──────────────
+    // Score uploads are non-fatal by default: a Langfuse outage records a failure
+    // (ScoreErrorCallback + ScoresFailed) but never fails the eval itself.
+    await efficiency.RecordLangfuseScoresAsync(scenario);
+    await coherence.RecordLangfuseScoresAsync(scenario);
+
+    Console.WriteLine();
+    if (!langfuse.IsEnabled)
+    {
+        Console.WriteLine("[langfuse] (Scores skipped — export disabled.)");
+    }
+    else if (langfuse.ScoresFailed == 0)
+    {
+        Console.WriteLine("[langfuse] Recorded evaluator metrics as scores on the scenario trace.");
+    }
+    else
+    {
+        Console.WriteLine($"[langfuse] {langfuse.ScoresFailed} score(s) failed to upload (eval still passed).");
+    }
+}
+
+// Scenario disposed (root span ended); flush so the completed trace is exported.
+langfuse.Flush();
+
+Console.WriteLine();
+Console.WriteLine("Done. With credentials set, open Langfuse and find the trace named");
+Console.WriteLine("'eval: cached-summary' to see the run, its gen_ai spans, and the scores.");
+return 0;
+
+static void PrintMetrics(string evaluatorName, Microsoft.Extensions.AI.Evaluation.EvaluationResult result)
+{
+    Console.WriteLine();
+    Console.WriteLine($"[eval] {evaluatorName} — {result.Metrics.Count} metric(s):");
+    foreach (var metric in result.Metrics.Values)
+    {
+        var value = metric switch
+        {
+            Microsoft.Extensions.AI.Evaluation.NumericMetric nm => nm.Value?.ToString("F2") ?? "n/a",
+            Microsoft.Extensions.AI.Evaluation.BooleanMetric bm => bm.Value?.ToString() ?? "n/a",
+            Microsoft.Extensions.AI.Evaluation.StringMetric sm => sm.Value ?? "n/a",
+            _ => "n/a",
+        };
+        Console.WriteLine($"        • {metric.Name} = {value}");
+    }
+}
+
+internal sealed class MockChatClient : IChatClient
+{
+    private readonly ChatClientMetadata _metadata = new(
+        providerName: "mock-provider",
+        providerUri: new Uri("https://api.example.com:443"),
+        defaultModelId: "mock-model");
+
+    public Task<ChatResponse> GetResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        var response = new ChatResponse(
+            [new ChatMessage(ChatRole.Assistant, "Mock summary of the cached prompt content.")])
+        {
+            ModelId = "mock-model",
+            Usage = new UsageDetails
+            {
+                InputTokenCount = 4000,
+                OutputTokenCount = 180,
+                TotalTokenCount = 4180,
+                CachedInputTokenCount = 2500,
+                ReasoningTokenCount = 90,
+            },
+        };
+        return Task.FromResult(response);
+    }
+
+    public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default) =>
+        throw new NotSupportedException("Streaming is not used in this example.");
+
+    public void Dispose()
+    {
+    }
+
+    public object? GetService(Type serviceType, object? serviceKey = null)
+    {
+        ArgumentNullException.ThrowIfNull(serviceType);
+        return serviceType == typeof(ChatClientMetadata) ? _metadata : null;
+    }
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/EnvironmentVariableScope.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/EnvironmentVariableScope.cs
@@ -1,0 +1,30 @@
+namespace NexusLabs.Needlr.AgentFramework.Langfuse.Tests;
+
+/// <summary>
+/// Sets process environment variables for the duration of a test and restores their previous
+/// values on disposal. Used to exercise <see cref="LangfuseOptions.FromEnvironment"/> without
+/// leaking state across tests.
+/// </summary>
+internal sealed class EnvironmentVariableScope : IDisposable
+{
+    private readonly Dictionary<string, string?> _previousValues = [];
+
+    public EnvironmentVariableScope(IReadOnlyDictionary<string, string?> values)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+
+        foreach (var (key, value) in values)
+        {
+            _previousValues[key] = Environment.GetEnvironmentVariable(key);
+            Environment.SetEnvironmentVariable(key, value);
+        }
+    }
+
+    public void Dispose()
+    {
+        foreach (var (key, value) in _previousValues)
+        {
+            Environment.SetEnvironmentVariable(key, value);
+        }
+    }
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/LangfuseActivityCollection.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/LangfuseActivityCollection.cs
@@ -1,0 +1,9 @@
+namespace NexusLabs.Needlr.AgentFramework.Langfuse.Tests;
+
+/// <summary>
+/// Serializes tests that start activities on the shared Langfuse <c>ActivitySource</c>. Because
+/// activity listeners are process-global, running these in parallel would let one test's listener
+/// observe another test's spans.
+/// </summary>
+[CollectionDefinition("Langfuse activity", DisableParallelization = true)]
+public sealed class LangfuseActivityCollection;

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/LangfuseEndpointsTests.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/LangfuseEndpointsTests.cs
@@ -1,0 +1,85 @@
+using System.Text;
+
+namespace NexusLabs.Needlr.AgentFramework.Langfuse.Tests;
+
+public sealed class LangfuseEndpointsTests
+{
+    [Fact]
+    public void Resolve_ExplicitEuRegion_BuildsCloudOtelAndScoresEndpoints()
+    {
+        var options = new LangfuseOptions { PublicKey = "pk-lf-1", SecretKey = "sk-lf-2", Region = LangfuseRegion.Eu };
+
+        var endpoints = LangfuseEndpoints.Resolve(options);
+
+        Assert.Equal("https://cloud.langfuse.com/api/public/otel/v1/traces", endpoints.TracesEndpoint.ToString());
+        Assert.Equal("https://cloud.langfuse.com/api/public/otel/v1/metrics", endpoints.MetricsEndpoint.ToString());
+        Assert.Equal("https://cloud.langfuse.com/api/public/scores", endpoints.ScoresEndpoint.ToString());
+    }
+
+    [Theory]
+    [InlineData(LangfuseRegion.Us, "https://us.cloud.langfuse.com/api/public/otel/v1/traces")]
+    [InlineData(LangfuseRegion.Jp, "https://jp.cloud.langfuse.com/api/public/otel/v1/traces")]
+    [InlineData(LangfuseRegion.Hipaa, "https://hipaa.cloud.langfuse.com/api/public/otel/v1/traces")]
+    public void Resolve_KnownRegions_MapToExpectedBaseUrls(LangfuseRegion region, string expectedTraces)
+    {
+        var options = new LangfuseOptions { PublicKey = "pk", SecretKey = "sk", Region = region };
+
+        var endpoints = LangfuseEndpoints.Resolve(options);
+
+        Assert.Equal(expectedTraces, endpoints.TracesEndpoint.ToString());
+    }
+
+    [Fact]
+    public void Resolve_ExplicitHost_TakesPrecedenceAndToleratesMissingTrailingSlash()
+    {
+        var options = new LangfuseOptions
+        {
+            PublicKey = "pk",
+            SecretKey = "sk",
+            Region = LangfuseRegion.Us,
+            Host = "http://localhost:3000",
+        };
+
+        var endpoints = LangfuseEndpoints.Resolve(options);
+
+        Assert.Equal("http://localhost:3000/api/public/otel/v1/traces", endpoints.TracesEndpoint.ToString());
+        Assert.Equal("http://localhost:3000/api/public/scores", endpoints.ScoresEndpoint.ToString());
+    }
+
+    [Fact]
+    public void Resolve_BuildsBasicAuthHeaderFromBase64OfKeys()
+    {
+        var options = new LangfuseOptions { PublicKey = "pk-lf-1", SecretKey = "sk-lf-2", Region = LangfuseRegion.Eu };
+        var expected = "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes("pk-lf-1:sk-lf-2"));
+
+        var endpoints = LangfuseEndpoints.Resolve(options);
+
+        Assert.Equal(expected, endpoints.AuthorizationHeaderValue);
+        Assert.Contains($"Authorization={expected}", endpoints.Headers, StringComparison.Ordinal);
+        Assert.Contains("x-langfuse-ingestion-version=4", endpoints.Headers, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Resolve_MissingKeys_Throws()
+    {
+        var options = new LangfuseOptions { PublicKey = "pk" };
+
+        Assert.Throws<InvalidOperationException>(() => LangfuseEndpoints.Resolve(options));
+    }
+
+    [Fact]
+    public void Resolve_NonHttpHost_Throws()
+    {
+        var options = new LangfuseOptions { PublicKey = "pk", SecretKey = "sk", Host = "ftp://example.com" };
+
+        Assert.Throws<InvalidOperationException>(() => LangfuseEndpoints.Resolve(options));
+    }
+
+    [Fact]
+    public void Resolve_NoHostOrRegion_Throws()
+    {
+        var options = new LangfuseOptions { PublicKey = "pk", SecretKey = "sk" };
+
+        Assert.Throws<InvalidOperationException>(() => LangfuseEndpoints.Resolve(options));
+    }
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/LangfuseEvaluationScoreExtensionsTests.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/LangfuseEvaluationScoreExtensionsTests.cs
@@ -1,0 +1,51 @@
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.AI.Evaluation;
+
+using Moq;
+
+namespace NexusLabs.Needlr.AgentFramework.Langfuse.Tests;
+
+public sealed class LangfuseEvaluationScoreExtensionsTests
+{
+    [Fact]
+    public async Task EvaluateAndRecordAsync_RunsEachEvaluatorAndRecordsEachResult()
+    {
+        var result1 = new EvaluationResult(new NumericMetric("m1", value: 1.0));
+        var result2 = new EvaluationResult(new BooleanMetric("m2", value: true));
+
+        var evaluator1 = CreateEvaluator(result1);
+        var evaluator2 = CreateEvaluator(result2);
+
+        var scenario = new Mock<ILangfuseScenario>(MockBehavior.Strict);
+        scenario
+            .Setup(s => s.RecordEvaluationAsync(It.IsAny<EvaluationResult>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var messages = new[] { new ChatMessage(ChatRole.User, "hi") };
+        var response = new ChatResponse(new ChatMessage(ChatRole.Assistant, "yo"));
+
+        var results = await scenario.Object.EvaluateAndRecordAsync(
+            [evaluator1.Object, evaluator2.Object],
+            messages,
+            response,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal([result1, result2], results);
+        scenario.Verify(s => s.RecordEvaluationAsync(result1, It.IsAny<CancellationToken>()), Times.Once);
+        scenario.Verify(s => s.RecordEvaluationAsync(result2, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    private static Mock<IEvaluator> CreateEvaluator(EvaluationResult result)
+    {
+        var evaluator = new Mock<IEvaluator>(MockBehavior.Strict);
+        evaluator
+            .Setup(e => e.EvaluateAsync(
+                It.IsAny<IEnumerable<ChatMessage>>(),
+                It.IsAny<ChatResponse>(),
+                It.IsAny<ChatConfiguration?>(),
+                It.IsAny<IEnumerable<EvaluationContext>?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(result);
+        return evaluator;
+    }
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/LangfuseOptionsTests.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/LangfuseOptionsTests.cs
@@ -1,0 +1,78 @@
+namespace NexusLabs.Needlr.AgentFramework.Langfuse.Tests;
+
+public sealed class LangfuseOptionsTests
+{
+    [Fact]
+    public void IsConfigured_RequiresKeysEnabledAndExplicitTarget()
+    {
+        Assert.False(new LangfuseOptions().IsConfigured);
+        Assert.False(new LangfuseOptions { PublicKey = "pk" }.IsConfigured);
+        Assert.False(new LangfuseOptions { SecretKey = "sk" }.IsConfigured);
+
+        // Keys present but no Host/Region → not configured (no accidental cloud egress).
+        Assert.False(new LangfuseOptions { PublicKey = "pk", SecretKey = "sk" }.IsConfigured);
+
+        // Explicit target enables it.
+        Assert.True(new LangfuseOptions { PublicKey = "pk", SecretKey = "sk", Host = "http://localhost:3000" }.IsConfigured);
+        Assert.True(new LangfuseOptions { PublicKey = "pk", SecretKey = "sk", Region = LangfuseRegion.Eu }.IsConfigured);
+
+        Assert.False(new LangfuseOptions { PublicKey = "pk", SecretKey = "sk", Region = LangfuseRegion.Eu, Enabled = false }.IsConfigured);
+    }
+
+    [Fact]
+    public void HasCredentials_IsIndependentOfTarget()
+    {
+        Assert.True(new LangfuseOptions { PublicKey = "pk", SecretKey = "sk" }.HasCredentials);
+        Assert.False(new LangfuseOptions { PublicKey = "pk", SecretKey = "sk" }.HasExplicitTarget);
+    }
+
+    [Fact]
+    public void Defaults_MatchNeedlrTelemetrySourceNames()
+    {
+        var options = new LangfuseOptions();
+
+        Assert.Equal("NexusLabs.Needlr.AgentFramework", options.AgentActivitySourceName);
+        Assert.Equal("NexusLabs.Needlr.AgentFramework", options.AgentMeterName);
+        Assert.Equal("Experimental.Microsoft.Extensions.AI", options.GenAiMeterName);
+        Assert.Null(options.Region);
+        Assert.False(options.IncludeMetrics);
+        Assert.False(options.NormalizeScoreNames);
+        Assert.Equal(LangfuseScoreFailureMode.NonFatal, options.ScoreFailureMode);
+        Assert.Equal(1.0, options.SamplingRatio);
+    }
+
+    [Fact]
+    public void FromEnvironment_ReadsKeysAndHost()
+    {
+        using var _ = new EnvironmentVariableScope(new Dictionary<string, string?>
+        {
+            [LangfuseOptions.PublicKeyEnvironmentVariable] = "pk-env",
+            [LangfuseOptions.SecretKeyEnvironmentVariable] = "sk-env",
+            [LangfuseOptions.HostEnvironmentVariable] = "http://localhost:3000",
+        });
+
+        var options = LangfuseOptions.FromEnvironment();
+
+        Assert.Equal("pk-env", options.PublicKey);
+        Assert.Equal("sk-env", options.SecretKey);
+        Assert.Equal("http://localhost:3000", options.Host);
+        Assert.True(options.IsConfigured);
+    }
+
+    [Fact]
+    public void FromEnvironment_BlankKeys_AreTreatedAsAbsent()
+    {
+        using var _ = new EnvironmentVariableScope(new Dictionary<string, string?>
+        {
+            [LangfuseOptions.PublicKeyEnvironmentVariable] = "   ",
+            [LangfuseOptions.SecretKeyEnvironmentVariable] = null,
+            [LangfuseOptions.HostEnvironmentVariable] = null,
+        });
+
+        var options = LangfuseOptions.FromEnvironment();
+
+        Assert.Null(options.PublicKey);
+        Assert.Null(options.SecretKey);
+        Assert.False(options.IsConfigured);
+    }
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/LangfuseScenarioTests.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/LangfuseScenarioTests.cs
@@ -1,0 +1,212 @@
+using System.Diagnostics;
+using System.Net;
+using System.Text.Json;
+
+using Microsoft.Extensions.AI.Evaluation;
+
+using Moq;
+using Moq.Protected;
+
+namespace NexusLabs.Needlr.AgentFramework.Langfuse.Tests;
+
+[Collection("Langfuse activity")]
+public sealed class LangfuseScenarioTests
+{
+    [Fact]
+    public void BeginScenario_SetsLangfuseTraceLevelAttributesOnRootSpan()
+    {
+        using var listener = StartListener();
+        var recorder = new LangfuseScoreRecorder(CreateApiClient(out _), StrictSink(), normalizeNames: false);
+
+        using var scenario = new LangfuseScenario(
+            recorder,
+            name: "trip-planner",
+            sessionId: "run-1",
+            userId: "user-9",
+            tags: ["happy-path", "regression"],
+            metadata: new Dictionary<string, string> { ["dataset"] = "v1" });
+
+        var activity = scenario.Activity;
+        Assert.NotNull(activity);
+        Assert.Equal("trip-planner", activity!.GetTagItem("langfuse.trace.name"));
+        Assert.Equal("run-1", activity.GetTagItem("langfuse.session.id"));
+        Assert.Equal("user-9", activity.GetTagItem("langfuse.user.id"));
+        Assert.Equal("v1", activity.GetTagItem("langfuse.trace.metadata.dataset"));
+
+        var tags = Assert.IsType<string[]>(activity.GetTagItem("langfuse.trace.tags"));
+        Assert.Equal(["happy-path", "regression"], tags);
+
+        Assert.Equal("run-1", activity.GetBaggageItem("session.id"));
+        Assert.Equal("user-9", activity.GetBaggageItem("user.id"));
+        Assert.False(string.IsNullOrEmpty(scenario.TraceId));
+    }
+
+    [Fact]
+    public async Task RecordScoreAsync_PostsScoreForScenarioTrace()
+    {
+        using var listener = StartListener();
+        var recorder = new LangfuseScoreRecorder(CreateApiClient(out var bodies), StrictSink(), normalizeNames: false);
+
+        using var scenario = new LangfuseScenario(recorder, "scenario", null, null, null, null);
+        var traceId = scenario.TraceId;
+
+        await scenario.RecordScoreAsync("relevance", 0.75, "looks good", TestContext.Current.CancellationToken);
+
+        var body = Assert.Single(bodies);
+        using var json = JsonDocument.Parse(body);
+        Assert.Equal(traceId, json.RootElement.GetProperty("traceId").GetString());
+        Assert.Equal("relevance", json.RootElement.GetProperty("name").GetString());
+        Assert.Equal(0.75, json.RootElement.GetProperty("value").GetDouble());
+        Assert.Equal("NUMERIC", json.RootElement.GetProperty("dataType").GetString());
+    }
+
+    [Fact]
+    public async Task RecordEvaluationAsync_MapsEachMetricTypeToAScore()
+    {
+        using var listener = StartListener();
+        var recorder = new LangfuseScoreRecorder(CreateApiClient(out var bodies), StrictSink(), normalizeNames: false);
+
+        using var scenario = new LangfuseScenario(recorder, "scenario", null, null, null, null);
+
+        var result = new EvaluationResult(
+            new NumericMetric("Total Tokens", value: 1200),
+            new BooleanMetric("All Tool Calls Succeeded", value: true),
+            new StringMetric("Termination Mode", value: "completed"),
+            new NumericMetric("Unset Metric", value: null));
+
+        await scenario.RecordEvaluationAsync(result, TestContext.Current.CancellationToken);
+
+        Assert.Equal(3, bodies.Count);
+
+        var byName = bodies
+            .Select(b => JsonDocument.Parse(b).RootElement)
+            .ToDictionary(e => e.GetProperty("name").GetString()!, e => e);
+
+        Assert.Equal("NUMERIC", byName["Total Tokens"].GetProperty("dataType").GetString());
+        Assert.Equal(1200, byName["Total Tokens"].GetProperty("value").GetDouble());
+
+        Assert.Equal("BOOLEAN", byName["All Tool Calls Succeeded"].GetProperty("dataType").GetString());
+        Assert.Equal(1, byName["All Tool Calls Succeeded"].GetProperty("value").GetDouble());
+
+        Assert.Equal("CATEGORICAL", byName["Termination Mode"].GetProperty("dataType").GetString());
+        Assert.Equal("completed", byName["Termination Mode"].GetProperty("value").GetString());
+
+        Assert.False(byName.ContainsKey("Unset Metric"));
+    }
+
+    [Fact]
+    public async Task RecordScoreAsync_NonFatalMode_DoesNotThrowAndRecordsFailure()
+    {
+        using var listener = StartListener();
+        LangfuseScoreError? captured = null;
+        var sink = new LangfuseScoreFailureSink(LangfuseScoreFailureMode.NonFatal, e => captured = e);
+        var recorder = new LangfuseScoreRecorder(CreateFailingApiClient(), sink, normalizeNames: false);
+
+        using var scenario = new LangfuseScenario(recorder, "scenario", null, null, null, null);
+
+        await scenario.RecordScoreAsync("relevance", 0.5, cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, sink.FailedCount);
+        Assert.NotNull(captured);
+        Assert.Equal("relevance", captured!.ScoreName);
+        Assert.Equal(scenario.TraceId, captured.TraceId);
+    }
+
+    [Fact]
+    public async Task RecordScoreAsync_StrictMode_Throws()
+    {
+        using var listener = StartListener();
+        var sink = new LangfuseScoreFailureSink(LangfuseScoreFailureMode.Strict, null);
+        var recorder = new LangfuseScoreRecorder(CreateFailingApiClient(), sink, normalizeNames: false);
+
+        using var scenario = new LangfuseScenario(recorder, "scenario", null, null, null, null);
+
+        await Assert.ThrowsAsync<LangfuseException>(() =>
+            scenario.RecordScoreAsync("relevance", 0.5, cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Equal(0, sink.FailedCount);
+    }
+
+    [Fact]
+    public async Task ChildSpans_InheritOnlyTheirOwnScenarioBaggage_UnderParallelScenarios()
+    {
+        using var listener = StartListener();
+        var recorder = new LangfuseScoreRecorder(CreateApiClient(out _), StrictSink(), normalizeNames: false);
+        var processor = new LangfuseTraceAttributeProcessor();
+
+        async Task<(string? Session, string? User)> RunScenario(string id)
+        {
+            await Task.Yield();
+            using var scenario = new LangfuseScenario(
+                recorder, $"scenario-{id}", sessionId: id, userId: $"user-{id}", tags: null, metadata: null);
+
+            await Task.Delay(15);
+            using var child = LangfuseActivitySource.Source.StartActivity("agent.tool work")!;
+            processor.OnStart(child);
+            await Task.Delay(15);
+
+            return (child.GetTagItem("session.id") as string, child.GetTagItem("user.id") as string);
+        }
+
+        var results = await Task.WhenAll(RunScenario("A"), RunScenario("B"));
+
+        Assert.Contains(("A", "user-A"), results);
+        Assert.Contains(("B", "user-B"), results);
+    }
+
+    private static LangfuseScoreFailureSink StrictSink() => new(LangfuseScoreFailureMode.Strict, null);
+
+    private static ActivityListener StartListener()
+    {
+        var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == LangfuseActivitySource.Name,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+        };
+        ActivitySource.AddActivityListener(listener);
+        return listener;
+    }
+
+    private static LangfuseScoreApiClient CreateApiClient(out List<string> capturedBodies)
+    {
+        var bodies = new List<string>();
+        capturedBodies = bodies;
+
+        var handler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns(async (HttpRequestMessage request, CancellationToken token) =>
+            {
+                bodies.Add(await request.Content!.ReadAsStringAsync(token));
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            });
+
+        var httpClient = new HttpClient(handler.Object);
+        return new LangfuseScoreApiClient(
+            httpClient,
+            new Uri("https://cloud.langfuse.com/api/public/scores"),
+            "Basic cGs6c2s=");
+    }
+
+    private static LangfuseScoreApiClient CreateFailingApiClient()
+    {
+        var handler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.InternalServerError)
+            {
+                Content = new StringContent("boom"),
+            });
+
+        var httpClient = new HttpClient(handler.Object);
+        return new LangfuseScoreApiClient(
+            httpClient,
+            new Uri("https://cloud.langfuse.com/api/public/scores"),
+            "Basic cGs6c2s=");
+    }
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/LangfuseScoreApiClientTests.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/LangfuseScoreApiClientTests.cs
@@ -1,0 +1,123 @@
+using System.Net;
+using System.Text.Json;
+
+using Moq;
+using Moq.Protected;
+
+namespace NexusLabs.Needlr.AgentFramework.Langfuse.Tests;
+
+public sealed class LangfuseScoreApiClientTests
+{
+    [Fact]
+    public async Task CreateAsync_PostsScoreWithBasicAuthAndExpectedBody()
+    {
+        HttpRequestMessage? capturedRequest = null;
+        string? capturedBody = null;
+
+        var handler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns(async (HttpRequestMessage request, CancellationToken token) =>
+            {
+                capturedRequest = request;
+                capturedBody = request.Content is null
+                    ? null
+                    : await request.Content.ReadAsStringAsync(token);
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            });
+
+        using var httpClient = new HttpClient(handler.Object, disposeHandler: false);
+        var client = new LangfuseScoreApiClient(
+            httpClient,
+            new Uri("https://cloud.langfuse.com/api/public/scores"),
+            "Basic cGs6c2s=");
+
+        var score = new LangfuseScore
+        {
+            TraceId = "abc123",
+            Name = "tool_calls_all_succeeded",
+            Value = 1.0,
+            DataType = "BOOLEAN",
+            Comment = "all tools ok",
+        };
+
+        await client.CreateAsync(score, CancellationToken.None);
+
+        Assert.NotNull(capturedRequest);
+        Assert.Equal(HttpMethod.Post, capturedRequest!.Method);
+        Assert.Equal("https://cloud.langfuse.com/api/public/scores", capturedRequest.RequestUri!.ToString());
+        Assert.Equal("Basic", capturedRequest.Headers.Authorization!.Scheme);
+        Assert.Equal("cGs6c2s=", capturedRequest.Headers.Authorization.Parameter);
+
+        using var json = JsonDocument.Parse(capturedBody!);
+        var root = json.RootElement;
+        Assert.Equal("abc123", root.GetProperty("traceId").GetString());
+        Assert.Equal("tool_calls_all_succeeded", root.GetProperty("name").GetString());
+        Assert.Equal(1.0, root.GetProperty("value").GetDouble());
+        Assert.Equal("BOOLEAN", root.GetProperty("dataType").GetString());
+        Assert.Equal("all tools ok", root.GetProperty("comment").GetString());
+    }
+
+    [Fact]
+    public async Task CreateAsync_CategoricalScore_SerializesStringValue()
+    {
+        string? capturedBody = null;
+
+        var handler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns(async (HttpRequestMessage request, CancellationToken token) =>
+            {
+                capturedBody = await request.Content!.ReadAsStringAsync(token);
+                return new HttpResponseMessage(HttpStatusCode.Created);
+            });
+
+        using var httpClient = new HttpClient(handler.Object, disposeHandler: false);
+        var client = new LangfuseScoreApiClient(
+            httpClient,
+            new Uri("https://cloud.langfuse.com/api/public/scores"),
+            "Basic cGs6c2s=");
+
+        await client.CreateAsync(
+            new LangfuseScore { TraceId = "t", Name = "verdict", Value = "partially correct", DataType = "CATEGORICAL" },
+            CancellationToken.None);
+
+        using var json = JsonDocument.Parse(capturedBody!);
+        Assert.Equal("partially correct", json.RootElement.GetProperty("value").GetString());
+        Assert.False(json.RootElement.TryGetProperty("comment", out _));
+    }
+
+    [Fact]
+    public async Task CreateAsync_NonSuccessStatus_ThrowsLangfuseException()
+    {
+        var handler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.Unauthorized)
+            {
+                Content = new StringContent("invalid credentials"),
+            });
+
+        using var httpClient = new HttpClient(handler.Object, disposeHandler: false);
+        var client = new LangfuseScoreApiClient(
+            httpClient,
+            new Uri("https://cloud.langfuse.com/api/public/scores"),
+            "Basic cGs6c2s=");
+
+        var ex = await Assert.ThrowsAsync<LangfuseException>(() => client.CreateAsync(
+            new LangfuseScore { TraceId = "t", Name = "n", Value = 1.0, DataType = "NUMERIC" },
+            CancellationToken.None));
+
+        Assert.Contains("401", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("invalid credentials", ex.Message, StringComparison.Ordinal);
+    }
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/LangfuseScoreRecorderTests.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/LangfuseScoreRecorderTests.cs
@@ -1,0 +1,59 @@
+using System.Net;
+using System.Text.Json;
+
+using Moq;
+using Moq.Protected;
+
+namespace NexusLabs.Needlr.AgentFramework.Langfuse.Tests;
+
+public sealed class LangfuseScoreRecorderTests
+{
+    [Fact]
+    public async Task NormalizeScoreNames_ConvertsToSnakeCase()
+    {
+        var recorder = CreateRecorder(out var bodies, normalizeNames: true);
+
+        await recorder.RecordNumericAsync("trace-1", "All Tool Calls Succeeded", 1.0, null, TestContext.Current.CancellationToken);
+
+        var body = Assert.Single(bodies);
+        using var json = JsonDocument.Parse(body);
+        Assert.Equal("all_tool_calls_succeeded", json.RootElement.GetProperty("name").GetString());
+    }
+
+    [Fact]
+    public async Task WithoutNormalization_SendsNameVerbatim()
+    {
+        var recorder = CreateRecorder(out var bodies, normalizeNames: false);
+
+        await recorder.RecordNumericAsync("trace-1", "All Tool Calls Succeeded", 1.0, null, TestContext.Current.CancellationToken);
+
+        var body = Assert.Single(bodies);
+        using var json = JsonDocument.Parse(body);
+        Assert.Equal("All Tool Calls Succeeded", json.RootElement.GetProperty("name").GetString());
+    }
+
+    private static LangfuseScoreRecorder CreateRecorder(out List<string> capturedBodies, bool normalizeNames)
+    {
+        var bodies = new List<string>();
+        capturedBodies = bodies;
+
+        var handler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns(async (HttpRequestMessage request, CancellationToken token) =>
+            {
+                bodies.Add(await request.Content!.ReadAsStringAsync(token));
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            });
+
+        var apiClient = new LangfuseScoreApiClient(
+            new HttpClient(handler.Object),
+            new Uri("https://cloud.langfuse.com/api/public/scores"),
+            "Basic cGs6c2s=");
+        var sink = new LangfuseScoreFailureSink(LangfuseScoreFailureMode.Strict, null);
+        return new LangfuseScoreRecorder(apiClient, sink, normalizeNames);
+    }
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/LangfuseServiceCollectionExtensionsTests.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/LangfuseServiceCollectionExtensionsTests.cs
@@ -1,0 +1,62 @@
+using Microsoft.Extensions.DependencyInjection;
+
+using OpenTelemetry.Trace;
+
+namespace NexusLabs.Needlr.AgentFramework.Langfuse.Tests;
+
+public sealed class LangfuseServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void AddNeedlrLangfuse_Configured_RegistersEnabledScoreClientAndTracerProvider()
+    {
+        var services = new ServiceCollection();
+
+        services.AddNeedlrLangfuse(o =>
+        {
+            o.PublicKey = "pk-lf-1";
+            o.SecretKey = "sk-lf-2";
+            o.Host = "http://localhost:3000";
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        var scoreClient = provider.GetService<ILangfuseScoreClient>();
+        Assert.NotNull(scoreClient);
+        Assert.True(scoreClient!.IsEnabled);
+
+        // AddOpenTelemetry registers a TracerProvider when tracing is configured.
+        Assert.NotNull(provider.GetService<TracerProvider>());
+    }
+
+    [Fact]
+    public void AddNeedlrLangfuse_NotConfigured_RegistersDisabledNoOpScoreClient()
+    {
+        var services = new ServiceCollection();
+
+        // Keys present but no Host/Region → not configured → disabled (no cloud egress).
+        services.AddNeedlrLangfuse(o =>
+        {
+            o.PublicKey = "pk-lf-1";
+            o.SecretKey = "sk-lf-2";
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        var scoreClient = provider.GetService<ILangfuseScoreClient>();
+        Assert.NotNull(scoreClient);
+        Assert.False(scoreClient!.IsEnabled);
+    }
+
+    [Fact]
+    public async Task AddNeedlrLangfuse_DisabledScoreClient_RecordIsNoOp()
+    {
+        var services = new ServiceCollection();
+        services.AddNeedlrLangfuse(o => { o.Enabled = false; });
+
+        using var provider = services.BuildServiceProvider();
+        var scoreClient = provider.GetRequiredService<ILangfuseScoreClient>();
+
+        await scoreClient.RecordScoreAsync("trace", "name", 1.0, cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal(0, scoreClient.ScoresFailed);
+    }
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/LangfuseTelemetryDisabledTests.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/LangfuseTelemetryDisabledTests.cs
@@ -1,0 +1,55 @@
+namespace NexusLabs.Needlr.AgentFramework.Langfuse.Tests;
+
+public sealed class LangfuseTelemetryDisabledTests
+{
+    [Fact]
+    public void Start_WithoutCredentials_ReturnsDisabledNoOpSession()
+    {
+        using var session = LangfuseTelemetry.Start(new LangfuseOptions());
+
+        Assert.False(session.IsEnabled);
+        Assert.True(session.Flush());
+    }
+
+    [Fact]
+    public async Task DisabledScenario_RecordsScoresWithoutThrowingOrCallingNetwork()
+    {
+        using var session = LangfuseTelemetry.Start(new LangfuseOptions());
+        using var scenario = session.BeginScenario("scenario", sessionId: "run-1", tags: ["smoke"]);
+
+        Assert.Null(scenario.TraceId);
+        Assert.Null(scenario.Activity);
+
+        await scenario.RecordScoreAsync("numeric", 0.5, cancellationToken: TestContext.Current.CancellationToken);
+        await scenario.RecordScoreAsync("boolean", true, cancellationToken: TestContext.Current.CancellationToken);
+        await scenario.RecordScoreAsync("categorical", "good", cancellationToken: TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public void Start_WithEnabledFalse_IsDisabledEvenWithKeys()
+    {
+        var options = new LangfuseOptions { PublicKey = "pk", SecretKey = "sk", Region = LangfuseRegion.Eu, Enabled = false };
+
+        using var session = LangfuseTelemetry.Start(options);
+
+        Assert.False(session.IsEnabled);
+    }
+
+    [Fact]
+    public void Start_WithKeysButNoTarget_IsDisabledAndWarnsAboutCloudEgress()
+    {
+        string? warning = null;
+        var options = new LangfuseOptions
+        {
+            PublicKey = "pk",
+            SecretKey = "sk",
+            DiagnosticsCallback = msg => warning = msg,
+        };
+
+        using var session = LangfuseTelemetry.Start(options);
+
+        Assert.False(session.IsEnabled);
+        Assert.NotNull(warning);
+        Assert.Contains("no export target", warning!, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/LangfuseTraceAttributeProcessorTests.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/LangfuseTraceAttributeProcessorTests.cs
@@ -1,0 +1,94 @@
+using System.Diagnostics;
+using System.Text.Json;
+
+namespace NexusLabs.Needlr.AgentFramework.Langfuse.Tests;
+
+public sealed class LangfuseTraceAttributeProcessorTests
+{
+    [Fact]
+    public void OnStart_CopiesBaggageToTags_WithoutOverwritingExistingTags()
+    {
+        using var scope = StartActivity("op", out var activity);
+        activity.SetBaggage("session.id", "run-9");
+        activity.SetTag("user.id", "preset");
+        activity.SetBaggage("user.id", "from-baggage");
+
+        new LangfuseTraceAttributeProcessor().OnStart(activity);
+
+        Assert.Equal("run-9", activity.GetTagItem("session.id"));
+        Assert.Equal("preset", activity.GetTagItem("user.id"));
+    }
+
+    [Theory]
+    [InlineData("agent.chat", "generation")]
+    [InlineData("agent.chat.stream", "generation")]
+    [InlineData("agent.tool search_web", "span")]
+    [InlineData("agent.tool fetch_weather", "span")]
+    public void OnStart_SetsObservationType(string operationName, string expectedType)
+    {
+        using var scope = StartActivity(operationName, out var activity);
+
+        new LangfuseTraceAttributeProcessor().OnStart(activity);
+
+        Assert.Equal(expectedType, activity.GetTagItem("langfuse.observation.type"));
+    }
+
+    [Theory]
+    [InlineData("eval: cached-summary")]
+    [InlineData("agent.chatter")] // not an exact match for agent.chat — must NOT become a generation
+    [InlineData("some.other.span")]
+    public void OnStart_LeavesObservationTypeUnsetForNonAgentSpans(string operationName)
+    {
+        using var scope = StartActivity(operationName, out var activity);
+
+        new LangfuseTraceAttributeProcessor().OnStart(activity);
+
+        Assert.Null(activity.GetTagItem("langfuse.observation.type"));
+    }
+
+    [Fact]
+    public void OnEnd_WritesUsageDetailsJsonFromGenAiTags()
+    {
+        using var scope = StartActivity("agent.chat", out var activity);
+        activity.SetTag("gen_ai.usage.input_tokens", 1000);
+        activity.SetTag("gen_ai.usage.output_tokens", 200);
+        activity.SetTag("gen_ai.usage.cached_input_tokens", 500);
+        activity.SetTag("gen_ai.usage.reasoning_tokens", 50);
+
+        new LangfuseTraceAttributeProcessor().OnEnd(activity);
+
+        var raw = Assert.IsType<string>(activity.GetTagItem("langfuse.observation.usage_details"));
+        using var json = JsonDocument.Parse(raw);
+        var root = json.RootElement;
+        Assert.Equal(1000, root.GetProperty("input").GetInt64());
+        Assert.Equal(200, root.GetProperty("output").GetInt64());
+        Assert.Equal(500, root.GetProperty("cache_read_input_tokens").GetInt64());
+        Assert.Equal(50, root.GetProperty("reasoning_tokens").GetInt64());
+        Assert.Equal(1200, root.GetProperty("total").GetInt64());
+    }
+
+    [Fact]
+    public void OnEnd_WithoutUsageTags_DoesNotWriteUsageDetails()
+    {
+        using var scope = StartActivity("agent.tool search", out var activity);
+
+        new LangfuseTraceAttributeProcessor().OnEnd(activity);
+
+        Assert.Null(activity.GetTagItem("langfuse.observation.usage_details"));
+    }
+
+    private static ActivityListener StartActivity(string operationName, out Activity activity)
+    {
+        var source = new ActivitySource($"test-{Guid.NewGuid():N}");
+        var listener = new ActivityListener
+        {
+            ShouldListenTo = s => s == source,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        activity = source.StartActivity(operationName)
+            ?? throw new InvalidOperationException("Activity was not sampled.");
+        return listener;
+    }
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/NexusLabs.Needlr.AgentFramework.Langfuse.Tests.csproj
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/NexusLabs.Needlr.AgentFramework.Langfuse.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry" />
+    <PackageReference Include="OpenTelemetry.Exporter.InMemory" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NexusLabs.Needlr.AgentFramework\NexusLabs.Needlr.AgentFramework.csproj" />
+    <ProjectReference Include="..\NexusLabs.Needlr.AgentFramework.Langfuse\NexusLabs.Needlr.AgentFramework.Langfuse.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/DisabledLangfuseScenario.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/DisabledLangfuseScenario.cs
@@ -1,0 +1,39 @@
+using System.Diagnostics;
+
+using Microsoft.Extensions.AI.Evaluation;
+
+namespace NexusLabs.Needlr.AgentFramework.Langfuse;
+
+/// <summary>
+/// Inert <see cref="ILangfuseScenario"/> returned by a disabled session. Starts no span and posts
+/// no scores, so eval code paths run unchanged when Langfuse is not configured.
+/// </summary>
+internal sealed class DisabledLangfuseScenario : ILangfuseScenario
+{
+    /// <inheritdoc />
+    public string? TraceId => null;
+
+    /// <inheritdoc />
+    public Activity? Activity => null;
+
+    /// <inheritdoc />
+    public Task RecordScoreAsync(string name, double value, string? comment = null, CancellationToken cancellationToken = default) =>
+        Task.CompletedTask;
+
+    /// <inheritdoc />
+    public Task RecordScoreAsync(string name, bool value, string? comment = null, CancellationToken cancellationToken = default) =>
+        Task.CompletedTask;
+
+    /// <inheritdoc />
+    public Task RecordScoreAsync(string name, string value, string? comment = null, CancellationToken cancellationToken = default) =>
+        Task.CompletedTask;
+
+    /// <inheritdoc />
+    public Task RecordEvaluationAsync(EvaluationResult result, CancellationToken cancellationToken = default) =>
+        Task.CompletedTask;
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+    }
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/DisabledLangfuseScoreClient.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/DisabledLangfuseScoreClient.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.AI.Evaluation;
+
+namespace NexusLabs.Needlr.AgentFramework.Langfuse;
+
+/// <summary>
+/// Inert <see cref="ILangfuseScoreClient"/> registered when Langfuse is not configured, so host
+/// applications can always inject the client and call it without branching on configuration state.
+/// </summary>
+internal sealed class DisabledLangfuseScoreClient : ILangfuseScoreClient
+{
+    /// <inheritdoc />
+    public bool IsEnabled => false;
+
+    /// <inheritdoc />
+    public int ScoresFailed => 0;
+
+    /// <inheritdoc />
+    public Task RecordScoreAsync(string traceId, string name, double value, string? comment = null, CancellationToken cancellationToken = default) =>
+        Task.CompletedTask;
+
+    /// <inheritdoc />
+    public Task RecordScoreAsync(string traceId, string name, bool value, string? comment = null, CancellationToken cancellationToken = default) =>
+        Task.CompletedTask;
+
+    /// <inheritdoc />
+    public Task RecordScoreAsync(string traceId, string name, string value, string? comment = null, CancellationToken cancellationToken = default) =>
+        Task.CompletedTask;
+
+    /// <inheritdoc />
+    public Task RecordEvaluationAsync(string traceId, EvaluationResult result, CancellationToken cancellationToken = default) =>
+        Task.CompletedTask;
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/DisabledLangfuseSession.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/DisabledLangfuseSession.cs
@@ -1,0 +1,31 @@
+namespace NexusLabs.Needlr.AgentFramework.Langfuse;
+
+/// <summary>
+/// Inert <see cref="ILangfuseSession"/> returned when Langfuse export is not configured. All
+/// members are no-ops so calling code never needs to branch on whether credentials are present.
+/// </summary>
+internal sealed class DisabledLangfuseSession : ILangfuseSession
+{
+    /// <inheritdoc />
+    public bool IsEnabled => false;
+
+    /// <inheritdoc />
+    public int ScoresFailed => 0;
+
+    /// <inheritdoc />
+    public bool Flush(TimeSpan? timeout = null) => true;
+
+    /// <inheritdoc />
+    public ILangfuseScenario BeginScenario(
+        string name,
+        string? sessionId = null,
+        string? userId = null,
+        IEnumerable<string>? tags = null,
+        IReadOnlyDictionary<string, string>? metadata = null) =>
+        new DisabledLangfuseScenario();
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+    }
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/ILangfuseScenario.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/ILangfuseScenario.cs
@@ -1,0 +1,77 @@
+using System.Diagnostics;
+
+using Microsoft.Extensions.AI.Evaluation;
+
+namespace NexusLabs.Needlr.AgentFramework.Langfuse;
+
+/// <summary>
+/// Represents a single Langfuse trace scoped to one eval scenario or agent run. Created via
+/// <see cref="ILangfuseSession.BeginScenario"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Beginning a scenario starts a root OpenTelemetry span carrying Langfuse trace-level attributes
+/// (name, session id, user id, tags, metadata). Agent telemetry produced while the scenario is
+/// active nests under this trace. Disposing the scenario ends the root span.
+/// </para>
+/// <para>
+/// Evaluation scores are attached to the scenario's trace through the Langfuse Scores API, keyed
+/// by <see cref="TraceId"/>. Because Langfuse links scores to traces asynchronously, scores may be
+/// recorded while the scenario is still open.
+/// </para>
+/// </remarks>
+public interface ILangfuseScenario : IDisposable
+{
+    /// <summary>
+    /// Gets the Langfuse trace id (the lowercase-hex OpenTelemetry trace id) for this scenario, or
+    /// <see langword="null"/> when the owning session is disabled.
+    /// </summary>
+    string? TraceId { get; }
+
+    /// <summary>
+    /// Gets the root <see cref="Activity"/> for this scenario, or <see langword="null"/> when the
+    /// owning session is disabled or no listener is sampling the span.
+    /// </summary>
+    Activity? Activity { get; }
+
+    /// <summary>
+    /// Records a numeric score on this scenario's trace.
+    /// </summary>
+    /// <param name="name">The score name.</param>
+    /// <param name="value">The numeric value.</param>
+    /// <param name="comment">An optional explanation surfaced in Langfuse.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task that completes when Langfuse has accepted the score.</returns>
+    Task RecordScoreAsync(string name, double value, string? comment = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Records a boolean score (stored as <c>1</c>/<c>0</c>) on this scenario's trace.
+    /// </summary>
+    /// <param name="name">The score name.</param>
+    /// <param name="value">The boolean value.</param>
+    /// <param name="comment">An optional explanation surfaced in Langfuse.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task that completes when Langfuse has accepted the score.</returns>
+    Task RecordScoreAsync(string name, bool value, string? comment = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Records a categorical score on this scenario's trace.
+    /// </summary>
+    /// <param name="name">The score name.</param>
+    /// <param name="value">The category label.</param>
+    /// <param name="comment">An optional explanation surfaced in Langfuse.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task that completes when Langfuse has accepted the score.</returns>
+    Task RecordScoreAsync(string name, string value, string? comment = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Projects every metric in a <see cref="EvaluationResult"/> to a Langfuse score on this
+    /// scenario's trace. Numeric metrics become numeric scores, boolean metrics become boolean
+    /// scores, and string metrics become categorical scores. Each metric's reason is sent as the
+    /// score comment. Metrics whose value is unset are skipped.
+    /// </summary>
+    /// <param name="result">The evaluation result to project.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task that completes when Langfuse has accepted all projected scores.</returns>
+    Task RecordEvaluationAsync(EvaluationResult result, CancellationToken cancellationToken = default);
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/ILangfuseScoreClient.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/ILangfuseScoreClient.cs
@@ -1,0 +1,64 @@
+using Microsoft.Extensions.AI.Evaluation;
+
+namespace NexusLabs.Needlr.AgentFramework.Langfuse;
+
+/// <summary>
+/// Records Langfuse scores against a known trace id. Registered in dependency injection by
+/// <see cref="LangfuseServiceCollectionExtensions.AddNeedlrLangfuse"/> for ASP.NET Core and
+/// generic-host applications that score their own request traces.
+/// </summary>
+/// <remarks>
+/// In a host application the OTLP exporter assigns each operation an OpenTelemetry trace id
+/// (<c>Activity.Current?.TraceId</c>). Pass that id here to attach evaluation scores to the
+/// corresponding Langfuse trace. For the eval/console flow, prefer
+/// <see cref="ILangfuseSession.BeginScenario"/>, which manages the trace for you.
+/// </remarks>
+public interface ILangfuseScoreClient
+{
+    /// <summary>
+    /// Gets a value indicating whether scores are being sent. <see langword="false"/> when Langfuse
+    /// was not configured, in which case all record calls are no-ops.
+    /// </summary>
+    bool IsEnabled { get; }
+
+    /// <summary>Gets the cumulative number of score uploads that have failed.</summary>
+    int ScoresFailed { get; }
+
+    /// <summary>Records a numeric score against <paramref name="traceId"/>.</summary>
+    /// <param name="traceId">The Langfuse/OpenTelemetry trace id to attach the score to.</param>
+    /// <param name="name">The score name.</param>
+    /// <param name="value">The numeric value.</param>
+    /// <param name="comment">An optional explanation surfaced in Langfuse.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task that completes when Langfuse has accepted the score.</returns>
+    Task RecordScoreAsync(string traceId, string name, double value, string? comment = null, CancellationToken cancellationToken = default);
+
+    /// <summary>Records a boolean score (stored as <c>1</c>/<c>0</c>) against <paramref name="traceId"/>.</summary>
+    /// <param name="traceId">The Langfuse/OpenTelemetry trace id to attach the score to.</param>
+    /// <param name="name">The score name.</param>
+    /// <param name="value">The boolean value.</param>
+    /// <param name="comment">An optional explanation surfaced in Langfuse.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task that completes when Langfuse has accepted the score.</returns>
+    Task RecordScoreAsync(string traceId, string name, bool value, string? comment = null, CancellationToken cancellationToken = default);
+
+    /// <summary>Records a categorical score against <paramref name="traceId"/>.</summary>
+    /// <param name="traceId">The Langfuse/OpenTelemetry trace id to attach the score to.</param>
+    /// <param name="name">The score name.</param>
+    /// <param name="value">The category label.</param>
+    /// <param name="comment">An optional explanation surfaced in Langfuse.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task that completes when Langfuse has accepted the score.</returns>
+    Task RecordScoreAsync(string traceId, string name, string value, string? comment = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Projects every metric in <paramref name="result"/> to a Langfuse score against
+    /// <paramref name="traceId"/>, using the same mapping as
+    /// <see cref="ILangfuseScenario.RecordEvaluationAsync"/>.
+    /// </summary>
+    /// <param name="traceId">The Langfuse/OpenTelemetry trace id to attach the scores to.</param>
+    /// <param name="result">The evaluation result to project.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task that completes when Langfuse has accepted all projected scores.</returns>
+    Task RecordEvaluationAsync(string traceId, EvaluationResult result, CancellationToken cancellationToken = default);
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/ILangfuseSession.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/ILangfuseSession.cs
@@ -1,0 +1,64 @@
+namespace NexusLabs.Needlr.AgentFramework.Langfuse;
+
+/// <summary>
+/// Represents an active Langfuse export session. Owns the OpenTelemetry tracer/meter providers
+/// that forward Needlr agent telemetry to Langfuse and flushes pending telemetry on disposal.
+/// </summary>
+/// <remarks>
+/// Obtain an instance from <see cref="LangfuseTelemetry.Start(LangfuseOptions)"/>. Keep it alive
+/// for the lifetime over which agent runs and evaluations should be captured (for example, an
+/// xUnit collection fixture), then dispose it to force a final flush.
+/// </remarks>
+public interface ILangfuseSession : IDisposable
+{
+    /// <summary>
+    /// Gets a value indicating whether this session is exporting telemetry. <see langword="false"/>
+    /// when the supplied <see cref="LangfuseOptions"/> were not configured (for example, missing
+    /// credentials), in which case the session is an inert no-op.
+    /// </summary>
+    bool IsEnabled { get; }
+
+    /// <summary>
+    /// Gets the cumulative number of evaluation-score uploads that have failed across all scenarios
+    /// created from this session. Always <c>0</c> under
+    /// <see cref="LangfuseScoreFailureMode.Strict"/> (failures throw instead) and for a disabled
+    /// session. Useful as an assertion target or a health indicator.
+    /// </summary>
+    int ScoresFailed { get; }
+
+    /// <summary>
+    /// Flushes any buffered telemetry to Langfuse. Useful before reading results or at the end of
+    /// a test run. No-op when <see cref="IsEnabled"/> is <see langword="false"/>.
+    /// </summary>
+    /// <param name="timeout">
+    /// Maximum time to wait for the flush to complete, or <see cref="System.Threading.Timeout.InfiniteTimeSpan"/>
+    /// to wait indefinitely. When <see langword="null"/>, a provider default is used.
+    /// </param>
+    /// <returns><see langword="true"/> if the flush succeeded; otherwise <see langword="false"/>.</returns>
+    bool Flush(TimeSpan? timeout = null);
+
+    /// <summary>
+    /// Begins a Langfuse trace scoped to a single eval scenario or agent run. Agent telemetry
+    /// produced while the returned scenario is active nests under its trace, and evaluation scores
+    /// can be attached to it.
+    /// </summary>
+    /// <param name="name">The trace name shown in Langfuse (for example the eval scenario name).</param>
+    /// <param name="sessionId">
+    /// An optional Langfuse session id used to group related traces (for example multiple
+    /// iterations of one scenario).
+    /// </param>
+    /// <param name="userId">An optional end-user identifier associated with the trace.</param>
+    /// <param name="tags">Optional tags used to categorize the trace in Langfuse.</param>
+    /// <param name="metadata">Optional filterable key/value metadata attached to the trace.</param>
+    /// <returns>
+    /// An <see cref="ILangfuseScenario"/> to dispose when the scenario completes. When this session
+    /// is disabled the returned scenario is an inert no-op.
+    /// </returns>
+    /// <exception cref="ArgumentException"><paramref name="name"/> is <see langword="null"/> or whitespace.</exception>
+    ILangfuseScenario BeginScenario(
+        string name,
+        string? sessionId = null,
+        string? userId = null,
+        IEnumerable<string>? tags = null,
+        IReadOnlyDictionary<string, string>? metadata = null);
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseActivitySource.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseActivitySource.cs
@@ -1,0 +1,24 @@
+using System.Diagnostics;
+
+namespace NexusLabs.Needlr.AgentFramework.Langfuse;
+
+/// <summary>
+/// Owns the <see cref="ActivitySource"/> used to mint Langfuse scenario spans.
+/// </summary>
+/// <remarks>
+/// An <see cref="ActivitySource"/> is a process-global telemetry primitive matched by name by
+/// the OpenTelemetry SDK (<c>AddSource</c>) and by <see cref="ActivityListener"/> in tests, so a
+/// single shared instance is the idiomatic pattern rather than shared mutable state. It is kept
+/// <see langword="internal"/> and is the only static in this package.
+/// </remarks>
+internal static class LangfuseActivitySource
+{
+    /// <summary>
+    /// The name of the <see cref="ActivitySource"/> that emits Langfuse scenario spans. The
+    /// export bootstrap subscribes to this name so scenario roots are forwarded to Langfuse.
+    /// </summary>
+    public const string Name = "NexusLabs.Needlr.AgentFramework.Langfuse";
+
+    /// <summary>Gets the shared scenario <see cref="ActivitySource"/>.</summary>
+    public static ActivitySource Source { get; } = new(Name);
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseEndpoints.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseEndpoints.cs
@@ -1,0 +1,127 @@
+using System.Text;
+
+namespace NexusLabs.Needlr.AgentFramework.Langfuse;
+
+/// <summary>
+/// Resolves the Langfuse OTLP/HTTP ingestion endpoints and authentication headers from a
+/// <see cref="LangfuseOptions"/> instance.
+/// </summary>
+/// <remarks>
+/// Langfuse exposes an OpenTelemetry-compatible endpoint at <c>/api/public/otel</c> and
+/// authenticates with HTTP Basic auth over the base64 of <c>publicKey:secretKey</c>. Only
+/// OTLP over HTTP is supported (gRPC is not), so the .NET exporter is always configured for
+/// the <c>HttpProtobuf</c> protocol against the signal-specific paths produced here.
+/// </remarks>
+internal sealed class LangfuseEndpoints
+{
+    private const string OtelBasePath = "api/public/otel";
+
+    private LangfuseEndpoints(
+        Uri tracesEndpoint,
+        Uri metricsEndpoint,
+        Uri scoresEndpoint,
+        string authorizationHeaderValue,
+        string headers)
+    {
+        TracesEndpoint = tracesEndpoint;
+        MetricsEndpoint = metricsEndpoint;
+        ScoresEndpoint = scoresEndpoint;
+        AuthorizationHeaderValue = authorizationHeaderValue;
+        Headers = headers;
+    }
+
+    /// <summary>Gets the full OTLP/HTTP traces endpoint (<c>.../api/public/otel/v1/traces</c>).</summary>
+    public Uri TracesEndpoint { get; }
+
+    /// <summary>Gets the full OTLP/HTTP metrics endpoint (<c>.../api/public/otel/v1/metrics</c>).</summary>
+    public Uri MetricsEndpoint { get; }
+
+    /// <summary>Gets the Langfuse public Scores API endpoint (<c>.../api/public/scores</c>).</summary>
+    public Uri ScoresEndpoint { get; }
+
+    /// <summary>Gets the <c>Authorization</c> header value (<c>Basic &lt;base64&gt;</c>).</summary>
+    public string AuthorizationHeaderValue { get; }
+
+    /// <summary>
+    /// Gets the comma-separated header string consumed by the OTLP exporter, carrying the
+    /// <c>Authorization</c> header and the Langfuse ingestion-version header.
+    /// </summary>
+    public string Headers { get; }
+
+    /// <summary>
+    /// Resolves the ingestion endpoints and headers for the supplied options.
+    /// </summary>
+    /// <param name="options">A configured options instance.</param>
+    /// <returns>The resolved <see cref="LangfuseEndpoints"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="options"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// <paramref name="options"/> is missing the public or secret key, or its
+    /// <see cref="LangfuseOptions.Host"/>/<see cref="LangfuseOptions.Region"/> cannot be resolved
+    /// to an absolute HTTP(S) URL.
+    /// </exception>
+    public static LangfuseEndpoints Resolve(LangfuseOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (string.IsNullOrWhiteSpace(options.PublicKey) || string.IsNullOrWhiteSpace(options.SecretKey))
+        {
+            throw new InvalidOperationException(
+                "Langfuse public and secret keys are required to resolve ingestion endpoints. " +
+                "Check LangfuseOptions.IsConfigured before resolving endpoints.");
+        }
+
+        var baseUrl = ResolveBaseUrl(options);
+
+        var auth = Convert.ToBase64String(
+            Encoding.UTF8.GetBytes($"{options.PublicKey}:{options.SecretKey}"));
+        var authorizationHeaderValue = $"Basic {auth}";
+        var headers = $"Authorization={authorizationHeaderValue},x-langfuse-ingestion-version=4";
+
+        return new LangfuseEndpoints(
+            tracesEndpoint: new Uri(baseUrl, $"{OtelBasePath}/v1/traces"),
+            metricsEndpoint: new Uri(baseUrl, $"{OtelBasePath}/v1/metrics"),
+            scoresEndpoint: new Uri(baseUrl, "api/public/scores"),
+            authorizationHeaderValue: authorizationHeaderValue,
+            headers: headers);
+    }
+
+    private static Uri ResolveBaseUrl(LangfuseOptions options)
+    {
+        string raw;
+        if (!string.IsNullOrWhiteSpace(options.Host))
+        {
+            raw = options.Host;
+        }
+        else if (options.Region is { } region)
+        {
+            raw = RegionBaseUrl(region);
+        }
+        else
+        {
+            throw new InvalidOperationException(
+                "Langfuse export target is not set. Provide a Host (self-hosted) or a Region " +
+                "(Langfuse Cloud). Check LangfuseOptions.IsConfigured before resolving endpoints.");
+        }
+
+        if (!Uri.TryCreate(EnsureTrailingSlash(raw), UriKind.Absolute, out var uri)
+            || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+        {
+            throw new InvalidOperationException(
+                $"Langfuse host '{raw}' is not a valid absolute HTTP(S) URL.");
+        }
+
+        return uri;
+    }
+
+    private static string RegionBaseUrl(LangfuseRegion region) => region switch
+    {
+        LangfuseRegion.Eu => "https://cloud.langfuse.com",
+        LangfuseRegion.Us => "https://us.cloud.langfuse.com",
+        LangfuseRegion.Jp => "https://jp.cloud.langfuse.com",
+        LangfuseRegion.Hipaa => "https://hipaa.cloud.langfuse.com",
+        _ => throw new InvalidOperationException($"Unknown Langfuse region '{region}'."),
+    };
+
+    private static string EnsureTrailingSlash(string url) =>
+        url.EndsWith('/') ? url : url + "/";
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseEvaluationScoreExtensions.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseEvaluationScoreExtensions.cs
@@ -1,0 +1,82 @@
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.AI.Evaluation;
+
+namespace NexusLabs.Needlr.AgentFramework.Langfuse;
+
+/// <summary>
+/// Convenience extensions for projecting <c>Microsoft.Extensions.AI.Evaluation</c> results onto a
+/// Langfuse scenario trace as scores.
+/// </summary>
+public static class LangfuseEvaluationScoreExtensions
+{
+    /// <summary>
+    /// Records every metric in <paramref name="result"/> as a Langfuse score on
+    /// <paramref name="scenario"/>'s trace. Equivalent to
+    /// <see cref="ILangfuseScenario.RecordEvaluationAsync"/>, provided as a fluent call site for
+    /// eval code that already holds an <see cref="EvaluationResult"/>.
+    /// </summary>
+    /// <param name="result">The evaluation result to project.</param>
+    /// <param name="scenario">The scenario whose trace the scores attach to.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task that completes when Langfuse has accepted all projected scores.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="result"/> or <paramref name="scenario"/> is <see langword="null"/>.
+    /// </exception>
+    public static Task RecordLangfuseScoresAsync(
+        this EvaluationResult result,
+        ILangfuseScenario scenario,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        ArgumentNullException.ThrowIfNull(scenario);
+
+        return scenario.RecordEvaluationAsync(result, cancellationToken);
+    }
+
+    /// <summary>
+    /// Runs each evaluator over the supplied agent output and records every resulting metric as a
+    /// Langfuse score on the scenario's trace. Collapses the per-test
+    /// evaluate-then-record boilerplate into one call.
+    /// </summary>
+    /// <param name="scenario">The scenario whose trace the scores attach to.</param>
+    /// <param name="evaluators">The evaluators to run.</param>
+    /// <param name="messages">The conversation messages sent to the agent (for example, from <c>EvaluationInputs.Messages</c>).</param>
+    /// <param name="modelResponse">The agent's response (for example, from <c>EvaluationInputs.ModelResponse</c>).</param>
+    /// <param name="chatConfiguration">Optional chat configuration for LLM-judged evaluators.</param>
+    /// <param name="additionalContext">Optional additional context (for example, <c>AgentRunDiagnosticsContext</c>).</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>The evaluation results, in evaluator order.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="scenario"/>, <paramref name="evaluators"/>, <paramref name="messages"/>, or
+    /// <paramref name="modelResponse"/> is <see langword="null"/>.
+    /// </exception>
+    public static async Task<IReadOnlyList<EvaluationResult>> EvaluateAndRecordAsync(
+        this ILangfuseScenario scenario,
+        IEnumerable<IEvaluator> evaluators,
+        IEnumerable<ChatMessage> messages,
+        ChatResponse modelResponse,
+        ChatConfiguration? chatConfiguration = null,
+        IEnumerable<EvaluationContext>? additionalContext = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(scenario);
+        ArgumentNullException.ThrowIfNull(evaluators);
+        ArgumentNullException.ThrowIfNull(messages);
+        ArgumentNullException.ThrowIfNull(modelResponse);
+
+        var materializedMessages = messages as IReadOnlyList<ChatMessage> ?? messages.ToList();
+        var contextList = additionalContext?.ToList();
+        var results = new List<EvaluationResult>();
+
+        foreach (var evaluator in evaluators)
+        {
+            var result = await evaluator
+                .EvaluateAsync(materializedMessages, modelResponse, chatConfiguration, contextList, cancellationToken)
+                .ConfigureAwait(false);
+            await scenario.RecordEvaluationAsync(result, cancellationToken).ConfigureAwait(false);
+            results.Add(result);
+        }
+
+        return results;
+    }
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseException.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseException.cs
@@ -1,0 +1,26 @@
+namespace NexusLabs.Needlr.AgentFramework.Langfuse;
+
+/// <summary>
+/// The exception thrown when a request to the Langfuse API fails.
+/// </summary>
+public sealed class LangfuseException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LangfuseException"/> class.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    public LangfuseException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LangfuseException"/> class.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    /// <param name="innerException">The underlying exception.</param>
+    public LangfuseException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseExportGuard.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseExportGuard.cs
@@ -1,0 +1,30 @@
+namespace NexusLabs.Needlr.AgentFramework.Langfuse;
+
+/// <summary>
+/// Shared guard logic for the Langfuse export entry points. Surfaces a diagnostic when credentials
+/// are present but no explicit export target was chosen, so the "disabled to avoid cloud egress"
+/// decision is visible rather than silent.
+/// </summary>
+internal static class LangfuseExportGuard
+{
+    /// <summary>
+    /// Invokes <see cref="LangfuseOptions.DiagnosticsCallback"/> when credentials are present and
+    /// enabled but neither a <see cref="LangfuseOptions.Host"/> nor a
+    /// <see cref="LangfuseOptions.Region"/> was set, explaining why export is disabled.
+    /// </summary>
+    /// <param name="options">The export options.</param>
+    public static void WarnIfCredentialsWithoutTarget(LangfuseOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (options.HasCredentials && !options.HasExplicitTarget)
+        {
+            options.DiagnosticsCallback?.Invoke(
+                "Langfuse credentials were provided but no export target was set, so export is " +
+                "disabled. This prevents accidentally sending traces (which may include prompts, " +
+                "agent outputs, and customer data) to Langfuse Cloud. Set LangfuseOptions.Host for " +
+                "a self-hosted deployment, or LangfuseOptions.Region to opt in to a Langfuse Cloud " +
+                "region.");
+        }
+    }
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseOptions.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseOptions.cs
@@ -1,0 +1,223 @@
+using NexusLabs.Needlr.AgentFramework.Diagnostics;
+
+namespace NexusLabs.Needlr.AgentFramework.Langfuse;
+
+/// <summary>
+/// Configuration for exporting Needlr agent telemetry and evaluation scores to Langfuse.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The common path is <see cref="FromEnvironment"/>, which reads the standard Langfuse
+/// environment variables. When the public/secret keys are absent the integration disables
+/// itself and behaves as a no-op, so credential-less CI runs never fail.
+/// </para>
+/// <para>
+/// Needlr emits OpenTelemetry traces and metrics under well-known source and meter names.
+/// The defaults here match <see cref="AgentFrameworkMetricsOptions"/>. If a consumer has
+/// customised those names via <c>ConfigureMetrics(...)</c>, set
+/// <see cref="AgentActivitySourceName"/>, <see cref="AgentMeterName"/>, and
+/// <see cref="GenAiMeterName"/> to the same values, or add them through
+/// <see cref="AdditionalActivitySources"/> / <see cref="AdditionalMeters"/>.
+/// </para>
+/// </remarks>
+public sealed class LangfuseOptions
+{
+    private static readonly AgentFrameworkMetricsOptions MetricsDefaults = new();
+
+    /// <summary>
+    /// Environment variable read for the Langfuse public key by <see cref="FromEnvironment"/>.
+    /// </summary>
+    public const string PublicKeyEnvironmentVariable = "LANGFUSE_PUBLIC_KEY";
+
+    /// <summary>
+    /// Environment variable read for the Langfuse secret key by <see cref="FromEnvironment"/>.
+    /// </summary>
+    public const string SecretKeyEnvironmentVariable = "LANGFUSE_SECRET_KEY";
+
+    /// <summary>
+    /// Environment variable read for the Langfuse host (base URL) by <see cref="FromEnvironment"/>.
+    /// </summary>
+    public const string HostEnvironmentVariable = "LANGFUSE_HOST";
+
+    /// <summary>
+    /// Gets or sets the Langfuse public key (<c>pk-lf-...</c>). Required for export.
+    /// </summary>
+    public string? PublicKey { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Langfuse secret key (<c>sk-lf-...</c>). Required for export.
+    /// </summary>
+    public string? SecretKey { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Langfuse base URL (for example <c>https://cloud.langfuse.com</c> or a
+    /// self-hosted <c>http://localhost:3000</c>). When set, this takes precedence over
+    /// <see cref="Region"/>. When <see langword="null"/>, the URL is derived from
+    /// <see cref="Region"/>.
+    /// </summary>
+    public string? Host { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Langfuse Cloud data region. <see langword="null"/> by default — exporting
+    /// to a cloud region is therefore an explicit, opt-in choice. Ignored when <see cref="Host"/>
+    /// is set.
+    /// </summary>
+    /// <remarks>
+    /// To avoid silently sending traces (which may include prompts, agent outputs, and customer
+    /// data) to Langfuse Cloud, this integration requires an <strong>explicit</strong> target: set
+    /// <see cref="Host"/> for a self-hosted deployment, or set <see cref="Region"/> to deliberately
+    /// opt in to a Langfuse Cloud region. When neither is set, export is disabled even if
+    /// credentials are present (see <see cref="IsConfigured"/>) and a message is sent to
+    /// <see cref="DiagnosticsCallback"/>.
+    /// </remarks>
+    public LangfuseRegion? Region { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether export is enabled. When <see langword="true"/>
+    /// (the default) export still only occurs if <see cref="PublicKey"/> and
+    /// <see cref="SecretKey"/> are both present — see <see cref="IsConfigured"/>. Set to
+    /// <see langword="false"/> to force a no-op regardless of credentials.
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the OpenTelemetry <c>service.name</c> resource attribute applied to exported
+    /// telemetry. Surfaces in Langfuse as the originating service. Defaults to
+    /// <c>"needlr-agent"</c>.
+    /// </summary>
+    public string ServiceName { get; set; } = "needlr-agent";
+
+    /// <summary>
+    /// Gets or sets the optional OpenTelemetry <c>service.version</c> resource attribute.
+    /// </summary>
+    public string? ServiceVersion { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether Needlr's <c>gen_ai</c> metrics (including the
+    /// <c>gen_ai.client.token.usage</c> histogram) are exported alongside traces. Defaults to
+    /// <see langword="false"/>.
+    /// </summary>
+    /// <remarks>
+    /// As of Langfuse v3.x the OTLP metrics endpoint (<c>/api/public/otel/v1/metrics</c>) accepts
+    /// requests (returns HTTP 200) but does <strong>not</strong> ingest the data — there is no
+    /// corresponding metrics read API, so exported metrics are silently discarded. Token usage is
+    /// already carried on the generation spans, so metrics export is off by default. Enable this
+    /// only if you point the exporter at a backend that ingests OTLP metrics.
+    /// </remarks>
+    public bool IncludeMetrics { get; set; }
+
+    /// <summary>
+    /// Gets or sets how a failed evaluation-score upload is handled. Defaults to
+    /// <see cref="LangfuseScoreFailureMode.NonFatal"/> so a transient Langfuse outage does not turn
+    /// a passing eval into a failure.
+    /// </summary>
+    public LangfuseScoreFailureMode ScoreFailureMode { get; set; } = LangfuseScoreFailureMode.NonFatal;
+
+    /// <summary>
+    /// Gets or sets an optional callback invoked when a score upload fails under
+    /// <see cref="LangfuseScoreFailureMode.NonFatal"/>. Use it to log the loss with your own logger.
+    /// </summary>
+    public Action<LangfuseScoreError>? ScoreErrorCallback { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether evaluator metric names are normalised to
+    /// <c>snake_case</c> before being sent as Langfuse score names. Off by default; names are sent
+    /// verbatim. Enable for consistent dashboard filtering/grouping.
+    /// </summary>
+    public bool NormalizeScoreNames { get; set; }
+
+    /// <summary>
+    /// Gets or sets an optional callback for library diagnostic messages — for example, the warning
+    /// emitted when credentials are present but no export target (<see cref="Host"/> or
+    /// <see cref="Region"/>) was chosen. Wire it to your logger to surface these conditions.
+    /// </summary>
+    public Action<string>? DiagnosticsCallback { get; set; }
+
+    /// <summary>
+    /// Gets or sets the head-based trace sampling ratio in the range <c>0.0</c> to <c>1.0</c>.
+    /// Defaults to <c>1.0</c> (sample everything), which is appropriate for eval workloads.
+    /// </summary>
+    public double SamplingRatio { get; set; } = 1.0;
+
+    /// <summary>
+    /// Gets or sets the name of Needlr's agent <see cref="System.Diagnostics.ActivitySource"/>
+    /// to export. Defaults to <see cref="AgentFrameworkMetricsOptions.MeterName"/>'s default.
+    /// </summary>
+    public string AgentActivitySourceName { get; set; } = MetricsDefaults.MeterName;
+
+    /// <summary>
+    /// Gets or sets the name of Needlr's agent <see cref="System.Diagnostics.Metrics.Meter"/>
+    /// to export. Defaults to <see cref="AgentFrameworkMetricsOptions.MeterName"/>'s default.
+    /// </summary>
+    public string AgentMeterName { get; set; } = MetricsDefaults.MeterName;
+
+    /// <summary>
+    /// Gets or sets the name of the meter that owns the <c>gen_ai.client.token.usage</c>
+    /// histogram shared by Needlr and MEAI. Defaults to
+    /// <see cref="AgentFrameworkMetricsOptions.GenAiMeterName"/>'s default
+    /// (<c>"Experimental.Microsoft.Extensions.AI"</c>).
+    /// </summary>
+    public string GenAiMeterName { get; set; } = MetricsDefaults.GenAiMeterName;
+
+    /// <summary>
+    /// Gets a mutable list of additional <see cref="System.Diagnostics.ActivitySource"/> names
+    /// to export — for example a host's own source or MAF's agent source.
+    /// </summary>
+    public IList<string> AdditionalActivitySources { get; } = [];
+
+    /// <summary>
+    /// Gets a mutable list of additional <see cref="System.Diagnostics.Metrics.Meter"/> names
+    /// to export.
+    /// </summary>
+    public IList<string> AdditionalMeters { get; } = [];
+
+    /// <summary>
+    /// Gets a value indicating whether both API keys are present and export is enabled. Does not
+    /// account for whether an export target was chosen — see <see cref="HasExplicitTarget"/> and
+    /// <see cref="IsConfigured"/>.
+    /// </summary>
+    public bool HasCredentials =>
+        Enabled
+        && !string.IsNullOrWhiteSpace(PublicKey)
+        && !string.IsNullOrWhiteSpace(SecretKey);
+
+    /// <summary>
+    /// Gets a value indicating whether an explicit export target was chosen — either a
+    /// <see cref="Host"/> (self-hosted) or a <see cref="Region"/> (deliberate Langfuse Cloud
+    /// opt-in).
+    /// </summary>
+    public bool HasExplicitTarget =>
+        !string.IsNullOrWhiteSpace(Host) || Region.HasValue;
+
+    /// <summary>
+    /// Gets a value indicating whether the integration is fully configured to export: credentials
+    /// are present, export is enabled, and an explicit target (<see cref="Host"/> or
+    /// <see cref="Region"/>) was chosen. Requiring an explicit target prevents accidentally sending
+    /// traces to Langfuse Cloud.
+    /// </summary>
+    public bool IsConfigured => HasCredentials && HasExplicitTarget;
+
+    /// <summary>
+    /// Builds a <see cref="LangfuseOptions"/> from the standard Langfuse environment variables
+    /// (<see cref="PublicKeyEnvironmentVariable"/>, <see cref="SecretKeyEnvironmentVariable"/>,
+    /// and <see cref="HostEnvironmentVariable"/>).
+    /// </summary>
+    /// <returns>
+    /// A populated <see cref="LangfuseOptions"/>. When the keys are absent the result has
+    /// <see cref="IsConfigured"/> equal to <see langword="false"/> and the integration no-ops.
+    /// </returns>
+    public static LangfuseOptions FromEnvironment()
+    {
+        var options = new LangfuseOptions
+        {
+            PublicKey = NullIfBlank(Environment.GetEnvironmentVariable(PublicKeyEnvironmentVariable)),
+            SecretKey = NullIfBlank(Environment.GetEnvironmentVariable(SecretKeyEnvironmentVariable)),
+            Host = NullIfBlank(Environment.GetEnvironmentVariable(HostEnvironmentVariable)),
+        };
+
+        return options;
+    }
+
+    private static string? NullIfBlank(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value;
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseRegion.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseRegion.cs
@@ -1,0 +1,29 @@
+namespace NexusLabs.Needlr.AgentFramework.Langfuse;
+
+/// <summary>
+/// Identifies the Langfuse deployment that traces and scores are sent to. Used to derive
+/// the base URL of the OTLP ingestion endpoint when <see cref="LangfuseOptions.Host"/> is
+/// not set explicitly.
+/// </summary>
+public enum LangfuseRegion
+{
+    /// <summary>
+    /// Langfuse Cloud, EU data region (<c>https://cloud.langfuse.com</c>). The default.
+    /// </summary>
+    Eu = 0,
+
+    /// <summary>
+    /// Langfuse Cloud, US data region (<c>https://us.cloud.langfuse.com</c>).
+    /// </summary>
+    Us = 1,
+
+    /// <summary>
+    /// Langfuse Cloud, Japan data region (<c>https://jp.cloud.langfuse.com</c>).
+    /// </summary>
+    Jp = 2,
+
+    /// <summary>
+    /// Langfuse Cloud, HIPAA data region (<c>https://hipaa.cloud.langfuse.com</c>).
+    /// </summary>
+    Hipaa = 3,
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseScenario.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseScenario.cs
@@ -1,0 +1,117 @@
+using System.Diagnostics;
+
+using Microsoft.Extensions.AI.Evaluation;
+
+namespace NexusLabs.Needlr.AgentFramework.Langfuse;
+
+/// <summary>
+/// Active <see cref="ILangfuseScenario"/> backed by a root OpenTelemetry span and a shared
+/// <see cref="LangfuseScoreRecorder"/>.
+/// </summary>
+internal sealed class LangfuseScenario : ILangfuseScenario
+{
+    private readonly Activity? _activity;
+    private readonly LangfuseScoreRecorder _recorder;
+
+    public LangfuseScenario(
+        LangfuseScoreRecorder recorder,
+        string name,
+        string? sessionId,
+        string? userId,
+        IEnumerable<string>? tags,
+        IReadOnlyDictionary<string, string>? metadata)
+    {
+        ArgumentNullException.ThrowIfNull(recorder);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        _recorder = recorder;
+        _activity = LangfuseActivitySource.Source.StartActivity(name, ActivityKind.Internal);
+
+        ApplyTraceAttributes(_activity, name, sessionId, userId, tags, metadata);
+    }
+
+    /// <inheritdoc />
+    public string? TraceId => _activity?.TraceId.ToString();
+
+    /// <inheritdoc />
+    public Activity? Activity => _activity;
+
+    /// <inheritdoc />
+    public Task RecordScoreAsync(string name, double value, string? comment = null, CancellationToken cancellationToken = default) =>
+        TraceId is { Length: > 0 } id
+            ? _recorder.RecordNumericAsync(id, name, value, comment, cancellationToken)
+            : _recorder.RecordSkippedAsync(name, cancellationToken);
+
+    /// <inheritdoc />
+    public Task RecordScoreAsync(string name, bool value, string? comment = null, CancellationToken cancellationToken = default) =>
+        TraceId is { Length: > 0 } id
+            ? _recorder.RecordBooleanAsync(id, name, value, comment, cancellationToken)
+            : _recorder.RecordSkippedAsync(name, cancellationToken);
+
+    /// <inheritdoc />
+    public Task RecordScoreAsync(string name, string value, string? comment = null, CancellationToken cancellationToken = default) =>
+        TraceId is { Length: > 0 } id
+            ? _recorder.RecordCategoricalAsync(id, name, value, comment, cancellationToken)
+            : _recorder.RecordSkippedAsync(name, cancellationToken);
+
+    /// <inheritdoc />
+    public Task RecordEvaluationAsync(EvaluationResult result, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+
+        return TraceId is { Length: > 0 } id
+            ? _recorder.RecordEvaluationAsync(id, result, cancellationToken)
+            : _recorder.RecordSkippedAsync("evaluation", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public void Dispose() => _activity?.Dispose();
+
+    private static void ApplyTraceAttributes(
+        Activity? activity,
+        string name,
+        string? sessionId,
+        string? userId,
+        IEnumerable<string>? tags,
+        IReadOnlyDictionary<string, string>? metadata)
+    {
+        if (activity is null)
+        {
+            return;
+        }
+
+        activity.SetTag("langfuse.trace.name", name);
+
+        if (!string.IsNullOrWhiteSpace(sessionId))
+        {
+            activity.SetTag("langfuse.session.id", sessionId);
+            activity.SetBaggage("session.id", sessionId);
+        }
+
+        if (!string.IsNullOrWhiteSpace(userId))
+        {
+            activity.SetTag("langfuse.user.id", userId);
+            activity.SetBaggage("user.id", userId);
+        }
+
+        if (tags is not null)
+        {
+            var tagArray = tags.Where(t => !string.IsNullOrWhiteSpace(t)).ToArray();
+            if (tagArray.Length > 0)
+            {
+                activity.SetTag("langfuse.trace.tags", tagArray);
+            }
+        }
+
+        if (metadata is not null)
+        {
+            foreach (var entry in metadata)
+            {
+                if (!string.IsNullOrWhiteSpace(entry.Key))
+                {
+                    activity.SetTag($"langfuse.trace.metadata.{entry.Key}", entry.Value);
+                }
+            }
+        }
+    }
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseScore.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseScore.cs
@@ -1,0 +1,33 @@
+namespace NexusLabs.Needlr.AgentFramework.Langfuse;
+
+/// <summary>
+/// Serializable payload for a single Langfuse score ingested via the public Scores API.
+/// </summary>
+/// <remarks>
+/// Property names are projected to camelCase by the score client to match the Langfuse REST
+/// contract. <see cref="Value"/> is a <see cref="double"/> for numeric and boolean scores and a
+/// <see cref="string"/> for categorical and text scores.
+/// </remarks>
+internal sealed record LangfuseScore
+{
+    /// <summary>Gets the id of the trace the score is attached to. Required.</summary>
+    public required string TraceId { get; init; }
+
+    /// <summary>Gets the score name (for example an evaluator metric name). Required.</summary>
+    public required string Name { get; init; }
+
+    /// <summary>Gets the score value: a number for numeric/boolean, a string for categorical/text.</summary>
+    public required object Value { get; init; }
+
+    /// <summary>Gets the Langfuse data type token (<c>NUMERIC</c>, <c>BOOLEAN</c>, <c>CATEGORICAL</c>, <c>TEXT</c>).</summary>
+    public required string DataType { get; init; }
+
+    /// <summary>Gets the optional id of a specific observation within the trace to attach the score to.</summary>
+    public string? ObservationId { get; init; }
+
+    /// <summary>Gets the optional free-text comment that accompanies the score.</summary>
+    public string? Comment { get; init; }
+
+    /// <summary>Gets the optional client-supplied id used as an idempotency key.</summary>
+    public string? Id { get; init; }
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseScoreApiClient.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseScoreApiClient.cs
@@ -1,0 +1,86 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace NexusLabs.Needlr.AgentFramework.Langfuse;
+
+/// <summary>
+/// Posts scores to the Langfuse public Scores API (<c>POST /api/public/scores</c>) using HTTP
+/// Basic authentication. This is the low-level transport; mapping and failure handling live in
+/// <see cref="LangfuseScoreRecorder"/>.
+/// </summary>
+/// <remarks>
+/// A score may be ingested before its trace exists; Langfuse links the two by trace id once the
+/// trace is received. The underlying <see cref="HttpClient"/> is owned by the caller and disposed
+/// with it.
+/// </remarks>
+internal sealed class LangfuseScoreApiClient
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private readonly HttpClient _httpClient;
+    private readonly Uri _scoresEndpoint;
+
+    public LangfuseScoreApiClient(HttpClient httpClient, Uri scoresEndpoint, string authorizationHeaderValue)
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
+        ArgumentNullException.ThrowIfNull(scoresEndpoint);
+        ArgumentException.ThrowIfNullOrWhiteSpace(authorizationHeaderValue);
+
+        _httpClient = httpClient;
+        _scoresEndpoint = scoresEndpoint;
+
+        if (_httpClient.DefaultRequestHeaders.Authorization is null)
+        {
+            var space = authorizationHeaderValue.IndexOf(' ');
+            _httpClient.DefaultRequestHeaders.Authorization = space > 0
+                ? new System.Net.Http.Headers.AuthenticationHeaderValue(
+                    authorizationHeaderValue[..space],
+                    authorizationHeaderValue[(space + 1)..])
+                : new System.Net.Http.Headers.AuthenticationHeaderValue(authorizationHeaderValue);
+        }
+    }
+
+    /// <summary>
+    /// Sends a single score to Langfuse.
+    /// </summary>
+    /// <param name="score">The score to ingest.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <exception cref="LangfuseException">The request failed or returned a non-success status.</exception>
+    public async Task CreateAsync(LangfuseScore score, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(score);
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await _httpClient
+                .PostAsJsonAsync(_scoresEndpoint, score, SerializerOptions, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+        {
+            throw new LangfuseException(
+                $"Failed to send score '{score.Name}' to Langfuse at '{_scoresEndpoint}'.", ex);
+        }
+
+        using (response)
+        {
+            if (response.IsSuccessStatusCode)
+            {
+                return;
+            }
+
+            var body = await response.Content
+                .ReadAsStringAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            throw new LangfuseException(
+                $"Langfuse rejected score '{score.Name}' with status {(int)response.StatusCode} " +
+                $"({response.ReasonPhrase}): {body}");
+        }
+    }
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseScoreClient.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseScoreClient.cs
@@ -1,0 +1,44 @@
+using Microsoft.Extensions.AI.Evaluation;
+
+namespace NexusLabs.Needlr.AgentFramework.Langfuse;
+
+/// <summary>
+/// Default <see cref="ILangfuseScoreClient"/> that records scores via a shared
+/// <see cref="LangfuseScoreRecorder"/>.
+/// </summary>
+internal sealed class LangfuseScoreClient : ILangfuseScoreClient
+{
+    private readonly LangfuseScoreRecorder _recorder;
+    private readonly LangfuseScoreFailureSink _failureSink;
+
+    public LangfuseScoreClient(LangfuseScoreRecorder recorder, LangfuseScoreFailureSink failureSink)
+    {
+        ArgumentNullException.ThrowIfNull(recorder);
+        ArgumentNullException.ThrowIfNull(failureSink);
+
+        _recorder = recorder;
+        _failureSink = failureSink;
+    }
+
+    /// <inheritdoc />
+    public bool IsEnabled => true;
+
+    /// <inheritdoc />
+    public int ScoresFailed => _failureSink.FailedCount;
+
+    /// <inheritdoc />
+    public Task RecordScoreAsync(string traceId, string name, double value, string? comment = null, CancellationToken cancellationToken = default) =>
+        _recorder.RecordNumericAsync(traceId, name, value, comment, cancellationToken);
+
+    /// <inheritdoc />
+    public Task RecordScoreAsync(string traceId, string name, bool value, string? comment = null, CancellationToken cancellationToken = default) =>
+        _recorder.RecordBooleanAsync(traceId, name, value, comment, cancellationToken);
+
+    /// <inheritdoc />
+    public Task RecordScoreAsync(string traceId, string name, string value, string? comment = null, CancellationToken cancellationToken = default) =>
+        _recorder.RecordCategoricalAsync(traceId, name, value, comment, cancellationToken);
+
+    /// <inheritdoc />
+    public Task RecordEvaluationAsync(string traceId, EvaluationResult result, CancellationToken cancellationToken = default) =>
+        _recorder.RecordEvaluationAsync(traceId, result, cancellationToken);
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseScoreDataType.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseScoreDataType.cs
@@ -1,0 +1,20 @@
+namespace NexusLabs.Needlr.AgentFramework.Langfuse;
+
+/// <summary>
+/// The data type of a Langfuse score, controlling how the score value is interpreted and
+/// displayed.
+/// </summary>
+public enum LangfuseScoreDataType
+{
+    /// <summary>A continuous numeric score. The value is a floating-point number.</summary>
+    Numeric = 0,
+
+    /// <summary>A boolean score. The value is <c>1</c> (true) or <c>0</c> (false).</summary>
+    Boolean = 1,
+
+    /// <summary>A categorical score. The value is a category label string.</summary>
+    Categorical = 2,
+
+    /// <summary>A free-text score. The value is an arbitrary string (1–500 characters).</summary>
+    Text = 3,
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseScoreError.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseScoreError.cs
@@ -1,0 +1,12 @@
+namespace NexusLabs.Needlr.AgentFramework.Langfuse;
+
+/// <summary>
+/// Describes a single failed attempt to upload an evaluation score to Langfuse. Passed to
+/// <see cref="LangfuseOptions.ScoreErrorCallback"/> when
+/// <see cref="LangfuseScoreFailureMode.NonFatal"/> is in effect, so callers can log the loss with
+/// their own logger.
+/// </summary>
+/// <param name="ScoreName">The name of the score that failed to upload.</param>
+/// <param name="TraceId">The Langfuse trace id the score was destined for, if known.</param>
+/// <param name="Exception">The exception describing the failure.</param>
+public sealed record LangfuseScoreError(string ScoreName, string? TraceId, Exception Exception);

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseScoreFailureMode.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseScoreFailureMode.cs
@@ -1,0 +1,26 @@
+namespace NexusLabs.Needlr.AgentFramework.Langfuse;
+
+/// <summary>
+/// Controls how a Langfuse scenario reacts when uploading an evaluation score to the Langfuse
+/// Scores API fails.
+/// </summary>
+/// <remarks>
+/// A score upload is a dashboard write that happens <em>after</em> an eval has already produced its
+/// verdict. Treating a transient Langfuse outage as an eval failure would turn a green eval red for
+/// reasons unrelated to the system under test, so the default is <see cref="NonFatal"/>.
+/// </remarks>
+public enum LangfuseScoreFailureMode
+{
+    /// <summary>
+    /// A failed score upload is recorded (the session's failure counter is incremented and the
+    /// configured error callback is invoked) but does not throw. The eval continues. This is the
+    /// default and the recommended mode for eval harnesses.
+    /// </summary>
+    NonFatal = 0,
+
+    /// <summary>
+    /// A failed score upload throws <see cref="LangfuseException"/>. Use this when a missing score
+    /// should hard-fail the caller.
+    /// </summary>
+    Strict = 1,
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseScoreFailureSink.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseScoreFailureSink.cs
@@ -1,0 +1,44 @@
+namespace NexusLabs.Needlr.AgentFramework.Langfuse;
+
+/// <summary>
+/// Applies a session's <see cref="LangfuseScoreFailureMode"/> to a failed score upload and tracks
+/// how many uploads have failed. Shared by every scenario created from one session.
+/// </summary>
+internal sealed class LangfuseScoreFailureSink
+{
+    private readonly LangfuseScoreFailureMode _mode;
+    private readonly Action<LangfuseScoreError>? _callback;
+    private int _failedCount;
+
+    public LangfuseScoreFailureSink(
+        LangfuseScoreFailureMode mode,
+        Action<LangfuseScoreError>? callback)
+    {
+        _mode = mode;
+        _callback = callback;
+    }
+
+    /// <summary>Gets the cumulative number of score uploads that have failed.</summary>
+    public int FailedCount => Volatile.Read(ref _failedCount);
+
+    /// <summary>
+    /// Records a failed score upload. In <see cref="LangfuseScoreFailureMode.Strict"/> mode the
+    /// originating exception is rethrown; otherwise the failure counter is incremented, the error
+    /// callback (if any) is invoked, and control returns to the caller.
+    /// </summary>
+    /// <param name="scoreName">The name of the score that failed.</param>
+    /// <param name="traceId">The destination trace id, if known.</param>
+    /// <param name="exception">The failure.</param>
+    public void Record(string scoreName, string? traceId, LangfuseException exception)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+
+        if (_mode == LangfuseScoreFailureMode.Strict)
+        {
+            throw exception;
+        }
+
+        Interlocked.Increment(ref _failedCount);
+        _callback?.Invoke(new LangfuseScoreError(scoreName, traceId, exception));
+    }
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseScoreRecorder.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseScoreRecorder.cs
@@ -1,0 +1,138 @@
+using System.Text;
+
+using Microsoft.Extensions.AI.Evaluation;
+
+namespace NexusLabs.Needlr.AgentFramework.Langfuse;
+
+/// <summary>
+/// Maps typed scores and <see cref="EvaluationResult"/> metrics to Langfuse score payloads, posts
+/// them via <see cref="LangfuseScoreApiClient"/>, and routes failures through a
+/// <see cref="LangfuseScoreFailureSink"/>. Shared by <see cref="LangfuseScenario"/> (session path)
+/// and <see cref="LangfuseScoreClient"/> (host path) so the mapping lives in one place.
+/// </summary>
+internal sealed class LangfuseScoreRecorder
+{
+    private const string NumericDataType = "NUMERIC";
+    private const string BooleanDataType = "BOOLEAN";
+    private const string CategoricalDataType = "CATEGORICAL";
+
+    private readonly LangfuseScoreApiClient _apiClient;
+    private readonly LangfuseScoreFailureSink _failureSink;
+    private readonly bool _normalizeNames;
+
+    public LangfuseScoreRecorder(
+        LangfuseScoreApiClient apiClient,
+        LangfuseScoreFailureSink failureSink,
+        bool normalizeNames)
+    {
+        ArgumentNullException.ThrowIfNull(apiClient);
+        ArgumentNullException.ThrowIfNull(failureSink);
+
+        _apiClient = apiClient;
+        _failureSink = failureSink;
+        _normalizeNames = normalizeNames;
+    }
+
+    public Task RecordNumericAsync(string traceId, string name, double value, string? comment, CancellationToken cancellationToken) =>
+        SendAsync(traceId, name, value, NumericDataType, comment, cancellationToken);
+
+    public Task RecordBooleanAsync(string traceId, string name, bool value, string? comment, CancellationToken cancellationToken) =>
+        SendAsync(traceId, name, value ? 1.0 : 0.0, BooleanDataType, comment, cancellationToken);
+
+    public Task RecordCategoricalAsync(string traceId, string name, string value, string? comment, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        return SendAsync(traceId, name, value, CategoricalDataType, comment, cancellationToken);
+    }
+
+    public async Task RecordEvaluationAsync(string traceId, EvaluationResult result, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+
+        foreach (var metric in result.Metrics.Values)
+        {
+            switch (metric)
+            {
+                case NumericMetric { Value: { } numeric }:
+                    await RecordNumericAsync(traceId, metric.Name, numeric, metric.Reason, cancellationToken).ConfigureAwait(false);
+                    break;
+                case BooleanMetric { Value: { } boolean }:
+                    await RecordBooleanAsync(traceId, metric.Name, boolean, metric.Reason, cancellationToken).ConfigureAwait(false);
+                    break;
+                case StringMetric { Value: { Length: > 0 } category }:
+                    await RecordCategoricalAsync(traceId, metric.Name, category, metric.Reason, cancellationToken).ConfigureAwait(false);
+                    break;
+            }
+        }
+    }
+
+    private async Task SendAsync(string traceId, string name, object value, string dataType, string? comment, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(traceId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        var score = new LangfuseScore
+        {
+            TraceId = traceId,
+            Name = NormalizeName(name),
+            Value = value,
+            DataType = dataType,
+            Comment = comment,
+        };
+
+        try
+        {
+            await _apiClient.CreateAsync(score, cancellationToken).ConfigureAwait(false);
+        }
+        catch (LangfuseException ex)
+        {
+            _failureSink.Record(name, traceId, ex);
+        }
+    }
+
+    /// <summary>
+    /// Records a score that could not be attached because no sampled trace was available (for
+    /// example, head sampling dropped the scenario span). Routed through the failure sink so it is
+    /// surfaced rather than silently lost.
+    /// </summary>
+    public Task RecordSkippedAsync(string name, CancellationToken cancellationToken)
+    {
+        var failure = new LangfuseException(
+            $"Cannot record score '{name}': no sampled trace was available to attach it to. " +
+            "Ensure the Langfuse session is enabled and sampling is not dropping the scenario span.");
+
+        try
+        {
+            _failureSink.Record(name, null, failure);
+            return Task.CompletedTask;
+        }
+        catch (LangfuseException ex)
+        {
+            return Task.FromException(ex);
+        }
+    }
+
+    private string NormalizeName(string name) => _normalizeNames ? ToSnakeCase(name) : name;
+
+    private static string ToSnakeCase(string name)
+    {
+        var builder = new StringBuilder(name.Length);
+        var previousWasUnderscore = false;
+
+        foreach (var ch in name.Trim())
+        {
+            if (char.IsLetterOrDigit(ch))
+            {
+                builder.Append(char.ToLowerInvariant(ch));
+                previousWasUnderscore = false;
+            }
+            else if (!previousWasUnderscore && builder.Length > 0)
+            {
+                builder.Append('_');
+                previousWasUnderscore = true;
+            }
+        }
+
+        return builder.ToString().Trim('_');
+    }
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseServiceCollectionExtensions.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseServiceCollectionExtensions.cs
@@ -1,0 +1,101 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+using OpenTelemetry.Exporter;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+namespace NexusLabs.Needlr.AgentFramework.Langfuse;
+
+/// <summary>
+/// Registers Langfuse OTLP export on an <see cref="IServiceCollection"/> for ASP.NET Core and
+/// generic-host applications.
+/// </summary>
+/// <remarks>
+/// Unlike <see cref="LangfuseTelemetry.Start(LangfuseOptions)"/> — which builds standalone
+/// providers for evals and console apps — this integrates with the host's
+/// <c>AddOpenTelemetry()</c> pipeline so the tracer and meter providers share the application
+/// lifecycle. When the supplied options are not configured (for example, missing credentials),
+/// registration is skipped and the application starts normally without exporting.
+/// </remarks>
+public static class LangfuseServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds Langfuse OTLP/HTTP export of Needlr agent telemetry to the host's OpenTelemetry
+    /// pipeline.
+    /// </summary>
+    /// <param name="services">The service collection to configure.</param>
+    /// <param name="configure">
+    /// Optional callback to customise the <see cref="LangfuseOptions"/>. When <see langword="null"/>,
+    /// options are read from the environment via <see cref="LangfuseOptions.FromEnvironment"/>.
+    /// </param>
+    /// <returns>The same <see cref="IServiceCollection"/> for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="services"/> is <see langword="null"/>.</exception>
+    public static IServiceCollection AddNeedlrLangfuse(
+        this IServiceCollection services,
+        Action<LangfuseOptions>? configure = null)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        var options = LangfuseOptions.FromEnvironment();
+        configure?.Invoke(options);
+
+        if (!options.IsConfigured)
+        {
+            LangfuseExportGuard.WarnIfCredentialsWithoutTarget(options);
+            services.TryAddSingleton<ILangfuseScoreClient>(new DisabledLangfuseScoreClient());
+            return services;
+        }
+
+        var endpoints = LangfuseEndpoints.Resolve(options);
+
+        var otelBuilder = services
+            .AddOpenTelemetry()
+            .ConfigureResource(resource =>
+            {
+                if (string.IsNullOrWhiteSpace(options.ServiceVersion))
+                {
+                    resource.AddService(options.ServiceName);
+                }
+                else
+                {
+                    resource.AddService(options.ServiceName, serviceVersion: options.ServiceVersion);
+                }
+            })
+            .WithTracing(tracing => tracing
+                .AddSource(LangfuseActivitySource.Name)
+                .AddSource(options.AgentActivitySourceName)
+                .AddSource([.. options.AdditionalActivitySources])
+                .AddProcessor(new LangfuseTraceAttributeProcessor())
+                .AddOtlpExporter(otlp => ConfigureOtlp(otlp, endpoints.TracesEndpoint, endpoints.Headers)));
+
+        if (options.IncludeMetrics)
+        {
+            otelBuilder.WithMetrics(metrics => metrics
+                .AddMeter(options.AgentMeterName)
+                .AddMeter(options.GenAiMeterName)
+                .AddMeter([.. options.AdditionalMeters])
+                .AddOtlpExporter(otlp => ConfigureOtlp(otlp, endpoints.MetricsEndpoint, endpoints.Headers)));
+        }
+
+        var httpClient = new HttpClient();
+        var apiClient = new LangfuseScoreApiClient(
+            httpClient,
+            endpoints.ScoresEndpoint,
+            endpoints.AuthorizationHeaderValue);
+        var failureSink = new LangfuseScoreFailureSink(options.ScoreFailureMode, options.ScoreErrorCallback);
+        var recorder = new LangfuseScoreRecorder(apiClient, failureSink, options.NormalizeScoreNames);
+
+        services.TryAddSingleton<ILangfuseScoreClient>(new LangfuseScoreClient(recorder, failureSink));
+
+        return services;
+    }
+
+    private static void ConfigureOtlp(OtlpExporterOptions otlp, Uri endpoint, string headers)
+    {
+        otlp.Endpoint = endpoint;
+        otlp.Protocol = OtlpExportProtocol.HttpProtobuf;
+        otlp.Headers = headers;
+    }
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseSession.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseSession.cs
@@ -1,0 +1,94 @@
+using System.Threading;
+
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+namespace NexusLabs.Needlr.AgentFramework.Langfuse;
+
+/// <summary>
+/// Active <see cref="ILangfuseSession"/> backed by OpenTelemetry tracer and (optionally) meter
+/// providers that export to Langfuse over OTLP/HTTP.
+/// </summary>
+internal sealed class LangfuseSession : ILangfuseSession
+{
+    private readonly TracerProvider _tracerProvider;
+    private readonly MeterProvider? _meterProvider;
+    private readonly HttpClient _httpClient;
+    private readonly LangfuseScoreRecorder _recorder;
+    private readonly LangfuseScoreFailureSink _failureSink;
+    private int _disposed;
+
+    public LangfuseSession(
+        TracerProvider tracerProvider,
+        MeterProvider? meterProvider,
+        HttpClient httpClient,
+        LangfuseScoreRecorder recorder,
+        LangfuseScoreFailureSink failureSink)
+    {
+        ArgumentNullException.ThrowIfNull(tracerProvider);
+        ArgumentNullException.ThrowIfNull(httpClient);
+        ArgumentNullException.ThrowIfNull(recorder);
+        ArgumentNullException.ThrowIfNull(failureSink);
+
+        _tracerProvider = tracerProvider;
+        _meterProvider = meterProvider;
+        _httpClient = httpClient;
+        _recorder = recorder;
+        _failureSink = failureSink;
+    }
+
+    /// <inheritdoc />
+    public bool IsEnabled => true;
+
+    /// <inheritdoc />
+    public int ScoresFailed => _failureSink.FailedCount;
+
+    /// <inheritdoc />
+    public bool Flush(TimeSpan? timeout = null)
+    {
+        var timeoutMs = ToTimeoutMilliseconds(timeout);
+        var traces = _tracerProvider.ForceFlush(timeoutMs);
+        var metrics = _meterProvider?.ForceFlush(timeoutMs) ?? true;
+        return traces && metrics;
+    }
+
+    /// <inheritdoc />
+    public ILangfuseScenario BeginScenario(
+        string name,
+        string? sessionId = null,
+        string? userId = null,
+        IEnumerable<string>? tags = null,
+        IReadOnlyDictionary<string, string>? metadata = null) =>
+        new LangfuseScenario(_recorder, name, sessionId, userId, tags, metadata);
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        Flush();
+        _tracerProvider.Dispose();
+        _meterProvider?.Dispose();
+        _httpClient.Dispose();
+    }
+
+    private static int ToTimeoutMilliseconds(TimeSpan? timeout)
+    {
+        if (timeout is null)
+        {
+            return Timeout.Infinite;
+        }
+
+        if (timeout.Value == Timeout.InfiniteTimeSpan)
+        {
+            return Timeout.Infinite;
+        }
+
+        var ms = (long)timeout.Value.TotalMilliseconds;
+        return ms < 0 ? Timeout.Infinite : (int)Math.Min(ms, int.MaxValue);
+    }
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseTelemetry.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseTelemetry.cs
@@ -1,0 +1,126 @@
+using OpenTelemetry;
+using OpenTelemetry.Exporter;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+namespace NexusLabs.Needlr.AgentFramework.Langfuse;
+
+/// <summary>
+/// Entry point for exporting Needlr agent telemetry to Langfuse without requiring a generic
+/// host. Designed for evals, console apps, and test fixtures that build telemetry by hand.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="Start(LangfuseOptions)"/> constructs standalone OpenTelemetry tracer and meter
+/// providers that subscribe to Needlr's <c>gen_ai</c> activity source and meters and export them
+/// to Langfuse over OTLP/HTTP. Dispose the returned <see cref="ILangfuseSession"/> to flush and
+/// tear them down.
+/// </para>
+/// <para>
+/// For ASP.NET Core / generic-host applications that already call <c>AddOpenTelemetry()</c>, use
+/// <see cref="LangfuseServiceCollectionExtensions.AddNeedlrLangfuse(Microsoft.Extensions.DependencyInjection.IServiceCollection, Action{LangfuseOptions}?)"/>
+/// instead so the providers participate in the host lifecycle.
+/// </para>
+/// <example>
+/// <code>
+/// using var langfuse = LangfuseTelemetry.Start(LangfuseOptions.FromEnvironment());
+/// using (LangfuseTrace.BeginScenario("trip-planner: NYC -> Tokyo", sessionId: runId))
+/// {
+///     var run = await runner.RunAsync(...);
+///     // ... evaluate and record scores ...
+/// }
+/// </code>
+/// </example>
+/// </remarks>
+public static class LangfuseTelemetry
+{
+    /// <summary>
+    /// Starts a Langfuse export session for the supplied options.
+    /// </summary>
+    /// <param name="options">
+    /// The export configuration. When <see cref="LangfuseOptions.IsConfigured"/> is
+    /// <see langword="false"/> (for example, missing credentials), a disabled no-op session is
+    /// returned so callers never need to branch on configuration state.
+    /// </param>
+    /// <returns>
+    /// An <see cref="ILangfuseSession"/> that exports telemetry until disposed.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="options"/> is <see langword="null"/>.</exception>
+    public static ILangfuseSession Start(LangfuseOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (!options.IsConfigured)
+        {
+            LangfuseExportGuard.WarnIfCredentialsWithoutTarget(options);
+            return new DisabledLangfuseSession();
+        }
+
+        var endpoints = LangfuseEndpoints.Resolve(options);
+        var resource = BuildResource(options);
+
+        var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .SetResourceBuilder(resource)
+            .SetSampler(BuildSampler(options.SamplingRatio))
+            .AddSource(LangfuseActivitySource.Name)
+            .AddSource(options.AgentActivitySourceName)
+            .AddSource([.. options.AdditionalActivitySources])
+            .AddProcessor(new LangfuseTraceAttributeProcessor())
+            .AddOtlpExporter(otlp => ConfigureOtlp(otlp, endpoints.TracesEndpoint, endpoints.Headers))
+            .Build();
+
+        MeterProvider? meterProvider = null;
+        if (options.IncludeMetrics)
+        {
+            meterProvider = Sdk.CreateMeterProviderBuilder()
+                .SetResourceBuilder(resource)
+                .AddMeter(options.AgentMeterName)
+                .AddMeter(options.GenAiMeterName)
+                .AddMeter([.. options.AdditionalMeters])
+                .AddOtlpExporter(otlp => ConfigureOtlp(otlp, endpoints.MetricsEndpoint, endpoints.Headers))
+                .Build();
+        }
+
+        var httpClient = new HttpClient();
+        var apiClient = new LangfuseScoreApiClient(
+            httpClient,
+            endpoints.ScoresEndpoint,
+            endpoints.AuthorizationHeaderValue);
+
+        var failureSink = new LangfuseScoreFailureSink(options.ScoreFailureMode, options.ScoreErrorCallback);
+        var recorder = new LangfuseScoreRecorder(apiClient, failureSink, options.NormalizeScoreNames);
+
+        return new LangfuseSession(tracerProvider, meterProvider, httpClient, recorder, failureSink);
+    }
+
+    private static ResourceBuilder BuildResource(LangfuseOptions options)
+    {
+        var builder = ResourceBuilder.CreateDefault();
+        return string.IsNullOrWhiteSpace(options.ServiceVersion)
+            ? builder.AddService(options.ServiceName)
+            : builder.AddService(options.ServiceName, serviceVersion: options.ServiceVersion);
+    }
+
+    private static Sampler BuildSampler(double ratio)
+    {
+        if (ratio >= 1.0)
+        {
+            return new AlwaysOnSampler();
+        }
+
+        if (ratio <= 0.0)
+        {
+            return new AlwaysOffSampler();
+        }
+
+        return new TraceIdRatioBasedSampler(ratio);
+    }
+
+    private static void ConfigureOtlp(OtlpExporterOptions otlp, Uri endpoint, string headers)
+    {
+        otlp.Endpoint = endpoint;
+        otlp.Protocol = OtlpExportProtocol.HttpProtobuf;
+        otlp.Headers = headers;
+    }
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseTraceAttributeProcessor.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseTraceAttributeProcessor.cs
@@ -1,0 +1,127 @@
+using System.Diagnostics;
+using System.Text.Json;
+
+using OpenTelemetry;
+
+namespace NexusLabs.Needlr.AgentFramework.Langfuse;
+
+/// <summary>
+/// Enriches spans with Langfuse-specific attributes as they flow through the export pipeline.
+/// </summary>
+/// <remarks>
+/// <list type="bullet">
+/// <item>
+/// Copies <see cref="Activity.Baggage"/> entries (trace-level <c>session.id</c> / <c>user.id</c>
+/// set on the scenario root) onto each span's tags so per-observation filtering works.
+/// </item>
+/// <item>
+/// Sets <c>langfuse.observation.type</c> explicitly — <c>generation</c> for chat-completion spans
+/// and <c>span</c> for tool-call spans — instead of relying on Langfuse's implicit
+/// "has a model attribute ⇒ generation" inference.
+/// </item>
+/// <item>
+/// Projects Needlr's <c>gen_ai.usage.*</c> tags into a <c>langfuse.observation.usage_details</c>
+/// JSON attribute so token usage (including <c>cache_read_input_tokens</c> and
+/// <c>reasoning_tokens</c>) reliably lands rather than depending on auto-mapping of non-standard
+/// keys.
+/// </item>
+/// </list>
+/// <para>
+/// This type derives from the OpenTelemetry SDK's <see cref="BaseProcessor{T}"/>, which is the
+/// only supported extension point for span processing; subclassing it is a framework requirement,
+/// not a design choice. It is registered before the OTLP exporter so its <see cref="OnEnd"/>
+/// mutations are visible to the exporter.
+/// </para>
+/// </remarks>
+internal sealed class LangfuseTraceAttributeProcessor : BaseProcessor<Activity>
+{
+    private const string ChatActivityName = "agent.chat";
+    private const string ChatStreamActivityName = "agent.chat.stream";
+    private const string ToolActivityPrefix = "agent.tool";
+
+    /// <inheritdoc />
+    public override void OnStart(Activity data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+
+        CopyBaggageToTags(data);
+        SetObservationType(data);
+    }
+
+    /// <inheritdoc />
+    public override void OnEnd(Activity data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+
+        SetUsageDetails(data);
+    }
+
+    private static void CopyBaggageToTags(Activity data)
+    {
+        foreach (var entry in data.Baggage)
+        {
+            if (entry.Value is not null && data.GetTagItem(entry.Key) is null)
+            {
+                data.SetTag(entry.Key, entry.Value);
+            }
+        }
+    }
+
+    private static void SetObservationType(Activity data)
+    {
+        if (data.GetTagItem("langfuse.observation.type") is not null)
+        {
+            return;
+        }
+
+        var type = data.OperationName switch
+        {
+            ChatActivityName or ChatStreamActivityName => "generation",
+            _ when data.OperationName.StartsWith(ToolActivityPrefix, StringComparison.Ordinal) => "span",
+            _ => null,
+        };
+
+        if (type is not null)
+        {
+            data.SetTag("langfuse.observation.type", type);
+        }
+    }
+
+    private static void SetUsageDetails(Activity data)
+    {
+        if (data.GetTagItem("langfuse.observation.usage_details") is not null)
+        {
+            return;
+        }
+
+        var input = ReadTokenTag(data, "gen_ai.usage.input_tokens");
+        var output = ReadTokenTag(data, "gen_ai.usage.output_tokens");
+        var cacheRead = ReadTokenTag(data, "gen_ai.usage.cached_input_tokens");
+        var reasoning = ReadTokenTag(data, "gen_ai.usage.reasoning_tokens");
+
+        if (input is null && output is null && cacheRead is null && reasoning is null)
+        {
+            return;
+        }
+
+        var usage = new Dictionary<string, long>(StringComparer.Ordinal);
+        if (input is { } i) usage["input"] = i;
+        if (output is { } o) usage["output"] = o;
+        if (cacheRead is { } c) usage["cache_read_input_tokens"] = c;
+        if (reasoning is { } r) usage["reasoning_tokens"] = r;
+        if (input is { } ti && output is { } to) usage["total"] = ti + to;
+
+        data.SetTag("langfuse.observation.usage_details", JsonSerializer.Serialize(usage));
+    }
+
+    private static long? ReadTokenTag(Activity data, string key) => data.GetTagItem(key) switch
+    {
+        null => null,
+        long l => l,
+        int n => n,
+        short s => s,
+        byte b => b,
+        string str when long.TryParse(str, out var parsed) => parsed,
+        _ => null,
+    };
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/NexusLabs.Needlr.AgentFramework.Langfuse.csproj
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/NexusLabs.Needlr.AgentFramework.Langfuse.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageDescription>Langfuse integration for NexusLabs.Needlr.AgentFramework. Exports Needlr's gen_ai OpenTelemetry traces and metrics to Langfuse over OTLP/HTTP and projects Microsoft.Extensions.AI.Evaluation results as Langfuse scores, so agent runs and evals appear on the Langfuse dashboard with a single call.</PackageDescription>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.AI.Evaluation" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="NexusLabs.Needlr.AgentFramework.Langfuse.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NexusLabs.Needlr.AgentFramework\NexusLabs.Needlr.AgentFramework.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/NexusLabs.Needlr.slnx
+++ b/src/NexusLabs.Needlr.slnx
@@ -47,6 +47,8 @@
     <Project Path="Examples/AgentFramework/IterativeTripPlannerApp/IterativeTripPlannerApp.csproj" />
     <Project Path="Examples/AgentFramework/IterativeTripPlannerApp.Core/IterativeTripPlannerApp.Core.csproj" />
     <Project Path="Examples/AgentFramework/IterativeTripPlannerApp.Evaluation/IterativeTripPlannerApp.Evaluation.csproj" />
+    <Project Path="Examples/AgentFramework/LangfuseEvaluationApp/LangfuseEvaluationApp.csproj" />
+    <Project Path="Examples/AgentFramework/LangfuseConformanceApp/LangfuseConformanceApp.csproj" />
     <Project Path="Examples/AgentFramework/DevUIApp/DevUIApp.csproj" />
     <Project Path="Examples/AgentFramework/DiagnosticAttributionApp/DiagnosticAttributionApp.csproj" />
     <Project Path="Examples/AgentFramework/IterativeLoopDiagnosticsApp/IterativeLoopDiagnosticsApp.csproj" />
@@ -136,6 +138,8 @@
     <Project Path="NexusLabs.Needlr.AgentFramework.Evaluation/NexusLabs.Needlr.AgentFramework.Evaluation.csproj" />
     <Project Path="NexusLabs.Needlr.AgentFramework.Evaluation.Tests/NexusLabs.Needlr.AgentFramework.Evaluation.Tests.csproj" />
     <Project Path="NexusLabs.Needlr.AgentFramework.Generators/NexusLabs.Needlr.AgentFramework.Generators.csproj" />
+    <Project Path="NexusLabs.Needlr.AgentFramework.Langfuse/NexusLabs.Needlr.AgentFramework.Langfuse.csproj" />
+    <Project Path="NexusLabs.Needlr.AgentFramework.Langfuse.Tests/NexusLabs.Needlr.AgentFramework.Langfuse.Tests.csproj" />
     <Project Path="NexusLabs.Needlr.AgentFramework.Testing/NexusLabs.Needlr.AgentFramework.Testing.csproj" />
     <Project Path="NexusLabs.Needlr.AgentFramework.Tests/NexusLabs.Needlr.AgentFramework.Tests.csproj" />
     <Project Path="NexusLabs.Needlr.AgentFramework.GeneratedWrapper.Tests/NexusLabs.Needlr.AgentFramework.GeneratedWrapper.Tests.csproj" />


### PR DESCRIPTION
## Summary

Adds **`NexusLabs.Needlr.AgentFramework.Langfuse`** — a one-call integration that exports Needlr's `gen_ai` OpenTelemetry traces to [Langfuse](https://langfuse.com) over OTLP/HTTP and projects `Microsoft.Extensions.AI.Evaluation` results as Langfuse scores. Needlr already emits GenAI-convention telemetry; this wires the "last mile" (exporter + per-scenario trace grouping + score bridge) so agent runs and evals show up on the Langfuse dashboard.

## Usage

Eval / console:

```csharp
using var langfuse = LangfuseTelemetry.Start(LangfuseOptions.FromEnvironment());
using (var scenario = langfuse.BeginScenario("eval: X", sessionId: runId, tags: ["nightly"]))
{
    var run = await runner.RunAsync(...);
    var inputs = run.Diagnostics!.ToEvaluationInputs();
    await scenario.EvaluateAndRecordAsync(
        [new EfficiencyEvaluator(200_000), new IterationCoherenceEvaluator(20)],
        inputs.Messages, inputs.ModelResponse,
        additionalContext: [new AgentRunDiagnosticsContext(run.Diagnostics!)]);
}
langfuse.Flush();
```

ASP.NET / host: `builder.Services.AddNeedlrLangfuse(o => o.ServiceName = "my-service");` also registers a DI-resolvable `ILangfuseScoreClient`.

## Key behaviors

- **Per-scenario traces** with `langfuse.trace.*` attributes; `session.id`/`user.id` propagated to child spans.
- **Span enrichment**: explicit `langfuse.observation.type` (generation/span) and `langfuse.observation.usage_details` JSON (incl. `cache_read_input_tokens`, `reasoning_tokens`).
- **Scores** via the Scores REST API, keyed by trace id. **Non-fatal by default** (`ScoresFailed` counter + error callback) so a Langfuse outage never fails an eval; opt-in `Strict` throws.
- **Cloud export is opt-in**: an explicit `Host` or `Region` is required — keys alone won't send data anywhere.
- **OTLP metrics off by default** (Langfuse does not ingest them today); token usage rides the generation spans.
- Graceful no-op when unconfigured, so the same code runs unchanged in credential-less CI.

## Examples

- `LangfuseEvaluationApp` — full flow, no LLM or Langfuse credentials required (no-ops cleanly).
- `LangfuseConformanceApp` — runs a small eval against a live Langfuse and **reads the trace + scores back** to prove ingestion; a `resiliency` argument instead proves graceful degradation when Langfuse is unreachable (no server required). Not part of CI.

## Testing

- New project builds clean; **43 unit tests** pass (options/endpoints/auth, scenario attributes, score mapping + datatypes, non-fatal vs strict failure, baggage isolation under parallel scenarios, observation typing, usage_details, DI registration).
- Adjacent evaluation suite unchanged: **138/138** pass.
- Docs: `docs/langfuse.md` (+ nav, getting-started bullet); `mkdocs --strict` passes.

## Notes

- Central packages add `OpenTelemetry.Exporter.OpenTelemetryProtocol` and `OpenTelemetry.Extensions.Hosting` (1.15.3, aligned with the existing OpenTelemetry pin).
- The live read-back and resiliency checks are runnable examples (not CI tests), since asserting real-server ingestion requires a running Langfuse.