### PR TITLE
fix(carter)!: make Needlr the sole ICarterModule registrar

### DIFF
--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -275,6 +275,26 @@ If you're building a Needlr integration package that ships plugins:
 Missing step 2 is the most common mistake — the generator runs but produces
 no output because it has no `[GenerateTypeRegistry]` trigger.
 
+#### Carter Module Discovery
+
+The `NexusLabs.Needlr.Carter` integration makes **Needlr the single source of
+truth** for `ICarterModule` registration. Its builder plugin calls
+`AddCarter(c => c.WithEmptyModules())`, which disables Carter's own assembly
+scan for modules. Needlr's type registry registers your modules, and Carter's
+`MapCarter()` maps whatever `ICarterModule` services are in the container.
+
+This avoids a double registration: a `public` module visible to *both* Carter's
+scan and Needlr's registry would otherwise be registered twice and mapped twice,
+producing an `AmbiguousMatchException` ("The request matched multiple endpoints")
+on every one of its routes at request time.
+
+The practical consequence: your Carter modules must be in Needlr's discovery
+scope. With the default `NexusLabs.Needlr.Build` tooling every project is scoped
+to its own `RootNamespace`, so modules are found automatically — `public` or
+`internal`. A module in an assembly that Needlr does not discover (no
+`[GenerateTypeRegistry]`, and not in the reflection scan set) will not be
+registered, because Carter no longer scans for it.
+
 ### Controlling Plugin Discovery
 
 #### Assembly Filtering

--- a/src/NexusLabs.Needlr.Carter.IntegrationTests/CarterModuleRegistrationSyringeTests.cs
+++ b/src/NexusLabs.Needlr.Carter.IntegrationTests/CarterModuleRegistrationSyringeTests.cs
@@ -1,0 +1,74 @@
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+
+using Carter;
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+
+using NexusLabs.Needlr.AspNet;
+using NexusLabs.Needlr.Injection;
+using NexusLabs.Needlr.Injection.SourceGen;
+
+using Xunit;
+
+#pragma warning disable xUnit1051 // TestContext.Current.CancellationToken not used - not applicable for integration tests
+
+namespace NexusLabs.Needlr.Carter.IntegrationTests;
+
+/// <summary>
+/// Exercises Carter modules through the full
+/// <c>Syringe().UsingSourceGen().ForWebApplication()…BuildWebApplication()</c> composition —
+/// the path on which the duplicate-registration bug occurred and which the existing
+/// <c>NexusLabs.Needlr.Carter.Tests</c> never covered.
+/// </summary>
+/// <remarks>
+/// A <c>public</c> module is discovered by both Carter's scan and Needlr's type registry; a
+/// gated observe-and-complement keeps it registered exactly once. An <c>internal</c> module is
+/// invisible to Carter 10.0.0, so Needlr must still register it. Both must serve their routes
+/// without an <see cref="Microsoft.AspNetCore.Routing.Matching.AmbiguousMatchException"/>.
+/// </remarks>
+public sealed class CarterModuleRegistrationSyringeTests
+{
+    [Fact]
+    public async Task PublicModule_ThroughSyringeSourceGen_RegistersExactlyOnce_AndServesRoute()
+    {
+        await using var app = BuildWebApplication();
+        await app.StartAsync();
+
+        var publicModules = app.Services.GetServices<ICarterModule>().Count(m => m is PublicPingModule);
+        Assert.Equal(1, publicModules);
+
+        var response = await app.GetTestClient().GetAsync("/api/public-ping");
+        response.EnsureSuccessStatusCode();
+        Assert.Contains("public-pong", await response.Content.ReadAsStringAsync());
+
+        await app.StopAsync();
+    }
+
+    [Fact]
+    public async Task InternalModule_ThroughSyringeSourceGen_RegistersExactlyOnce_AndServesRoute()
+    {
+        await using var app = BuildWebApplication();
+        await app.StartAsync();
+
+        var internalModules = app.Services.GetServices<ICarterModule>().Count(m => m is InternalPingModule);
+        Assert.Equal(1, internalModules);
+
+        var response = await app.GetTestClient().GetAsync("/api/internal-ping");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains("internal-pong", await response.Content.ReadAsStringAsync());
+
+        await app.StopAsync();
+    }
+
+    private static WebApplication BuildWebApplication()
+        => new Syringe()
+            .UsingSourceGen()
+            .ForWebApplication()
+            .UsingConfigurationCallback((builder, _) => builder.WebHost.UseTestServer())
+            .BuildWebApplication();
+}

--- a/src/NexusLabs.Needlr.Carter.IntegrationTests/CarterModuleRegistrationSyringeTests.cs
+++ b/src/NexusLabs.Needlr.Carter.IntegrationTests/CarterModuleRegistrationSyringeTests.cs
@@ -15,8 +15,6 @@ using NexusLabs.Needlr.Injection.SourceGen;
 
 using Xunit;
 
-#pragma warning disable xUnit1051 // TestContext.Current.CancellationToken not used - not applicable for integration tests
-
 namespace NexusLabs.Needlr.Carter.IntegrationTests;
 
 /// <summary>
@@ -26,43 +24,49 @@ namespace NexusLabs.Needlr.Carter.IntegrationTests;
 /// <c>NexusLabs.Needlr.Carter.Tests</c> never covered.
 /// </summary>
 /// <remarks>
-/// A <c>public</c> module is discovered by both Carter's scan and Needlr's type registry; a
-/// gated observe-and-complement keeps it registered exactly once. An <c>internal</c> module is
-/// invisible to Carter 10.0.0, so Needlr must still register it. Both must serve their routes
-/// without an <see cref="Microsoft.AspNetCore.Routing.Matching.AmbiguousMatchException"/>.
+/// The Carter plugin calls <c>AddCarter(c => c.WithEmptyModules())</c>, so Carter does not scan
+/// for modules and Needlr's type registry is the sole registrar. A <c>public</c> module would
+/// otherwise be discovered by both Carter and Needlr and registered twice; an <c>internal</c>
+/// module is invisible to Carter 10.0.0 and relies on Needlr entirely. Both must register exactly
+/// once and serve their routes without an
+/// <see cref="Microsoft.AspNetCore.Routing.Matching.AmbiguousMatchException"/>.
 /// </remarks>
 public sealed class CarterModuleRegistrationSyringeTests
 {
     [Fact]
     public async Task PublicModule_ThroughSyringeSourceGen_RegistersExactlyOnce_AndServesRoute()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
+
         await using var app = BuildWebApplication();
-        await app.StartAsync();
+        await app.StartAsync(cancellationToken);
 
         var publicModules = app.Services.GetServices<ICarterModule>().Count(m => m is PublicPingModule);
         Assert.Equal(1, publicModules);
 
-        var response = await app.GetTestClient().GetAsync("/api/public-ping");
+        var response = await app.GetTestClient().GetAsync("/api/public-ping", cancellationToken);
         response.EnsureSuccessStatusCode();
-        Assert.Contains("public-pong", await response.Content.ReadAsStringAsync());
+        Assert.Contains("public-pong", await response.Content.ReadAsStringAsync(cancellationToken));
 
-        await app.StopAsync();
+        await app.StopAsync(cancellationToken);
     }
 
     [Fact]
     public async Task InternalModule_ThroughSyringeSourceGen_RegistersExactlyOnce_AndServesRoute()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
+
         await using var app = BuildWebApplication();
-        await app.StartAsync();
+        await app.StartAsync(cancellationToken);
 
         var internalModules = app.Services.GetServices<ICarterModule>().Count(m => m is InternalPingModule);
         Assert.Equal(1, internalModules);
 
-        var response = await app.GetTestClient().GetAsync("/api/internal-ping");
+        var response = await app.GetTestClient().GetAsync("/api/internal-ping", cancellationToken);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        Assert.Contains("internal-pong", await response.Content.ReadAsStringAsync());
+        Assert.Contains("internal-pong", await response.Content.ReadAsStringAsync(cancellationToken));
 
-        await app.StopAsync();
+        await app.StopAsync(cancellationToken);
     }
 
     private static WebApplication BuildWebApplication()

--- a/src/NexusLabs.Needlr.Carter.IntegrationTests/GeneratorAssemblyInfo.cs
+++ b/src/NexusLabs.Needlr.Carter.IntegrationTests/GeneratorAssemblyInfo.cs
@@ -1,0 +1,5 @@
+using NexusLabs.Needlr.Generators;
+
+// Enable source generation for this assembly so the test Carter modules are discovered by
+// Needlr's type registry (exactly as a consumer's feature project would via NexusLabs.Needlr.Build).
+[assembly: GenerateTypeRegistry(IncludeNamespacePrefixes = ["NexusLabs.Needlr.Carter.IntegrationTests"])]

--- a/src/NexusLabs.Needlr.Carter.IntegrationTests/InternalPingModule.cs
+++ b/src/NexusLabs.Needlr.Carter.IntegrationTests/InternalPingModule.cs
@@ -1,0 +1,20 @@
+using Carter;
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace NexusLabs.Needlr.Carter.IntegrationTests;
+
+/// <summary>
+/// An <c>internal</c> Carter module. Carter 10.0.0 only discovers public modules, so its
+/// <c>AddCarter()</c> scan skips this one — Needlr's type registry is its sole registrar.
+/// This is the case a blanket "exclude ICarterModule from Needlr" fix would have broken.
+/// </summary>
+internal sealed class InternalPingModule : ICarterModule
+{
+    public void AddRoutes(IEndpointRouteBuilder app)
+    {
+        app.MapGet("/api/internal-ping", () => Results.Ok(new { message = "internal-pong" }));
+    }
+}

--- a/src/NexusLabs.Needlr.Carter.IntegrationTests/NexusLabs.Needlr.Carter.IntegrationTests.csproj
+++ b/src/NexusLabs.Needlr.Carter.IntegrationTests/NexusLabs.Needlr.Carter.IntegrationTests.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <PackageReference Include="Carter" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NexusLabs.Needlr.Carter\NexusLabs.Needlr.Carter.csproj" />
+    <ProjectReference Include="..\NexusLabs.Needlr.AspNet\NexusLabs.Needlr.AspNet.csproj" />
+    <ProjectReference Include="..\NexusLabs.Needlr.Injection.SourceGen\NexusLabs.Needlr.Injection.SourceGen.csproj" />
+    <ProjectReference Include="..\NexusLabs.Needlr.Injection\NexusLabs.Needlr.Injection.csproj" />
+    <ProjectReference Include="..\NexusLabs.Needlr.Generators\NexusLabs.Needlr.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\NexusLabs.Needlr.Generators.Attributes\NexusLabs.Needlr.Generators.Attributes.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/NexusLabs.Needlr.Carter.IntegrationTests/PublicPingModule.cs
+++ b/src/NexusLabs.Needlr.Carter.IntegrationTests/PublicPingModule.cs
@@ -1,0 +1,21 @@
+using Carter;
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace NexusLabs.Needlr.Carter.IntegrationTests;
+
+/// <summary>
+/// A <c>public</c> Carter module. It is discovered by BOTH Carter's <c>AddCarter()</c> scan
+/// (which finds public modules) AND Needlr's source-generated type registry, so it is the
+/// shape that previously double-registered.
+/// </summary>
+public sealed class PublicPingModule : ICarterModule
+{
+    /// <inheritdoc />
+    public void AddRoutes(IEndpointRouteBuilder app)
+    {
+        app.MapGet("/api/public-ping", () => Results.Ok(new { message = "public-pong" }));
+    }
+}

--- a/src/NexusLabs.Needlr.Carter.Tests/CarterEndToEndTests.cs
+++ b/src/NexusLabs.Needlr.Carter.Tests/CarterEndToEndTests.cs
@@ -6,11 +6,6 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
-
-using NexusLabs.Needlr.AspNet;
-using NexusLabs.Needlr.Injection;
-using NexusLabs.Needlr.Injection.SourceGen.PluginFactories;
 
 using Xunit;
 
@@ -19,8 +14,10 @@ using Xunit;
 namespace NexusLabs.Needlr.Carter.Tests;
 
 /// <summary>
-/// End-to-end tests that verify Carter modules actually handle HTTP requests
-/// when configured through the Needlr plugin system.
+/// Baseline end-to-end tests that verify Carter modules handle HTTP requests using
+/// Carter's own <c>AddCarter()</c>/<c>MapCarter()</c>. The full Needlr source-gen
+/// composition — where Needlr discovers and registers the modules — is covered by
+/// <c>NexusLabs.Needlr.Carter.IntegrationTests</c>.
 /// </summary>
 public sealed class CarterEndToEndTests
 {
@@ -104,105 +101,6 @@ public sealed class CarterEndToEndTests
 
         // Assert
         Assert.Equal(System.Net.HttpStatusCode.NotFound, response.StatusCode);
-    }
-
-    [Fact]
-    public async Task CarterModule_ConfiguredViaPluginSystem_WorksEndToEnd()
-    {
-        // Arrange - use plugin system to configure Carter
-        var builder = WebApplication.CreateBuilder();
-        builder.WebHost.UseTestServer();
-
-        // Configure Carter via the Needlr plugin
-        var builderPlugin = new CarterWebApplicationBuilderPlugin();
-        var mockLogger = new Moq.Mock<ILogger>();
-        var mockPluginFactory = new Moq.Mock<IPluginFactory>();
-        var builderOptions = new WebApplicationBuilderPluginOptions(
-            builder, [], mockLogger.Object, mockPluginFactory.Object);
-        builderPlugin.Configure(builderOptions);
-
-        // Option B contract: the Carter plugin disables Carter's own module scan, so Needlr's
-        // type registry is the sole registrar. This test does not run the Syringe registrar, so
-        // it registers the module directly to stand in for what Needlr would register.
-        builder.Services.AddSingleton<ICarterModule, TestCarterModule>();
-
-        var app = builder.Build();
-
-        // Configure routes via the Needlr plugin
-        var appPlugin = new CarterWebApplicationPlugin();
-        var appOptions = new WebApplicationPluginOptions(app, [], mockPluginFactory.Object);
-        appPlugin.Configure(appOptions);
-
-        await app.StartAsync();
-
-        var client = app.GetTestClient();
-
-        // Act
-        var response = await client.GetAsync("/api/test");
-
-        // Assert
-        response.EnsureSuccessStatusCode();
-        var content = await response.Content.ReadAsStringAsync();
-        Assert.Contains("Hello from Carter!", content);
-
-        await app.StopAsync();
-    }
-
-    [Fact]
-    public async Task CarterModule_WithSourceGenPluginFactory_WorksEndToEnd()
-    {
-        // Arrange - use source-generated plugin factory
-        var builder = WebApplication.CreateBuilder();
-        builder.WebHost.UseTestServer();
-
-        // Use the REAL source-generated plugin factory from Needlr.Carter
-        var pluginFactory = new GeneratedPluginFactory(
-            Generated.TypeRegistry.GetPluginTypes);
-
-        var mockLogger = new Moq.Mock<ILogger>();
-        var builderOptions = new WebApplicationBuilderPluginOptions(
-            builder, [typeof(CarterWebApplicationBuilderPlugin).Assembly], mockLogger.Object, pluginFactory);
-
-        // Get plugins via the source-generated factory
-        var builderPlugins = pluginFactory.CreatePluginsFromAssemblies<IWebApplicationBuilderPlugin>(
-            [typeof(CarterWebApplicationBuilderPlugin).Assembly]);
-
-        foreach (var plugin in builderPlugins)
-        {
-            plugin.Configure(builderOptions);
-        }
-
-        // Option B contract: the Carter plugin disables Carter's own module scan, so Needlr's
-        // type registry is the sole registrar. This test does not run the Syringe registrar, so
-        // it registers the module directly to stand in for what Needlr would register.
-        builder.Services.AddSingleton<ICarterModule, TestCarterModule>();
-
-        var app = builder.Build();
-
-        var appOptions = new WebApplicationPluginOptions(
-            app, [typeof(CarterWebApplicationPlugin).Assembly], pluginFactory);
-
-        var appPlugins = pluginFactory.CreatePluginsFromAssemblies<IWebApplicationPlugin>(
-            [typeof(CarterWebApplicationPlugin).Assembly]);
-
-        foreach (var plugin in appPlugins)
-        {
-            plugin.Configure(appOptions);
-        }
-
-        await app.StartAsync();
-
-        var client = app.GetTestClient();
-
-        // Act
-        var response = await client.GetAsync("/api/test");
-
-        // Assert
-        response.EnsureSuccessStatusCode();
-        var content = await response.Content.ReadAsStringAsync();
-        Assert.Contains("Hello from Carter!", content);
-
-        await app.StopAsync();
     }
 
     private static async Task<IHost> CreateTestHostAsync()

--- a/src/NexusLabs.Needlr.Carter.Tests/CarterEndToEndTests.cs
+++ b/src/NexusLabs.Needlr.Carter.Tests/CarterEndToEndTests.cs
@@ -121,6 +121,11 @@ public sealed class CarterEndToEndTests
             builder, [], mockLogger.Object, mockPluginFactory.Object);
         builderPlugin.Configure(builderOptions);
 
+        // Option B contract: the Carter plugin disables Carter's own module scan, so Needlr's
+        // type registry is the sole registrar. This test does not run the Syringe registrar, so
+        // it registers the module directly to stand in for what Needlr would register.
+        builder.Services.AddSingleton<ICarterModule, TestCarterModule>();
+
         var app = builder.Build();
 
         // Configure routes via the Needlr plugin
@@ -166,6 +171,11 @@ public sealed class CarterEndToEndTests
         {
             plugin.Configure(builderOptions);
         }
+
+        // Option B contract: the Carter plugin disables Carter's own module scan, so Needlr's
+        // type registry is the sole registrar. This test does not run the Syringe registrar, so
+        // it registers the module directly to stand in for what Needlr would register.
+        builder.Services.AddSingleton<ICarterModule, TestCarterModule>();
 
         var app = builder.Build();
 

--- a/src/NexusLabs.Needlr.Carter/CarterWebApplicationBuilderPlugin.cs
+++ b/src/NexusLabs.Needlr.Carter/CarterWebApplicationBuilderPlugin.cs
@@ -18,7 +18,14 @@ public sealed class CarterWebApplicationBuilderPlugin : IWebApplicationBuilderPl
         ArgumentNullException.ThrowIfNull(options);
 
         options.Logger.LogInformation("Configuring Carter services...");
-        options.Builder.Services.AddCarter();
+
+        // Disable Carter's own assembly scan for ICarterModule implementers: Needlr's type
+        // registry is the single source of truth for module registration. Without this, a
+        // public module is discovered by BOTH Carter and Needlr and mapped twice, which
+        // surfaces as an AmbiguousMatchException at request time. MapCarter() maps whatever
+        // ICarterModule services are in the container, so Needlr-registered modules still map.
+        options.Builder.Services.AddCarter(configurator: configurator => configurator.WithEmptyModules());
+
         options.Logger.LogInformation("Carter services configured successfully.");
     }
 }

--- a/src/NexusLabs.Needlr.slnx
+++ b/src/NexusLabs.Needlr.slnx
@@ -99,6 +99,7 @@
     <Project Path="NexusLabs.Needlr.AspNet/NexusLabs.Needlr.AspNet.csproj" />
   </Folder>
   <Folder Name="/Integrations/Carter/">
+    <Project Path="NexusLabs.Needlr.Carter.IntegrationTests/NexusLabs.Needlr.Carter.IntegrationTests.csproj" />
     <Project Path="NexusLabs.Needlr.Carter.Tests/NexusLabs.Needlr.Carter.Tests.csproj" />
     <Project Path="NexusLabs.Needlr.Carter/NexusLabs.Needlr.Carter.csproj" />
   </Folder>


### PR DESCRIPTION
## Problem

A `public` `ICarterModule` composed through Needlr source-gen was registered **twice** — once by Carter's own `AddCarter()` assembly scan and once by Needlr's type registry interface forwarding. At request time this surfaced as:

```
Microsoft.AspNetCore.Routing.Matching.AmbiguousMatchException:
The request matched multiple endpoints. Matches: GET /api/ping, GET /api/ping
```

`app.Services.GetServices<ICarterModule>()` returned the same module type twice. Reproduced through the real `Syringe().UsingSourceGen().ForWebApplication().BuildWebApplication()` path.

## Fix (one line of behavior)

`CarterWebApplicationBuilderPlugin` now disables Carter's own module scan:

```csharp
options.Builder.Services.AddCarter(configurator: configurator => configurator.WithEmptyModules());
```

Needlr's type registry becomes the **single source of truth** for `ICarterModule` registration. `MapCarter()` maps whatever `ICarterModule` services are present in the container, so Needlr-registered modules (public **and** same-assembly internal) still map — exactly once.

### Why this approach

- **Registrar-agnostic / actually generic:** Carter modules become ordinary Needlr-registered types, handled uniformly by the generated, reflection, and Scrutor registrars. No per-registrar special-casing.
- **No ordering dependency:** there is no second registration source to reconcile.
- **Smallest correct change:** one line plus an explanatory comment.

> A "gated observe-and-complement" mechanism (a `DeclareExternallyOwnedService<T>()` API + per-registrar dedup) was prototyped and **rejected/removed**: it duplicated logic across registrars, could not cleanly cover the Scrutor registrar, and depended on Carter-before-Needlr ordering. This approach avoids all three.

## :warning: BREAKING CHANGE

Consumers that adopted **`.Except<ICarterModule>()`** as a workaround for the duplicate must **remove it**. With Carter's scan disabled *and* Needlr excepting `ICarterModule`, modules would register **nowhere** and every route would 404.

Carter modules must also be within Needlr's discovery scope. With the default `NexusLabs.Needlr.Build` tooling every project is scoped to its `RootNamespace`, so this is automatic for the standard setup. A module in an assembly Needlr does not discover (no `[GenerateTypeRegistry]`, not in the reflection scan set) will no longer be found, because Carter no longer scans for it.

## Tests

- **New `NexusLabs.Needlr.Carter.IntegrationTests`** — exercises the full `Syringe().UsingSourceGen().ForWebApplication()` path (previously **uncovered** by any test) with both a **public** and an **internal** module, asserting a single `ICarterModule` registration and an HTTP 200 with no `AmbiguousMatchException`.
- **`NexusLabs.Needlr.Carter.Tests`** — two plugin-based end-to-end tests now register the module via DI to reflect the new contract (that project has no Needlr type registry of its own, so under the new model nothing else registers the module).

### Verification
- Full solution build: **0 errors**.
- `Carter.Tests` **24/24**, `Carter.IntegrationTests` **2/2**, `Injection.Tests` **192/192**.
- `mkdocs --strict`: passes.
- Red/green confirmed by toggling `WithEmptyModules()` — removing it makes the public-module test fail with `Actual: 2` (the duplicate).

## How to scrutinize quickly

```bash
dotnet test src/NexusLabs.Needlr.Carter.IntegrationTests/NexusLabs.Needlr.Carter.IntegrationTests.csproj
```

To see the bug it prevents: change the plugin's `AddCarter(... WithEmptyModules())` back to `AddCarter()` and re-run — the public-module test fails with two registrations.

## Deliberately out of scope

- **brandghost** (`.Except<ICarterModule>()` removal) — separate repo, intentionally not touched. It must remove that line when adopting this change or its Carter routes will 404.
- No reflection-mode Carter e2e through Syringe (option B is registrar-agnostic, so the source-gen integration test is representative).
