### PR TITLE
docs(examples): add source-gen Carter example with a public module

### DIFF
--- a/src/Examples/SourceGen/CarterSourceGen/CarterSourceGen.csproj
+++ b/src/Examples/SourceGen/CarterSourceGen/CarterSourceGen.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <ItemGroup>
+    <PackageReference Include="Carter" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\NexusLabs.Needlr.AspNet\NexusLabs.Needlr.AspNet.csproj" />
+    <ProjectReference Include="..\..\..\NexusLabs.Needlr.Carter\NexusLabs.Needlr.Carter.csproj" />
+    <ProjectReference Include="..\..\..\NexusLabs.Needlr.Injection.SourceGen\NexusLabs.Needlr.Injection.SourceGen.csproj" />
+    <ProjectReference Include="..\..\..\NexusLabs.Needlr.Generators\NexusLabs.Needlr.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\..\NexusLabs.Needlr.Generators.Attributes\NexusLabs.Needlr.Generators.Attributes.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Examples/SourceGen/CarterSourceGen/GreetingProvider.cs
+++ b/src/Examples/SourceGen/CarterSourceGen/GreetingProvider.cs
@@ -1,0 +1,11 @@
+namespace CarterSourceGen;
+
+/// <summary>
+/// A simple service that the Carter module depends on. It is discovered and registered
+/// by Needlr's source generator (no attributes required) and injected into the module's
+/// route handler, demonstrating that source-gen DI flows into Carter endpoints.
+/// </summary>
+internal sealed class GreetingProvider
+{
+    public string GetGreeting() => "pong";
+}

--- a/src/Examples/SourceGen/CarterSourceGen/PingModule.cs
+++ b/src/Examples/SourceGen/CarterSourceGen/PingModule.cs
@@ -1,0 +1,27 @@
+using Carter;
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace CarterSourceGen;
+
+/// <summary>
+/// A <c>public</c> Carter module. Under Needlr source generation, a public module is the
+/// shape that previously double-registered: Carter's own <c>AddCarter()</c> assembly scan
+/// found it AND Needlr's type registry forwarded <c>ICarterModule</c> to it, so every route
+/// was mapped twice and returned an <c>AmbiguousMatchException</c> at request time.
+///
+/// The <c>NexusLabs.Needlr.Carter</c> plugin now calls
+/// <c>AddCarter(c =&gt; c.WithEmptyModules())</c>, making Needlr the single registrar. This
+/// module is therefore registered exactly once and serves <c>GET /api/ping</c> normally.
+/// </summary>
+public sealed class PingModule : ICarterModule
+{
+    /// <inheritdoc />
+    public void AddRoutes(IEndpointRouteBuilder app)
+    {
+        app.MapGet("/api/ping", (GreetingProvider greetingProvider) =>
+            Results.Ok(new { message = greetingProvider.GetGreeting() }));
+    }
+}

--- a/src/Examples/SourceGen/CarterSourceGen/Program.cs
+++ b/src/Examples/SourceGen/CarterSourceGen/Program.cs
@@ -1,0 +1,62 @@
+using Carter;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using NexusLabs.Needlr.AspNet;
+using NexusLabs.Needlr.Injection;
+using NexusLabs.Needlr.Injection.SourceGen;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CarterSourceGen — demonstrates NexusLabs.Needlr.Carter on the source-generated
+// ASP.NET Core WebApplication path with a PUBLIC Carter module.
+//
+// This is the configuration that previously triggered a duplicate registration:
+// a public ICarterModule was discovered by BOTH Carter's own AddCarter() scan and
+// Needlr's source-gen type registry, so MapCarter() mapped each route twice and the
+// endpoint returned an AmbiguousMatchException.
+//
+// The NexusLabs.Needlr.Carter plugin now calls AddCarter(c => c.WithEmptyModules()),
+// so Carter no longer scans for modules and Needlr's type registry is the single
+// registrar. The public module below is registered exactly once and GET /api/ping
+// returns 200.
+//
+// The example self-checks: if PingModule resolves anything other than exactly once,
+// it sets a non-zero exit code (the bug signature), so the example doubles as a
+// runnable regression guard.
+// ─────────────────────────────────────────────────────────────────────────────
+
+var webApplication = new Syringe()
+    .UsingSourceGen()
+    .ForWebApplication()
+    .BuildWebApplication();
+
+var webAppTask = webApplication.RunAsync();
+
+var pingModuleRegistrations = webApplication.Services
+    .GetServices<ICarterModule>()
+    .Count(module => module is CarterSourceGen.PingModule);
+
+Console.WriteLine("CarterSourceGen Example");
+Console.WriteLine("=======================");
+Console.WriteLine("Public Carter module discovered through Needlr source generation.");
+Console.WriteLine();
+Console.WriteLine($"  ICarterModule registrations for PingModule: {pingModuleRegistrations}");
+
+if (pingModuleRegistrations == 1)
+{
+    Console.WriteLine("  ✓  Registered exactly once — GET /api/ping serves a single endpoint.");
+}
+else
+{
+    Console.WriteLine(
+        $"  ⚠  Expected exactly 1 registration but found {pingModuleRegistrations}. This is the");
+    Console.WriteLine(
+        "     duplicate-registration bug signature and would cause an AmbiguousMatchException.");
+    Environment.ExitCode = 1;
+}
+
+Console.WriteLine();
+Console.WriteLine("  GET /api/ping  →  {\"message\":\"pong\"}");
+Console.WriteLine();
+
+await webAppTask;

--- a/src/Examples/SourceGen/CarterSourceGen/Properties/launchSettings.json
+++ b/src/Examples/SourceGen/CarterSourceGen/Properties/launchSettings.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "CarterSourceGen": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "api/ping",
+      "applicationUrl": "https://localhost:7242;http://localhost:5242",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/NexusLabs.Needlr.slnx
+++ b/src/NexusLabs.Needlr.slnx
@@ -6,6 +6,7 @@
     <Project Path="Examples/Bundle/BundleExamplePlugin/BundleExamplePlugin.csproj" />
   </Folder>
   <Folder Name="/Examples/SourceGen/">
+    <Project Path="Examples/SourceGen/CarterSourceGen/CarterSourceGen.csproj" />
     <Project Path="Examples/SourceGen/HttpClientExample/HttpClientExample.csproj" />
     <Project Path="Examples/SourceGen/MinimalWebApiSourceGen/MinimalWebApiSourceGen.csproj" />
   </Folder>


### PR DESCRIPTION
## Summary

Adds a source-generated Carter example with a **public** module — the configuration that the duplicate-registration bug (fixed in #19) actually affected, and which no example previously covered.

## Why

The only existing Carter example, `Examples/Reflection/AspNetCoreApp1`, uses `UsingReflection()` with an **internal** module. That's the one Carter configuration the bug *never* hit (Carter 10.0.0 doesn't discover internal modules, so there was never a second registration). So the example suite demonstrated everything *except* the scenario the fix is about: a **public** `ICarterModule` on the **`UsingSourceGen()`** path.

This fills that gap with a runnable, self-checking example.

## What's added

`src/Examples/SourceGen/CarterSourceGen/`:

- **`PingModule.cs`** — `public sealed class PingModule : ICarterModule` mapping `GET /api/ping`.
- **`GreetingProvider.cs`** — an `internal` service auto-registered by source-gen and injected into the module's route, demonstrating source-gen DI flows into Carter endpoints.
- **`Program.cs`** — `Syringe().UsingSourceGen().ForWebApplication().BuildWebApplication()`. It resolves `GetServices<ICarterModule>()`, prints the registration count, and **sets a non-zero exit code if `PingModule` is not registered exactly once** — so the example doubles as a runnable regression guard for the `AmbiguousMatchException` the bug produced.
- `CarterSourceGen.csproj`, `Properties/launchSettings.json`, and a `.slnx` entry under `/Examples/SourceGen/`.

The example dog-foods the `NexusLabs.Needlr.Build` auto-attribute generation (via `Examples/Directory.Build.props`), so there is no hand-written `[assembly: GenerateTypeRegistry]` — exactly like a NuGet consumer.

## Verification

Ran the app (`dotnet run`):

```
  ICarterModule registrations for PingModule: 1
  ✓  Registered exactly once — GET /api/ping serves a single endpoint.
```

```
GET http://127.0.0.1:5242/api/ping  →  200  {"message":"pong"}
```

Full solution builds clean (`0 errors`). No production code changed — this is example/docs only.

## Notes

- I intentionally did **not** convert the existing reflection example to a public module — keeping an `internal` + reflection example is valid and shows that path still works (verified separately).
- Depends on the fix merged in #19 (`AddCarter(c => c.WithEmptyModules())`); this branch is cut from the post-merge `main`.
