### PR TITLE
feat(generators): source-generate composed closed-generic registrations

### DIFF
--- a/docs/analyzers/NDLRGEN035.md
+++ b/docs/analyzers/NDLRGEN035.md
@@ -1,0 +1,43 @@
+# NDLRGEN035: [RegisterClosedOverImplementationsOf] source type must be an open generic interface
+
+## Cause
+
+The first type argument passed to `[RegisterClosedOverImplementationsOf]` is not an open generic interface (unbound generic type).
+
+## Rule Description
+
+The attribute discovers concrete closed implementations of an open generic interface and registers a composition closed over each implementation's type argument(s). The source type must be:
+
+1. **An interface** (not a class or struct)
+2. **An open/unbound generic** using the `typeof(IInterface<>)` syntax
+
+Common mistakes include passing a closed generic like `typeof(IFooDefinition<string>)`, a non-generic interface like `typeof(IService)`, or a class instead of an interface.
+
+## How to Fix
+
+Use the open generic `typeof()` syntax with empty angle brackets:
+
+```csharp
+using NexusLabs.Needlr.Generators;
+
+public interface IFooDefinition<T> { }
+public interface IFoo { }
+
+// ❌ WRONG - closed generic
+[RegisterClosedOverImplementationsOf(typeof(IFooDefinition<string>), As = typeof(IFoo))]
+public class FooCore<T> : IFoo { }
+
+// ❌ WRONG - non-generic interface
+[RegisterClosedOverImplementationsOf(typeof(IFoo), As = typeof(IFoo))]
+public class OtherCore<T> : IFoo { }
+
+// ✅ CORRECT - open generic interface
+[RegisterClosedOverImplementationsOf(typeof(IFooDefinition<>), As = typeof(IFoo))]
+public class GoodCore<T> : IFoo { }
+```
+
+## See Also
+
+- [NDLRGEN036](NDLRGEN036.md) - Composition class must be an open generic with matching arity
+- [NDLRGEN037](NDLRGEN037.md) - Composition class must implement the `As` service type
+- [Compose and Expose Closed Generics](../composed-closed-generics.md)

--- a/docs/analyzers/NDLRGEN036.md
+++ b/docs/analyzers/NDLRGEN036.md
@@ -1,0 +1,44 @@
+# NDLRGEN036: [RegisterClosedOverImplementationsOf] composition must be an open generic class
+
+## Cause
+
+The class annotated with `[RegisterClosedOverImplementationsOf]` is not an open generic class, or its type-parameter count does not match the source open generic interface's arity.
+
+## Rule Description
+
+The generator closes the composition class over the type argument(s) of each discovered implementation of the source interface. For that to be possible, the composition class must be an open generic with the **same number of type parameters** as the source interface.
+
+## How to Fix
+
+Make the composition class generic with arity matching the source interface:
+
+```csharp
+using NexusLabs.Needlr.Generators;
+
+public interface IFooDefinition<T> { }
+public interface IFoo { }
+
+// ❌ WRONG - composition is not generic
+[RegisterClosedOverImplementationsOf(typeof(IFooDefinition<>), As = typeof(IFoo))]
+public class FooCore : IFoo { }
+
+// ✅ CORRECT - one type parameter to match IFooDefinition<>
+[RegisterClosedOverImplementationsOf(typeof(IFooDefinition<>), As = typeof(IFoo))]
+public class FooCore<T> : IFoo { }
+```
+
+For multi-parameter source interfaces, match the arity exactly:
+
+```csharp
+public interface IPairDefinition<TKey, TValue> { }
+
+// ✅ CORRECT - two type parameters to match IPairDefinition<,>
+[RegisterClosedOverImplementationsOf(typeof(IPairDefinition<,>), As = typeof(IPair))]
+public class PairCore<TKey, TValue> : IPair { }
+```
+
+## See Also
+
+- [NDLRGEN035](NDLRGEN035.md) - Source type must be an open generic interface
+- [NDLRGEN037](NDLRGEN037.md) - Composition class must implement the `As` service type
+- [Compose and Expose Closed Generics](../composed-closed-generics.md)

--- a/docs/analyzers/NDLRGEN037.md
+++ b/docs/analyzers/NDLRGEN037.md
@@ -1,0 +1,44 @@
+# NDLRGEN037: [RegisterClosedOverImplementationsOf] composition must implement the As service type
+
+## Cause
+
+The class annotated with `[RegisterClosedOverImplementationsOf]` either does not specify an `As` service type, or specifies one it does not implement.
+
+## Rule Description
+
+Each closed composition is registered as the service type named by `As`, so the composition class must:
+
+1. **Specify** an `As` type (e.g. `As = typeof(IFoo)`), and
+2. **Implement** it, directly or transitively.
+
+Without a valid `As` the generated registration would not compile (or would do nothing), so the attribute is meaningless.
+
+## How to Fix
+
+Set `As` to a service type the composition implements:
+
+```csharp
+using NexusLabs.Needlr.Generators;
+
+public interface IFooDefinition<T> { }
+public interface IFoo { }
+public interface IOther { }
+
+// ❌ WRONG - As is not specified
+[RegisterClosedOverImplementationsOf(typeof(IFooDefinition<>))]
+public class FooCore<T> : IFoo { }
+
+// ❌ WRONG - composition does not implement the As type
+[RegisterClosedOverImplementationsOf(typeof(IFooDefinition<>), As = typeof(IFoo))]
+public class OtherCore<T> : IOther { }
+
+// ✅ CORRECT - As is specified and implemented
+[RegisterClosedOverImplementationsOf(typeof(IFooDefinition<>), As = typeof(IFoo))]
+public class FooCore<T> : IFoo { }
+```
+
+## See Also
+
+- [NDLRGEN035](NDLRGEN035.md) - Source type must be an open generic interface
+- [NDLRGEN036](NDLRGEN036.md) - Composition class must be an open generic with matching arity
+- [Compose and Expose Closed Generics](../composed-closed-generics.md)

--- a/docs/analyzers/NDLRGEN038.md
+++ b/docs/analyzers/NDLRGEN038.md
@@ -1,0 +1,44 @@
+# NDLRGEN038: [RegisterClosedOverImplementationsOf] discovered type argument violates composition constraints
+
+## Cause
+
+An implementation of the designated open generic interface was discovered whose type argument(s) do not satisfy the composition type's generic constraints. The corresponding registration is **skipped** and this warning is reported.
+
+## Rule Description
+
+Unlike [NDLRGEN035](NDLRGEN035.md)–[NDLRGEN037](NDLRGEN037.md), this diagnostic is emitted by the **generator**, not by a per-attribute analyzer, because only the generator knows the full set of discovered implementations. When a discovered type argument cannot legally close the composition, emitting `new Composition<TArg>(...)` would fail to compile; the generator skips that registration and reports this warning instead, turning a would-be runtime absence into a build-time signal.
+
+This diagnostic is only **reachable** when the composition's constraints are *stricter* than the source interface's. If both carry the same constraint (e.g. `where TData : class`), every discovered implementation can always close the composition and this never fires.
+
+## How to Fix
+
+Align the constraints, or prevent the incompatible implementation from being discovered:
+
+```csharp
+using NexusLabs.Needlr.Generators;
+
+// The source interface is unconstrained, so a struct argument is allowed here...
+public interface IFooDefinition<TData> { }
+public struct StructData { }
+public sealed class StructFoo : IFooDefinition<StructData> { }
+
+public interface IFoo { }
+
+// ❌ WRONG - composition requires a reference type, but StructFoo closes over a struct.
+//    NDLRGEN038 is reported and the StructData registration is skipped.
+[RegisterClosedOverImplementationsOf(typeof(IFooDefinition<>), As = typeof(IFoo))]
+public sealed class FooCore<TData> : IFoo where TData : class { }
+```
+
+Fixes include:
+
+- **Constrain the source interface** so incompatible implementations cannot exist (`public interface IFooDefinition<TData> where TData : class`).
+- **Relax the composition's constraint** if the composition genuinely supports the wider set.
+- **Exclude the implementation** if it should not participate.
+
+## See Also
+
+- [NDLRGEN035](NDLRGEN035.md) - Source type must be an open generic interface
+- [NDLRGEN036](NDLRGEN036.md) - Composition class must be an open generic with matching arity
+- [NDLRGEN037](NDLRGEN037.md) - Composition class must implement the `As` service type
+- [Compose and Expose Closed Generics](../composed-closed-generics.md)

--- a/docs/analyzers/README.md
+++ b/docs/analyzers/README.md
@@ -110,6 +110,10 @@ These diagnostics are emitted by the source generator to detect configuration is
 | [NDLRGEN032](NDLRGEN032.md) | Error | [Provider] interface has invalid member |
 | [NDLRGEN033](NDLRGEN033.md) | Warning | [Provider] property uses concrete type |
 | [NDLRGEN034](NDLRGEN034.md) | Error | [Provider] circular dependency detected |
+| [NDLRGEN035](NDLRGEN035.md) | Error | [RegisterClosedOverImplementationsOf] source must be an open generic interface |
+| [NDLRGEN036](NDLRGEN036.md) | Error | [RegisterClosedOverImplementationsOf] composition must be an open generic class |
+| [NDLRGEN037](NDLRGEN037.md) | Error | [RegisterClosedOverImplementationsOf] composition must implement the As service type |
+| [NDLRGEN038](NDLRGEN038.md) | Warning | [RegisterClosedOverImplementationsOf] discovered type argument violates composition constraints |
 
 ## HttpClient Diagnostics (NexusLabs.Needlr.Generators)
 

--- a/docs/composed-closed-generics.md
+++ b/docs/composed-closed-generics.md
@@ -1,0 +1,145 @@
+---
+description: Source-generate a registration of an open generic composition type closed over the type argument of every discovered implementation of another open generic interface, exposed as a non-generic facade -- source generation only.
+---
+
+# Compose and Expose Closed Generics
+
+`[RegisterClosedOverImplementationsOf]` lets you keep a **compose-and-expose** pattern on the source-generation path. For **each** discovered concrete closed implementation of a designated open generic interface, the generator closes a reusable composition type over the *same* type argument(s) and registers it as a designated facade service type — resolving the composition's constructor dependencies from DI. This is a **source-generation-only** feature.
+
+## Overview
+
+A common pattern is an open, growing set of typed "definitions" — each a small type implementing `IFooDefinition<TData>` — that you want to expose uniformly behind a non-generic facade `IFoo`, so the rest of the system can enumerate `IEnumerable<IFoo>` without knowing any `TData`. A reusable open generic `FooCore<TData>` *composes* a definition with other per-type services (no inheritance) and implements `IFoo`.
+
+Without this feature you either:
+
+- **Hand-maintain one registration per `TData`** — which silently drifts: add a definition and forget the matching line, and the new variant is simply absent at runtime with no compile-time signal; or
+- **Use runtime reflection** (`Assembly.GetTypes()` + `MakeGenericType` + `ActivatorUtilities`) — which is AOT/trimming hostile and against the source-generation-first design.
+
+With `[RegisterClosedOverImplementationsOf]`, you write the marker once and adding a new feature variant means **adding one definition** and nothing else.
+
+## Quick Start
+
+```csharp
+using NexusLabs.Needlr.Generators;
+
+// Auto-discovered today: concrete, closed, unattributed.
+public interface IFooDefinition<TData> where TData : class
+{
+    string Discriminator { get; }
+}
+
+public sealed class AlphaFoo : IFooDefinition<AlphaData> { public string Discriminator => "alpha"; }
+public sealed class BetaFoo  : IFooDefinition<BetaData>  { public string Discriminator => "beta";  }
+
+// Non-generic facade consumed as IEnumerable<IFoo>.
+public interface IFoo { string Discriminator { get; } }
+
+// Reusable composition, closed per discovered TData and exposed as IFoo.
+[RegisterClosedOverImplementationsOf(typeof(IFooDefinition<>), As = typeof(IFoo))]
+public sealed class FooCore<TData> : IFoo where TData : class
+{
+    public FooCore(IFooDefinition<TData> definition, IFooStore<TData> store) { /* ... */ }
+    public string Discriminator => /* delegates to definition */ "";
+}
+```
+
+## What Gets Generated
+
+At compile time, Needlr discovers every concrete closed implementation of `IFooDefinition<>` and emits one registration per discovered type argument, resolving each constructor dependency closed over the same `TData`:
+
+```csharp
+// Generated code (simplified)
+services.AddSingleton<IFoo>(sp => new FooCore<AlphaData>(
+    sp.GetRequiredService<IFooDefinition<AlphaData>>(),
+    sp.GetRequiredService<IFooStore<AlphaData>>()));
+
+services.AddSingleton<IFoo>(sp => new FooCore<BetaData>(
+    sp.GetRequiredService<IFooDefinition<BetaData>>(),
+    sp.GetRequiredService<IFooStore<BetaData>>()));
+```
+
+The generator reads the composition's constructor and resolves **whatever** it asks for — it does not need to know about stores, loggers, or any specific dependency. `[FromKeyedServices("key")]` constructor parameters are resolved as keyed services.
+
+## Lifetime
+
+Each registration defaults to `Singleton`. Use the `Lifetime` property to change it:
+
+```csharp
+[RegisterClosedOverImplementationsOf(typeof(IFooDefinition<>), As = typeof(IFoo), Lifetime = InjectableLifetime.Scoped)]
+public sealed class FooCore<TData> : IFoo where TData : class { /* ... */ }
+```
+
+## Multi-Parameter Generics
+
+The marker takes the unbound `typeof(IFooDefinition<>)`, and the composition is closed over the discovered type argument(s) as a list. Interfaces with multiple type parameters work the same way, provided the composition's arity matches:
+
+```csharp
+public interface IPairDefinition<TKey, TValue> where TKey : class where TValue : class { }
+
+[RegisterClosedOverImplementationsOf(typeof(IPairDefinition<,>), As = typeof(IPair))]
+public sealed class PairCore<TKey, TValue> : IPair
+    where TKey : class where TValue : class
+{
+    public PairCore(IPairDefinition<TKey, TValue> definition) { /* ... */ }
+}
+```
+
+## Constraint Validation
+
+If a discovered type argument does not satisfy the composition type's generic constraints, the registration is **skipped** and the generator reports [NDLRGEN038](analyzers/NDLRGEN038.md) at build time — turning a would-be runtime absence into a build-time signal.
+
+This diagnostic is only *reachable* when the composition's constraints are **stricter** than the source interface's. If both carry the same constraint (e.g. `where TData : class`), every discovered implementation can always close the composition, so the diagnostic acts as a safety net for future divergence rather than something you hit day one.
+
+## What This Does and Does Not Catch
+
+The feature eliminates the **"I added a definition and forgot to wire it"** drift entirely: valid definitions auto-wire.
+
+It does **not** make the whole dependency graph statically provable. Transitive dependencies that the closed composition needs — such as an open-generic store registered in a plugin, or `ILogger<>` from `AddLogging` — are not visible to the source generator. If such a dependency is missing, resolution still throws at runtime (the same behavior as a hand-written factory). There is no regression; the failure simply remains a runtime one.
+
+## Cross-Assembly Discovery
+
+A composition closes over **exactly the set of definitions the generator registers** — the current assembly plus any referenced **plain class libraries** (libraries without their own `[GenerateTypeRegistry]`). This is the same set `[OpenDecoratorFor]` expands over, so cross-assembly definitions in plain libraries are handled with no extra work.
+
+The one boundary is Needlr's universal multi-assembly model: a referenced assembly that carries its **own** `[GenerateTypeRegistry]` self-registers its types (and is force-loaded by the consumer), so the consuming assembly's generator does not re-scan it. A marker in assembly **A** therefore does not reach definitions inside a self-registering referenced assembly **B** — **B** owns its own registration and can carry its own marker. Keep the marker in the same assembly as its definitions, or expose the definitions from a plain library, and discovery spans assemblies transparently.
+
+## Comparison with `[OpenDecoratorFor]`
+
+| Feature | `[OpenDecoratorFor]` | `[RegisterClosedOverImplementationsOf]` |
+|---------|----------------------|------------------------------------------|
+| Closes an open generic per discovered implementation | ✅ | ✅ |
+| Registered service type | the **same** closed interface (wraps the inner) | a **different** facade named by `As` |
+| Reads the closed type's constructor | ❌ (uses `AddDecorator`) | ✅ (emits `new T(...)` with DI resolution) |
+| Intent | decorate / wrap | compose and expose behind a facade |
+| Works with source-gen | ✅ | ✅ |
+| Attribute location | `NexusLabs.Needlr.Generators` | `NexusLabs.Needlr.Generators` |
+
+## Attribute Reference
+
+| Member | Type | Default | Description |
+|--------|------|---------|-------------|
+| `SourceOpenGenericInterface` (ctor) | `Type` | — | The open generic interface whose concrete closed implementations drive registration, e.g. `typeof(IFooDefinition<>)`. |
+| `As` | `Type?` | `null` | The facade service type each closed composition is registered as. Must be implemented by the composition class. |
+| `Lifetime` | `InjectableLifetime` | `Singleton` | The lifetime each closed registration is given. |
+
+`AllowMultiple = true`: a single composition type may carry several markers (e.g. exposing itself over multiple source interfaces or facades).
+
+## Validation
+
+Needlr provides compile-time analyzers to catch configuration errors:
+
+| Diagnostic | Description |
+|------------|-------------|
+| [NDLRGEN035](analyzers/NDLRGEN035.md) | Source type must be an open generic interface |
+| [NDLRGEN036](analyzers/NDLRGEN036.md) | Composition class must be an open generic with matching arity |
+| [NDLRGEN037](analyzers/NDLRGEN037.md) | Composition class must specify and implement the `As` service type |
+| [NDLRGEN038](analyzers/NDLRGEN038.md) | A discovered type argument violates the composition's constraints (registration skipped) |
+
+## Namespace Import
+
+The `[RegisterClosedOverImplementationsOf]` attribute is in the `NexusLabs.Needlr.Generators` namespace:
+
+```csharp
+using NexusLabs.Needlr.Generators;
+```
+
+This is intentional — it signals that the feature is source-generation-only.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -396,6 +396,7 @@ var webApplication = new Syringe()
 - Explore [Plugin Development](plugin-development.md) to extend functionality
 - Discover [Factory Delegates](factories.md) for types with runtime parameters
 - Read about [Interceptors](interceptors.md) for cross-cutting concerns
+- Compose typed plugins behind a uniform facade with [Compose and Expose Closed Generics](composed-closed-generics.md)
 - See [Advanced Usage](advanced-usage.md) for complex scenarios
 - Track agent execution in real-time with [Progress Reporting](progress-reporting.md)
 - Run multi-step agentic workloads with O(n) token cost via [Iterative Agent Loop](iterative-agent-loop.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,6 +70,7 @@ nav:
     - Tiered Provider Selector: tiered-provider-selector.md
     - Interceptors: interceptors.md
     - Open Generic Decorators: open-generic-decorators.md
+    - Compose and Expose Closed Generics: composed-closed-generics.md
     - Cancellation-Aware Logging: cancellation-aware-logging.md
     - Service Catalog: service-catalog.md
     - Breadcrumbs: breadcrumbs.md
@@ -134,6 +135,10 @@ nav:
       - NDLRGEN032: analyzers/NDLRGEN032.md
       - NDLRGEN033: analyzers/NDLRGEN033.md
       - NDLRGEN034: analyzers/NDLRGEN034.md
+      - NDLRGEN035: analyzers/NDLRGEN035.md
+      - NDLRGEN036: analyzers/NDLRGEN036.md
+      - NDLRGEN037: analyzers/NDLRGEN037.md
+      - NDLRGEN038: analyzers/NDLRGEN038.md
     - MAF Analyzers:
       - NDLRMAF001: analyzers/NDLRMAF001.md
       - NDLRMAF002: analyzers/NDLRMAF002.md

--- a/src/Examples/SourceGen/AotSourceGenConsoleApp/Program.cs
+++ b/src/Examples/SourceGen/AotSourceGenConsoleApp/Program.cs
@@ -283,3 +283,24 @@ Console.WriteLine($"Concrete type: {fileService.GetType().Name}");
 Console.WriteLine($"Via concrete - Read: {fileService.ReadFile("/data/users.json")}");
 fileService.WriteFile("/logs/app.log", "Application started");
 Console.WriteLine();
+
+// ─────────────────────────────────────────────────────────────────────────────
+// COMPOSE-AND-EXPOSE DEMO ([RegisterClosedOverImplementationsOf])
+// ─────────────────────────────────────────────────────────────────────────────
+Console.WriteLine("═══════════════════════════════════════════════════════════════════════════════");
+Console.WriteLine("COMPOSE-AND-EXPOSE DEMO");
+Console.WriteLine("═══════════════════════════════════════════════════════════════════════════════");
+Console.WriteLine();
+
+// BlockTypeCore<TData> carries [RegisterClosedOverImplementationsOf(typeof(IBlockTypeDefinition<>), As = typeof(IBlockType))].
+// The generator discovered every IBlockTypeDefinition<> implementation and registered one closed
+// BlockTypeCore<TData> per definition as IBlockType. Adding a new definition auto-wires here with no
+// extra registration — the host just enumerates IEnumerable<IBlockType>.
+Console.WriteLine("── Each discovered block definition is composed behind IBlockType ──");
+var blockTypes = provider.GetServices<IBlockType>().ToList();
+Console.WriteLine($"IBlockType registrations: {blockTypes.Count}");
+foreach (var blockType in blockTypes.OrderBy(b => b.Discriminator))
+{
+    Console.WriteLine($"  {blockType.Discriminator,-6} → {blockType.GetType().Name}");
+}
+Console.WriteLine();

--- a/src/Examples/SourceGen/AotSourceGenConsolePlugin/PluginTypes.cs
+++ b/src/Examples/SourceGen/AotSourceGenConsolePlugin/PluginTypes.cs
@@ -518,3 +518,91 @@ public sealed class FileService : IFileReader, IFileWriter, IFileDeleter
     public void DeleteFile(string path) 
         => Console.WriteLine($"[{_timeProvider.GetNow():HH:mm:ss}] Deleted '{path}'");
 }
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// COMPOSE-AND-EXPOSE DEMO ([RegisterClosedOverImplementationsOf])
+// ═══════════════════════════════════════════════════════════════════════════════
+//
+// Each "block type" is a pure definition implementing IBlockTypeDefinition<TData> and is
+// auto-discovered by Needlr. A single reusable open generic BlockTypeCore<TData> composes a
+// definition with a per-type store and is exposed as the non-generic facade IBlockType. The
+// [RegisterClosedOverImplementationsOf] marker makes the generator register one closed
+// BlockTypeCore<TData> per discovered definition — adding a new block type means adding ONE
+// definition, with no per-type wiring to keep in sync.
+
+/// <summary>A typed block definition. Concrete implementations are auto-discovered.</summary>
+public interface IBlockTypeDefinition<TData>
+    where TData : class
+{
+    string Discriminator { get; }
+}
+
+/// <summary>Per-type instance store, registered as an open generic by <see cref="BlockTypesPlugin"/>.</summary>
+public interface IBlockInstanceStore<TData>
+    where TData : class
+{
+    int Count { get; }
+}
+
+/// <summary>Default open-generic store implementation.</summary>
+public sealed class DefaultBlockInstanceStore<TData> : IBlockInstanceStore<TData>
+    where TData : class
+{
+    public int Count => 0;
+}
+
+/// <summary>Non-generic facade the host consumes as IEnumerable&lt;IBlockType&gt;.</summary>
+public interface IBlockType
+{
+    string Discriminator { get; }
+}
+
+/// <summary>Block payload shapes (pure data).</summary>
+public sealed class VideoBlockData;
+
+/// <summary>Block payload shapes (pure data).</summary>
+public sealed class LeadBlockData;
+
+/// <summary>A block definition — concrete, unattributed, auto-registered as IBlockTypeDefinition&lt;VideoBlockData&gt;.</summary>
+public sealed class VideoBlockDefinition : IBlockTypeDefinition<VideoBlockData>
+{
+    public string Discriminator => "video";
+}
+
+/// <summary>A block definition — concrete, unattributed, auto-registered as IBlockTypeDefinition&lt;LeadBlockData&gt;.</summary>
+public sealed class LeadBlockDefinition : IBlockTypeDefinition<LeadBlockData>
+{
+    public string Discriminator => "lead";
+}
+
+/// <summary>
+/// Reusable composition closed per discovered TData and exposed as IBlockType. Composed (no inheritance)
+/// from a definition and a per-type store. The generator emits one IBlockType registration per discovered
+/// IBlockTypeDefinition&lt;&gt; implementation, resolving the constructor dependencies from DI.
+/// </summary>
+[RegisterClosedOverImplementationsOf(typeof(IBlockTypeDefinition<>), As = typeof(IBlockType))]
+public sealed class BlockTypeCore<TData> : IBlockType
+    where TData : class
+{
+    private readonly IBlockTypeDefinition<TData> _definition;
+
+    public BlockTypeCore(IBlockTypeDefinition<TData> definition, IBlockInstanceStore<TData> store)
+    {
+        _definition = definition;
+        _ = store;
+    }
+
+    public string Discriminator => _definition.Discriminator;
+}
+
+/// <summary>
+/// Registers only the open-generic store. The per-type IBlockType registrations are emitted by the
+/// generator from the [RegisterClosedOverImplementationsOf] marker — there is no per-type list here.
+/// </summary>
+internal sealed class BlockTypesPlugin : IServiceCollectionPlugin
+{
+    public void Configure(ServiceCollectionPluginOptions options)
+    {
+        options.Services.AddSingleton(typeof(IBlockInstanceStore<>), typeof(DefaultBlockInstanceStore<>));
+    }
+}

--- a/src/NexusLabs.Needlr.Generators.Attributes/RegisterClosedOverImplementationsOfAttribute.cs
+++ b/src/NexusLabs.Needlr.Generators.Attributes/RegisterClosedOverImplementationsOfAttribute.cs
@@ -1,0 +1,96 @@
+using System;
+
+namespace NexusLabs.Needlr.Generators;
+
+/// <summary>
+/// Marks an open generic <em>composition</em> class so that the source generator registers a closed
+/// instance of it for <strong>each</strong> discovered concrete implementation of a designated
+/// open generic interface, exposed as a designated non-generic (or less-generic) facade service type.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is a source-generation only feature. It requires the <c>NexusLabs.Needlr.Generators</c>
+/// package and has no effect when using reflection-based registration.
+/// </para>
+/// <para>
+/// Use this attribute to keep a "compose-and-expose" pattern on the source-generation path instead of
+/// hand-maintaining one registration line per type argument (which silently drifts) or falling back to
+/// runtime reflection (which is AOT/trimming hostile). For every concrete closed implementation of the
+/// designated open generic interface that the generator discovers, it closes this composition class over
+/// the <em>same</em> type argument(s) and registers it as the service type named by <see cref="As"/>,
+/// resolving the composition's constructor dependencies from the service provider.
+/// </para>
+/// <para>
+/// The annotated class must:
+/// <list type="bullet">
+/// <item><description>Be an open generic class whose type-parameter arity matches the open generic interface.</description></item>
+/// <item><description>Implement the service type specified by <see cref="As"/>.</description></item>
+/// <item><description>Have a single public constructor whose parameters are all resolvable from the service provider.</description></item>
+/// </list>
+/// </para>
+/// <para>
+/// A discovered type argument that does not satisfy the composition class's generic constraints is
+/// skipped with a build diagnostic (<c>NDLRGEN038</c>) rather than producing a runtime failure.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// // Auto-discovered today: concrete, closed, unattributed.
+/// public interface IFooDefinition&lt;TData&gt; where TData : class
+/// {
+///     string Discriminator { get; }
+/// }
+///
+/// public sealed class AlphaFoo : IFooDefinition&lt;AlphaData&gt; { /* ... */ }
+/// public sealed class BetaFoo  : IFooDefinition&lt;BetaData&gt;  { /* ... */ }
+///
+/// // Non-generic facade consumed as IEnumerable&lt;IFoo&gt;.
+/// public interface IFoo { string Discriminator { get; } }
+///
+/// // Reusable composition closed per discovered TData and exposed as IFoo.
+/// [RegisterClosedOverImplementationsOf(typeof(IFooDefinition&lt;&gt;), As = typeof(IFoo))]
+/// public sealed class FooCore&lt;TData&gt; : IFoo where TData : class
+/// {
+///     public FooCore(IFooDefinition&lt;TData&gt; definition, IFooStore&lt;TData&gt; store) { /* ... */ }
+///     public string Discriminator =&gt; /* delegates to definition */ "";
+/// }
+///
+/// // Generator emits, per discovered implementation:
+/// // services.AddSingleton&lt;IFoo&gt;(sp =&gt; new FooCore&lt;AlphaData&gt;(
+/// //     sp.GetRequiredService&lt;IFooDefinition&lt;AlphaData&gt;&gt;(),
+/// //     sp.GetRequiredService&lt;IFooStore&lt;AlphaData&gt;&gt;()));
+/// // services.AddSingleton&lt;IFoo&gt;(sp =&gt; new FooCore&lt;BetaData&gt;( ... ));
+/// </code>
+/// </example>
+[AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = true)]
+public sealed class RegisterClosedOverImplementationsOfAttribute : Attribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RegisterClosedOverImplementationsOfAttribute"/> class.
+    /// </summary>
+    /// <param name="sourceOpenGenericInterface">
+    /// The open generic interface whose concrete closed implementations drive registration
+    /// (e.g., <c>typeof(IFooDefinition&lt;&gt;)</c>). Must be an open generic interface.
+    /// </param>
+    public RegisterClosedOverImplementationsOfAttribute(Type sourceOpenGenericInterface)
+    {
+        SourceOpenGenericInterface = sourceOpenGenericInterface;
+    }
+
+    /// <summary>
+    /// Gets the open generic interface whose concrete closed implementations drive registration.
+    /// </summary>
+    public Type SourceOpenGenericInterface { get; }
+
+    /// <summary>
+    /// Gets or sets the service type that each closed composition is registered as
+    /// (e.g., <c>typeof(IFoo)</c>). Must be a type implemented by the annotated composition class.
+    /// </summary>
+    public Type? As { get; set; }
+
+    /// <summary>
+    /// Gets or sets the lifetime each closed composition registration is given.
+    /// Defaults to <see cref="InjectableLifetime.Singleton"/>.
+    /// </summary>
+    public InjectableLifetime Lifetime { get; set; } = InjectableLifetime.Singleton;
+}

--- a/src/NexusLabs.Needlr.Generators.Tests/GeneratorTestRunner.cs
+++ b/src/NexusLabs.Needlr.Generators.Tests/GeneratorTestRunner.cs
@@ -741,6 +741,54 @@ public sealed class GeneratorTestRunner
     }
 
     /// <summary>
+    /// Inline attribute definitions for [RegisterClosedOverImplementationsOf] composition tests.
+    /// </summary>
+    public const string InlineComposedDefinitions = """
+        namespace NexusLabs.Needlr
+        {
+            [System.AttributeUsage(System.AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
+            public sealed class DoNotAutoRegisterAttribute : System.Attribute { }
+
+            [System.AttributeUsage(System.AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
+            public sealed class SingletonAttribute : System.Attribute { }
+        }
+
+        namespace NexusLabs.Needlr.Generators
+        {
+            [System.AttributeUsage(System.AttributeTargets.Assembly)]
+            public sealed class GenerateTypeRegistryAttribute : System.Attribute
+            {
+                public string[]? IncludeNamespacePrefixes { get; set; }
+                public bool IncludeSelf { get; set; } = true;
+            }
+
+            public enum InjectableLifetime { Singleton = 0, Scoped = 1, Transient = 2 }
+
+            [System.AttributeUsage(System.AttributeTargets.Class, Inherited = false, AllowMultiple = true)]
+            public sealed class RegisterClosedOverImplementationsOfAttribute : System.Attribute
+            {
+                public RegisterClosedOverImplementationsOfAttribute(System.Type sourceOpenGenericInterface)
+                {
+                    SourceOpenGenericInterface = sourceOpenGenericInterface;
+                }
+
+                public System.Type SourceOpenGenericInterface { get; }
+                public System.Type? As { get; set; }
+                public InjectableLifetime Lifetime { get; set; } = InjectableLifetime.Singleton;
+            }
+        }
+        """;
+
+    /// <summary>
+    /// Creates a runner for composition (RegisterClosedOverImplementationsOf) tests with inline type definitions.
+    /// </summary>
+    public static GeneratorTestRunner ForComposedWithInlineTypes()
+    {
+        return new GeneratorTestRunner()
+            .WithSource(InlineComposedDefinitions);
+    }
+
+    /// <summary>
     /// Creates a runner for interceptor tests with inline type definitions.
     /// </summary>
     public static GeneratorTestRunner ForInterceptorWithInlineTypes()

--- a/src/NexusLabs.Needlr.Generators.Tests/NeedlrTestAttributes.cs
+++ b/src/NexusLabs.Needlr.Generators.Tests/NeedlrTestAttributes.cs
@@ -219,6 +219,28 @@ namespace NexusLabs.Needlr.Generators
 }";
 
     /// <summary>
+    /// Open generic composition attribute (source-gen only).
+    /// </summary>
+    public const string ComposedRegistration = @"
+namespace NexusLabs.Needlr.Generators
+{
+    public enum InjectableLifetime { Singleton = 0, Scoped = 1, Transient = 2 }
+
+    [System.AttributeUsage(System.AttributeTargets.Class, Inherited = false, AllowMultiple = true)]
+    public sealed class RegisterClosedOverImplementationsOfAttribute : System.Attribute
+    {
+        public RegisterClosedOverImplementationsOfAttribute(System.Type sourceOpenGenericInterface)
+        {
+            SourceOpenGenericInterface = sourceOpenGenericInterface;
+        }
+
+        public System.Type SourceOpenGenericInterface { get; }
+        public System.Type As { get; set; }
+        public InjectableLifetime Lifetime { get; set; } = InjectableLifetime.Singleton;
+    }
+}";
+
+    /// <summary>
     /// Core attributes plus interceptors (for interceptor tests).
     /// </summary>
     public const string CoreWithInterceptors = Core + Interceptors;
@@ -242,4 +264,9 @@ namespace NexusLabs.Needlr.Generators
     /// All attributes including provider (Core + Interceptors + Decorators + Provider).
     /// </summary>
     public const string AllWithProvider = Core + Interceptors + Decorators + Provider;
+
+    /// <summary>
+    /// All attributes including composition (Core + Interceptors + Decorators + ComposedRegistration).
+    /// </summary>
+    public const string AllWithComposed = Core + Interceptors + Decorators + ComposedRegistration;
 }

--- a/src/NexusLabs.Needlr.Generators.Tests/RegisterClosedOverImplementationsOfAttributeAnalyzerTests.cs
+++ b/src/NexusLabs.Needlr.Generators.Tests/RegisterClosedOverImplementationsOfAttributeAnalyzerTests.cs
@@ -1,0 +1,263 @@
+using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+
+using Xunit;
+
+namespace NexusLabs.Needlr.Generators.Tests;
+
+/// <summary>
+/// Tests for RegisterClosedOverImplementationsOfAttributeAnalyzer diagnostics:
+/// - NDLRGEN035: Source type must be an open generic interface
+/// - NDLRGEN036: Composition must be an open generic class with matching arity
+/// - NDLRGEN037: Composition must implement the As service type
+/// </summary>
+public sealed class RegisterClosedOverImplementationsOfAttributeAnalyzerTests
+{
+    private static string Attributes => NeedlrTestAttributes.AllWithComposed;
+
+    [Fact]
+    public async Task Error_WhenSourceTypeIsNotGeneric()
+    {
+        var code = @"
+using NexusLabs.Needlr.Generators;
+
+public interface IService { }
+public interface IFacade { }
+
+[{|#0:RegisterClosedOverImplementationsOf(typeof(IService), As = typeof(IFacade))|}]
+public class Composition<T> : IFacade
+{
+}
+" + Attributes;
+
+        var test = new CSharpAnalyzerTest<RegisterClosedOverImplementationsOfAttributeAnalyzer, DefaultVerifier>
+        {
+            TestCode = code,
+            ExpectedDiagnostics =
+            {
+                new DiagnosticResult("NDLRGEN035", Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
+                    .WithLocation(0)
+                    .WithArguments("IService", "non-generic interface")
+            }
+        };
+
+        await test.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Error_WhenSourceTypeIsClass()
+    {
+        var code = @"
+using NexusLabs.Needlr.Generators;
+
+public class SomeClass<T> { }
+public interface IFacade { }
+
+[{|#0:RegisterClosedOverImplementationsOf(typeof(SomeClass<>), As = typeof(IFacade))|}]
+public class Composition<T> : IFacade
+{
+}
+" + Attributes;
+
+        var test = new CSharpAnalyzerTest<RegisterClosedOverImplementationsOfAttributeAnalyzer, DefaultVerifier>
+        {
+            TestCode = code,
+            ExpectedDiagnostics =
+            {
+                new DiagnosticResult("NDLRGEN035", Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
+                    .WithLocation(0)
+                    .WithArguments("SomeClass<>", "Class (not an interface)")
+            }
+        };
+
+        await test.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task NoError_WhenSourceIsOpenGenericInterface()
+    {
+        var code = @"
+using NexusLabs.Needlr.Generators;
+
+public interface IDefinition<T> { }
+public interface IFacade { }
+
+[RegisterClosedOverImplementationsOf(typeof(IDefinition<>), As = typeof(IFacade))]
+public class Composition<T> : IFacade
+{
+}
+" + Attributes;
+
+        var test = new CSharpAnalyzerTest<RegisterClosedOverImplementationsOfAttributeAnalyzer, DefaultVerifier>
+        {
+            TestCode = code
+        };
+
+        await test.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Error_WhenCompositionIsNotGeneric()
+    {
+        var code = @"
+using NexusLabs.Needlr.Generators;
+
+public interface IDefinition<T> { }
+public interface IFacade { }
+
+[{|#0:RegisterClosedOverImplementationsOf(typeof(IDefinition<>), As = typeof(IFacade))|}]
+public class Composition : IFacade
+{
+}
+" + Attributes;
+
+        var test = new CSharpAnalyzerTest<RegisterClosedOverImplementationsOfAttributeAnalyzer, DefaultVerifier>
+        {
+            TestCode = code,
+            ExpectedDiagnostics =
+            {
+                new DiagnosticResult("NDLRGEN036", Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
+                    .WithLocation(0)
+                    .WithArguments("Composition", "IDefinition<>", 1)
+            }
+        };
+
+        await test.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Error_WhenArityDoesNotMatch()
+    {
+        var code = @"
+using NexusLabs.Needlr.Generators;
+
+public interface IDefinition<TKey, TValue> { }
+public interface IFacade { }
+
+[{|#0:RegisterClosedOverImplementationsOf(typeof(IDefinition<,>), As = typeof(IFacade))|}]
+public class Composition<T> : IFacade
+{
+}
+" + Attributes;
+
+        var test = new CSharpAnalyzerTest<RegisterClosedOverImplementationsOfAttributeAnalyzer, DefaultVerifier>
+        {
+            TestCode = code,
+            ExpectedDiagnostics =
+            {
+                new DiagnosticResult("NDLRGEN036", Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
+                    .WithLocation(0)
+                    .WithArguments("Composition", "IDefinition<,>", 2)
+            }
+        };
+
+        await test.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task NoError_WhenArityMatches()
+    {
+        var code = @"
+using NexusLabs.Needlr.Generators;
+
+public interface IDefinition<TKey, TValue> { }
+public interface IFacade { }
+
+[RegisterClosedOverImplementationsOf(typeof(IDefinition<,>), As = typeof(IFacade))]
+public class Composition<TKey, TValue> : IFacade
+{
+}
+" + Attributes;
+
+        var test = new CSharpAnalyzerTest<RegisterClosedOverImplementationsOfAttributeAnalyzer, DefaultVerifier>
+        {
+            TestCode = code
+        };
+
+        await test.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Error_WhenCompositionDoesNotImplementAs()
+    {
+        var code = @"
+using NexusLabs.Needlr.Generators;
+
+public interface IDefinition<T> { }
+public interface IFacade { }
+public interface IOther { }
+
+[{|#0:RegisterClosedOverImplementationsOf(typeof(IDefinition<>), As = typeof(IFacade))|}]
+public class Composition<T> : IOther
+{
+}
+" + Attributes;
+
+        var test = new CSharpAnalyzerTest<RegisterClosedOverImplementationsOfAttributeAnalyzer, DefaultVerifier>
+        {
+            TestCode = code,
+            ExpectedDiagnostics =
+            {
+                new DiagnosticResult("NDLRGEN037", Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
+                    .WithLocation(0)
+                    .WithArguments("Composition")
+            }
+        };
+
+        await test.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Error_WhenAsNotSpecified()
+    {
+        var code = @"
+using NexusLabs.Needlr.Generators;
+
+public interface IDefinition<T> { }
+public interface IFacade { }
+
+[{|#0:RegisterClosedOverImplementationsOf(typeof(IDefinition<>))|}]
+public class Composition<T> : IFacade
+{
+}
+" + Attributes;
+
+        var test = new CSharpAnalyzerTest<RegisterClosedOverImplementationsOfAttributeAnalyzer, DefaultVerifier>
+        {
+            TestCode = code,
+            ExpectedDiagnostics =
+            {
+                new DiagnosticResult("NDLRGEN037", Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
+                    .WithLocation(0)
+                    .WithArguments("Composition")
+            }
+        };
+
+        await test.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task NoError_WhenValid()
+    {
+        var code = @"
+using NexusLabs.Needlr.Generators;
+
+public interface IDefinition<T> { }
+public interface IFacade { }
+
+[RegisterClosedOverImplementationsOf(typeof(IDefinition<>), As = typeof(IFacade))]
+public class Composition<T> : IFacade
+{
+}
+" + Attributes;
+
+        var test = new CSharpAnalyzerTest<RegisterClosedOverImplementationsOfAttributeAnalyzer, DefaultVerifier>
+        {
+            TestCode = code
+        };
+
+        await test.RunAsync(TestContext.Current.CancellationToken);
+    }
+}

--- a/src/NexusLabs.Needlr.Generators.Tests/RegisterClosedOverImplementationsOfGeneratorTests.cs
+++ b/src/NexusLabs.Needlr.Generators.Tests/RegisterClosedOverImplementationsOfGeneratorTests.cs
@@ -420,4 +420,45 @@ public sealed class RegisterClosedOverImplementationsOfGeneratorTests
         Assert.Equal(1, registrationCount);
         Assert.Contains(diagnostics, d => d.Id == "NDLRGEN038");
     }
+
+    [Fact]
+    public void Composition_CovariantConstraintSatisfiedByVariance_IsNotFalseSkipped()
+    {
+        // Regression guard: a fixed covariant generic constraint must NOT skip a type that satisfies it via
+        // variance. DogProducer : IProducer<Dog> satisfies `where TData : IProducer<Animal>` because
+        // IProducer is covariant, so the registration must be emitted with no NDLRGEN038.
+        var source = """
+            using NexusLabs.Needlr.Generators;
+
+            [assembly: GenerateTypeRegistry(IncludeNamespacePrefixes = new[] { "TestNamespace" })]
+
+            namespace TestNamespace
+            {
+                public interface IProducer<out T> { }
+                public class Animal { }
+                public sealed class Dog : Animal { }
+                public sealed class DogProducer : IProducer<Dog> { }
+
+                public interface IVarDefinition<TData> { }
+                public sealed class VarHolder : IVarDefinition<DogProducer> { }
+                public interface IVar { }
+
+                [RegisterClosedOverImplementationsOf(typeof(IVarDefinition<>), As = typeof(IVar))]
+                public sealed class VarCore<TData> : IVar where TData : IProducer<Animal>
+                {
+                    public VarCore(IVarDefinition<TData> definition) { }
+                }
+            }
+            """;
+
+        var generatedCode = GeneratorTestRunner.ForComposedWithInlineTypes()
+            .WithSource(source)
+            .RunTypeRegistryGenerator();
+        var diagnostics = GeneratorTestRunner.ForComposedWithInlineTypes()
+            .WithSource(source)
+            .RunTypeRegistryGeneratorDiagnostics();
+
+        Assert.Contains("new global::TestNamespace.VarCore<global::TestNamespace.DogProducer>", generatedCode);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "NDLRGEN038");
+    }
 }

--- a/src/NexusLabs.Needlr.Generators.Tests/RegisterClosedOverImplementationsOfGeneratorTests.cs
+++ b/src/NexusLabs.Needlr.Generators.Tests/RegisterClosedOverImplementationsOfGeneratorTests.cs
@@ -1,0 +1,384 @@
+using Xunit;
+
+namespace NexusLabs.Needlr.Generators.Tests;
+
+/// <summary>
+/// Tests that verify the source generator correctly handles [RegisterClosedOverImplementationsOf]
+/// attributes. For each discovered concrete closed implementation of the designated open generic
+/// interface, the generator closes the annotated composition type over the same type argument(s)
+/// and registers it as the designated facade service type, resolving constructor dependencies from DI.
+/// </summary>
+public sealed class RegisterClosedOverImplementationsOfGeneratorTests
+{
+    private const string Shapes = """
+        namespace TestNamespace
+        {
+            public interface IFooDefinition<TData> where TData : class
+            {
+                string Discriminator { get; }
+            }
+
+            public interface IFooStore<TData> where TData : class { }
+
+            public interface IFoo { string Discriminator { get; } }
+
+            public sealed class AlphaData { }
+            public sealed class BetaData { }
+
+            public sealed class AlphaFoo : IFooDefinition<AlphaData> { public string Discriminator => "alpha"; }
+            public sealed class BetaFoo : IFooDefinition<BetaData> { public string Discriminator => "beta"; }
+        }
+        """;
+
+    [Fact]
+    public void Composition_SingleImplementation_GeneratesClosedRegistrationAsFacade()
+    {
+        var source = """
+            using NexusLabs.Needlr.Generators;
+
+            [assembly: GenerateTypeRegistry(IncludeNamespacePrefixes = new[] { "TestNamespace" })]
+
+            namespace TestNamespace
+            {
+                public interface IBarDefinition<TData> where TData : class { }
+                public interface IBar { }
+                public sealed class OnlyData { }
+                public sealed class OnlyBar : IBarDefinition<OnlyData> { }
+
+                [RegisterClosedOverImplementationsOf(typeof(IBarDefinition<>), As = typeof(IBar))]
+                public sealed class BarCore<TData> : IBar where TData : class
+                {
+                    public BarCore(IBarDefinition<TData> definition) { }
+                }
+            }
+            """;
+
+        var generatedCode = GeneratorTestRunner.ForComposedWithInlineTypes()
+            .WithSource(source)
+            .RunTypeRegistryGenerator();
+
+        Assert.Contains("AddSingleton<global::TestNamespace.IBar>", generatedCode);
+        Assert.Contains("new global::TestNamespace.BarCore<global::TestNamespace.OnlyData>", generatedCode);
+        Assert.Contains("GetRequiredService<global::TestNamespace.IBarDefinition<global::TestNamespace.OnlyData>>", generatedCode);
+    }
+
+    [Fact]
+    public void Composition_MultipleImplementations_GeneratesOnePerDiscoveredTypeArgument()
+    {
+        var source = """
+            using NexusLabs.Needlr.Generators;
+
+            [assembly: GenerateTypeRegistry(IncludeNamespacePrefixes = new[] { "TestNamespace" })]
+
+            namespace TestNamespace
+            {
+                [RegisterClosedOverImplementationsOf(typeof(IFooDefinition<>), As = typeof(IFoo))]
+                public sealed class FooCore<TData> : IFoo where TData : class
+                {
+                    public FooCore(IFooDefinition<TData> definition, IFooStore<TData> store) { }
+                    public string Discriminator => "";
+                }
+            }
+            """;
+
+        var generatedCode = GeneratorTestRunner.ForComposedWithInlineTypes()
+            .WithSource(source)
+            .WithSource(Shapes)
+            .RunTypeRegistryGenerator();
+
+        Assert.Contains("new global::TestNamespace.FooCore<global::TestNamespace.AlphaData>", generatedCode);
+        Assert.Contains("new global::TestNamespace.FooCore<global::TestNamespace.BetaData>", generatedCode);
+    }
+
+    [Fact]
+    public void Composition_ResolvesEveryConstructorDependencyClosedOverTypeArgument()
+    {
+        var source = """
+            using NexusLabs.Needlr.Generators;
+
+            [assembly: GenerateTypeRegistry(IncludeNamespacePrefixes = new[] { "TestNamespace" })]
+
+            namespace TestNamespace
+            {
+                [RegisterClosedOverImplementationsOf(typeof(IFooDefinition<>), As = typeof(IFoo))]
+                public sealed class FooCore<TData> : IFoo where TData : class
+                {
+                    public FooCore(IFooDefinition<TData> definition, IFooStore<TData> store) { }
+                    public string Discriminator => "";
+                }
+            }
+            """;
+
+        var generatedCode = GeneratorTestRunner.ForComposedWithInlineTypes()
+            .WithSource(source)
+            .WithSource(Shapes)
+            .RunTypeRegistryGenerator();
+
+        Assert.Contains("GetRequiredService<global::TestNamespace.IFooDefinition<global::TestNamespace.AlphaData>>", generatedCode);
+        Assert.Contains("GetRequiredService<global::TestNamespace.IFooStore<global::TestNamespace.AlphaData>>", generatedCode);
+    }
+
+    [Fact]
+    public void Composition_NoImplementations_GeneratesNoRegistrations()
+    {
+        var source = """
+            using NexusLabs.Needlr.Generators;
+
+            [assembly: GenerateTypeRegistry(IncludeNamespacePrefixes = new[] { "TestNamespace" })]
+
+            namespace TestNamespace
+            {
+                public interface IBazDefinition<TData> where TData : class { }
+                public interface IBaz { }
+
+                [RegisterClosedOverImplementationsOf(typeof(IBazDefinition<>), As = typeof(IBaz))]
+                public sealed class BazCore<TData> : IBaz where TData : class
+                {
+                    public BazCore(IBazDefinition<TData> definition) { }
+                }
+            }
+            """;
+
+        var generatedCode = GeneratorTestRunner.ForComposedWithInlineTypes()
+            .WithSource(source)
+            .RunTypeRegistryGenerator();
+
+        Assert.DoesNotContain("new global::TestNamespace.BazCore<", generatedCode);
+    }
+
+    [Fact]
+    public void Composition_LifetimeScoped_GeneratesScopedRegistration()
+    {
+        var source = """
+            using NexusLabs.Needlr.Generators;
+
+            [assembly: GenerateTypeRegistry(IncludeNamespacePrefixes = new[] { "TestNamespace" })]
+
+            namespace TestNamespace
+            {
+                [RegisterClosedOverImplementationsOf(typeof(IFooDefinition<>), As = typeof(IFoo), Lifetime = InjectableLifetime.Scoped)]
+                public sealed class FooCore<TData> : IFoo where TData : class
+                {
+                    public FooCore(IFooDefinition<TData> definition) { }
+                    public string Discriminator => "";
+                }
+            }
+            """;
+
+        var generatedCode = GeneratorTestRunner.ForComposedWithInlineTypes()
+            .WithSource(source)
+            .WithSource(Shapes)
+            .RunTypeRegistryGenerator();
+
+        Assert.Contains("AddScoped<global::TestNamespace.IFoo>", generatedCode);
+        Assert.DoesNotContain("AddSingleton<global::TestNamespace.IFoo>", generatedCode);
+    }
+
+    [Fact]
+    public void Composition_TwoTypeParameters_ClosesCompositionOverBothArguments()
+    {
+        var source = """
+            using NexusLabs.Needlr.Generators;
+
+            [assembly: GenerateTypeRegistry(IncludeNamespacePrefixes = new[] { "TestNamespace" })]
+
+            namespace TestNamespace
+            {
+                public interface IPairDefinition<TKey, TValue> where TKey : class where TValue : class { }
+                public interface IPair { }
+                public sealed class KeyData { }
+                public sealed class ValueData { }
+                public sealed class KvPair : IPairDefinition<KeyData, ValueData> { }
+
+                [RegisterClosedOverImplementationsOf(typeof(IPairDefinition<,>), As = typeof(IPair))]
+                public sealed class PairCore<TKey, TValue> : IPair
+                    where TKey : class where TValue : class
+                {
+                    public PairCore(IPairDefinition<TKey, TValue> definition) { }
+                }
+            }
+            """;
+
+        var generatedCode = GeneratorTestRunner.ForComposedWithInlineTypes()
+            .WithSource(source)
+            .RunTypeRegistryGenerator();
+
+        Assert.Contains("new global::TestNamespace.PairCore<global::TestNamespace.KeyData, global::TestNamespace.ValueData>", generatedCode);
+    }
+
+    [Fact]
+    public void Composition_TypeArgumentViolatesConstraint_ReportsDiagnosticAndSkips()
+    {
+        var source = """
+            using NexusLabs.Needlr.Generators;
+
+            [assembly: GenerateTypeRegistry(IncludeNamespacePrefixes = new[] { "TestNamespace" })]
+
+            namespace TestNamespace
+            {
+                public interface IQuxDefinition<TData> { }
+                public struct StructData { }
+                public sealed class StructQux : IQuxDefinition<StructData> { }
+                public interface IQux { }
+
+                [RegisterClosedOverImplementationsOf(typeof(IQuxDefinition<>), As = typeof(IQux))]
+                public sealed class QuxCore<TData> : IQux where TData : class
+                {
+                    public QuxCore(IQuxDefinition<TData> definition) { }
+                }
+            }
+            """;
+
+        var runner = GeneratorTestRunner.ForComposedWithInlineTypes()
+            .WithSource(source);
+
+        var generatedCode = runner.RunTypeRegistryGenerator();
+        var diagnostics = GeneratorTestRunner.ForComposedWithInlineTypes()
+            .WithSource(source)
+            .RunTypeRegistryGeneratorDiagnostics();
+
+        Assert.DoesNotContain("new global::TestNamespace.QuxCore<global::TestNamespace.StructData>", generatedCode);
+        Assert.Contains(diagnostics, d => d.Id == "NDLRGEN038");
+    }
+
+    [Fact]
+    public void Composition_KeyedConstructorDependency_ResolvesAsKeyedService()
+    {
+        var source = """
+            using NexusLabs.Needlr.Generators;
+
+            [assembly: GenerateTypeRegistry(IncludeNamespacePrefixes = new[] { "TestNamespace" })]
+
+            namespace Microsoft.Extensions.DependencyInjection
+            {
+                [System.AttributeUsage(System.AttributeTargets.Parameter)]
+                public sealed class FromKeyedServicesAttribute : System.Attribute
+                {
+                    public FromKeyedServicesAttribute(object key) { Key = key; }
+                    public object Key { get; }
+                }
+            }
+
+            namespace TestNamespace
+            {
+                [RegisterClosedOverImplementationsOf(typeof(IFooDefinition<>), As = typeof(IFoo))]
+                public sealed class FooCore<TData> : IFoo where TData : class
+                {
+                    public FooCore(
+                        IFooDefinition<TData> definition,
+                        [Microsoft.Extensions.DependencyInjection.FromKeyedServices("primary")] IFooStore<TData> store) { }
+                    public string Discriminator => "";
+                }
+            }
+            """;
+
+        var generatedCode = GeneratorTestRunner.ForComposedWithInlineTypes()
+            .WithSource(source)
+            .WithSource(Shapes)
+            .RunTypeRegistryGenerator();
+
+        Assert.Contains("GetRequiredKeyedService<global::TestNamespace.IFooStore<global::TestNamespace.AlphaData>>(\"primary\")", generatedCode);
+        Assert.Contains("GetRequiredService<global::TestNamespace.IFooDefinition<global::TestNamespace.AlphaData>>", generatedCode);
+    }
+
+    [Fact]
+    public void Composition_DefinitionInReferencedAssembly_IsComposedOver()
+    {
+        // A definition living in a referenced library (no [GenerateTypeRegistry]) is auto-registered by the
+        // current assembly, so the composition must also close over it — same set decorators expand over.
+        var externalSource = """
+            namespace ExternalLib
+            {
+                public interface IExtDefinition<TData> where TData : class { }
+                public interface IExt { }
+                public sealed class ExtData { }
+                public sealed class ExtDefinition : IExtDefinition<ExtData> { }
+            }
+            """;
+
+        var mainSource = """
+            using NexusLabs.Needlr.Generators;
+            using ExternalLib;
+
+            [assembly: GenerateTypeRegistry(IncludeNamespacePrefixes = new[] { "TestNamespace", "ExternalLib" })]
+
+            namespace TestNamespace
+            {
+                [RegisterClosedOverImplementationsOf(typeof(IExtDefinition<>), As = typeof(IExt))]
+                public sealed class ExtCore<TData> : IExt where TData : class
+                {
+                    public ExtCore(IExtDefinition<TData> definition) { }
+                }
+            }
+            """;
+
+        var generatedCode = GeneratorTestRunner.ForComposedWithInlineTypes()
+            .WithCrossAssemblySource("ExternalLib", externalSource)
+            .WithSource(mainSource)
+            .RunTypeRegistryGenerator();
+
+        Assert.Contains("new global::TestNamespace.ExtCore<global::ExternalLib.ExtData>", generatedCode);
+        Assert.Contains("GetRequiredService<global::ExternalLib.IExtDefinition<global::ExternalLib.ExtData>>", generatedCode);
+    }
+
+    [Fact]
+    public void Composition_LifetimeTransient_GeneratesTransientRegistration()
+    {
+        var source = """
+            using NexusLabs.Needlr.Generators;
+
+            [assembly: GenerateTypeRegistry(IncludeNamespacePrefixes = new[] { "TestNamespace" })]
+
+            namespace TestNamespace
+            {
+                [RegisterClosedOverImplementationsOf(typeof(IFooDefinition<>), As = typeof(IFoo), Lifetime = InjectableLifetime.Transient)]
+                public sealed class FooCore<TData> : IFoo where TData : class
+                {
+                    public FooCore(IFooDefinition<TData> definition) { }
+                    public string Discriminator => "";
+                }
+            }
+            """;
+
+        var generatedCode = GeneratorTestRunner.ForComposedWithInlineTypes()
+            .WithSource(source)
+            .WithSource(Shapes)
+            .RunTypeRegistryGenerator();
+
+        Assert.Contains("AddTransient<global::TestNamespace.IFoo>", generatedCode);
+        Assert.DoesNotContain("AddSingleton<global::TestNamespace.IFoo>", generatedCode);
+    }
+
+    [Fact]
+    public void Composition_MultipleMarkers_RegistersUnderEachFacade()
+    {
+        var source = """
+            using NexusLabs.Needlr.Generators;
+
+            [assembly: GenerateTypeRegistry(IncludeNamespacePrefixes = new[] { "TestNamespace" })]
+
+            namespace TestNamespace
+            {
+                public interface IMultiDefinition<TData> where TData : class { }
+                public interface IMultiA { }
+                public interface IMultiB { }
+                public sealed class MultiData { }
+                public sealed class MultiImpl : IMultiDefinition<MultiData> { }
+
+                [RegisterClosedOverImplementationsOf(typeof(IMultiDefinition<>), As = typeof(IMultiA))]
+                [RegisterClosedOverImplementationsOf(typeof(IMultiDefinition<>), As = typeof(IMultiB))]
+                public sealed class MultiCore<TData> : IMultiA, IMultiB where TData : class
+                {
+                    public MultiCore(IMultiDefinition<TData> definition) { }
+                }
+            }
+            """;
+
+        var generatedCode = GeneratorTestRunner.ForComposedWithInlineTypes()
+            .WithSource(source)
+            .RunTypeRegistryGenerator();
+
+        Assert.Contains("AddSingleton<global::TestNamespace.IMultiA>", generatedCode);
+        Assert.Contains("AddSingleton<global::TestNamespace.IMultiB>", generatedCode);
+    }
+}

--- a/src/NexusLabs.Needlr.Generators.Tests/RegisterClosedOverImplementationsOfGeneratorTests.cs
+++ b/src/NexusLabs.Needlr.Generators.Tests/RegisterClosedOverImplementationsOfGeneratorTests.cs
@@ -381,4 +381,43 @@ public sealed class RegisterClosedOverImplementationsOfGeneratorTests
         Assert.Contains("AddSingleton<global::TestNamespace.IMultiA>", generatedCode);
         Assert.Contains("AddSingleton<global::TestNamespace.IMultiB>", generatedCode);
     }
+
+    [Fact]
+    public void Composition_NullableValueTypeArgumentViolatesNotNullConstraint_ReportsDiagnosticAndSkips()
+    {
+        var source = """
+            using NexusLabs.Needlr.Generators;
+
+            [assembly: GenerateTypeRegistry(IncludeNamespacePrefixes = new[] { "TestNamespace" })]
+
+            namespace TestNamespace
+            {
+                public interface INnDefinition<TData> { }
+                public sealed class RefData { }
+                public sealed class RefHolder : INnDefinition<RefData> { }
+                public sealed class NullableHolder : INnDefinition<int?> { }
+                public interface INn { }
+
+                [RegisterClosedOverImplementationsOf(typeof(INnDefinition<>), As = typeof(INn))]
+                public sealed class NnCore<TData> : INn where TData : notnull
+                {
+                    public NnCore(INnDefinition<TData> definition) { }
+                }
+            }
+            """;
+
+        var generatedCode = GeneratorTestRunner.ForComposedWithInlineTypes()
+            .WithSource(source)
+            .RunTypeRegistryGenerator();
+        var diagnostics = GeneratorTestRunner.ForComposedWithInlineTypes()
+            .WithSource(source)
+            .RunTypeRegistryGeneratorDiagnostics();
+
+        // The non-nullable reference type registers; the nullable value type (int?) is skipped + diagnosed.
+        Assert.Contains("new global::TestNamespace.NnCore<global::TestNamespace.RefData>", generatedCode);
+        var registrationCount = System.Text.RegularExpressions.Regex
+            .Matches(generatedCode, "new global::TestNamespace.NnCore<").Count;
+        Assert.Equal(1, registrationCount);
+        Assert.Contains(diagnostics, d => d.Id == "NDLRGEN038");
+    }
 }

--- a/src/NexusLabs.Needlr.Generators/AnalyzerReleases.Unshipped.md
+++ b/src/NexusLabs.Needlr.Generators/AnalyzerReleases.Unshipped.md
@@ -5,3 +5,7 @@
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
+NDLRGEN035 | NexusLabs.Needlr.Generators | Error | RegisterClosedOverImplementationsOfAttributeAnalyzer, [RegisterClosedOverImplementationsOf] source must be an open generic interface
+NDLRGEN036 | NexusLabs.Needlr.Generators | Error | RegisterClosedOverImplementationsOfAttributeAnalyzer, [RegisterClosedOverImplementationsOf] composition must be an open generic class
+NDLRGEN037 | NexusLabs.Needlr.Generators | Error | RegisterClosedOverImplementationsOfAttributeAnalyzer, [RegisterClosedOverImplementationsOf] composition must implement the As service type
+NDLRGEN038 | NexusLabs.Needlr.Generators | Warning | TypeRegistryGenerator, [RegisterClosedOverImplementationsOf] discovered type argument violates composition constraints

--- a/src/NexusLabs.Needlr.Generators/CodeGen/ComposedRegistrationsCodeGenerator.cs
+++ b/src/NexusLabs.Needlr.Generators/CodeGen/ComposedRegistrationsCodeGenerator.cs
@@ -1,0 +1,71 @@
+// Copyright (c) NexusLabs. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using NexusLabs.Needlr.Generators.Models;
+
+namespace NexusLabs.Needlr.Generators.CodeGen;
+
+/// <summary>
+/// Generates the <c>RegisterComposedTypes(IServiceCollection)</c> method that registers each open generic
+/// composition type closed over the type argument(s) of every discovered implementation of its designated
+/// open generic interface, exposed as the designated facade service type.
+/// </summary>
+internal static class ComposedRegistrationsCodeGenerator
+{
+    /// <summary>
+    /// Emits the <c>RegisterComposedTypes(IServiceCollection)</c> method body into the TypeRegistry class.
+    /// </summary>
+    internal static void GenerateRegisterComposedTypesMethod(
+        StringBuilder builder,
+        IReadOnlyList<DiscoveredComposedRegistration> registrations,
+        BreadcrumbWriter breadcrumbs,
+        string? projectDirectory)
+    {
+        builder.AppendLine("    /// <summary>");
+        builder.AppendLine("    /// Registers each composition type closed over the type argument(s) of every discovered");
+        builder.AppendLine("    /// implementation of its designated open generic interface, exposed as the designated facade.");
+        builder.AppendLine("    /// </summary>");
+        builder.AppendLine("    /// <param name=\"services\">The service collection to register to.</param>");
+        builder.AppendLine("    private static void RegisterComposedTypes(IServiceCollection services)");
+        builder.AppendLine("    {");
+
+        foreach (var registration in registrations)
+        {
+            var addMethod = GetAddMethod(registration.Lifetime);
+            var closedShortName = registration.ClosedCompositionTypeName.Split('.').Last();
+            var facadeShortName = registration.FacadeTypeName.Split('.').Last();
+            var sourcePath = registration.SourceFilePath != null
+                ? BreadcrumbWriter.GetRelativeSourcePath(registration.SourceFilePath, projectDirectory)
+                : $"[{registration.AssemblyName}]";
+
+            breadcrumbs.WriteInlineComment(builder, "        ", $"Composed: {closedShortName} as {facadeShortName} ← {sourcePath}");
+
+            if (registration.ConstructorArguments.Count == 0)
+            {
+                builder.AppendLine($"        services.{addMethod}<{registration.FacadeTypeName}>(sp => new {registration.ClosedCompositionTypeName}());");
+                continue;
+            }
+
+            builder.AppendLine($"        services.{addMethod}<{registration.FacadeTypeName}>(sp => new {registration.ClosedCompositionTypeName}(");
+
+            for (var i = 0; i < registration.ConstructorArguments.Count; i++)
+            {
+                var isLast = i == registration.ConstructorArguments.Count - 1;
+                builder.AppendLine($"            {registration.ConstructorArguments[i]}{(isLast ? "));" : ",")}");
+            }
+        }
+
+        builder.AppendLine("    }");
+    }
+
+    private static string GetAddMethod(GeneratorLifetime lifetime) => lifetime switch
+    {
+        GeneratorLifetime.Scoped => "AddScoped",
+        GeneratorLifetime.Transient => "AddTransient",
+        _ => "AddSingleton",
+    };
+}

--- a/src/NexusLabs.Needlr.Generators/CodeGen/DecoratorsCodeGenerator.cs
+++ b/src/NexusLabs.Needlr.Generators/CodeGen/DecoratorsCodeGenerator.cs
@@ -20,7 +20,7 @@ internal static class DecoratorsCodeGenerator
     /// <summary>
     /// Emits the <c>ApplyDecorators(IServiceCollection)</c> method body into the TypeRegistry class.
     /// </summary>
-    internal static void GenerateApplyDecoratorsMethod(StringBuilder builder, IReadOnlyList<DiscoveredDecorator> decorators, bool hasInterceptors, bool hasHostedServices, string safeAssemblyName, BreadcrumbWriter breadcrumbs, string? projectDirectory)
+    internal static void GenerateApplyDecoratorsMethod(StringBuilder builder, IReadOnlyList<DiscoveredDecorator> decorators, bool hasInterceptors, bool hasHostedServices, bool hasComposedRegistrations, string safeAssemblyName, BreadcrumbWriter breadcrumbs, string? projectDirectory)
     {
         builder.AppendLine("    /// <summary>");
         builder.AppendLine("    /// Applies all discovered decorators, interceptors, and hosted services to the service collection.");
@@ -34,6 +34,14 @@ internal static class DecoratorsCodeGenerator
         breadcrumbs.WriteInlineComment(builder, "        ", "Register service catalog for DI resolution");
         builder.AppendLine($"        services.AddSingleton<global::NexusLabs.Needlr.Catalog.IServiceCatalog, global::{safeAssemblyName}.Generated.ServiceCatalog>();");
         builder.AppendLine();
+
+        // Register composed (closed-over-implementations) registrations before decorators apply.
+        if (hasComposedRegistrations)
+        {
+            breadcrumbs.WriteInlineComment(builder, "        ", "Register composed closed-generic types");
+            builder.AppendLine("        RegisterComposedTypes(services);");
+            builder.AppendLine();
+        }
 
         // Register hosted services first (before decorators apply)
         if (hasHostedServices)

--- a/src/NexusLabs.Needlr.Generators/ComposedRegistrationDiscoveryHelper.cs
+++ b/src/NexusLabs.Needlr.Generators/ComposedRegistrationDiscoveryHelper.cs
@@ -274,9 +274,12 @@ internal static class ComposedRegistrationDiscoveryHelper
 
         foreach (var constraintType in typeParameter.ConstraintTypes)
         {
-            // A constraint that references another type parameter (e.g. where T : IComparable<T>) cannot be
-            // checked without full substitution; treat conservatively as satisfied for v1.
-            if (ContainsTypeParameter(constraintType))
+            // Only non-generic constraint types are validated here: exact-match assignability is
+            // variance-immune and reliable for them. Generic constraint types — whether self-referential
+            // (where T : IComparable<T>), variant (where T : IProducer<Animal>), or invariant — are
+            // deferred to the C# compiler so a variance/substitution subtlety can never skip a valid
+            // registration. A bare type-parameter constraint (where T : U) is likewise deferred.
+            if (constraintType is INamedTypeSymbol { IsGenericType: true } || ContainsTypeParameter(constraintType))
                 continue;
 
             if (!IsAssignableTo(typeArgument, constraintType))

--- a/src/NexusLabs.Needlr.Generators/ComposedRegistrationDiscoveryHelper.cs
+++ b/src/NexusLabs.Needlr.Generators/ComposedRegistrationDiscoveryHelper.cs
@@ -1,0 +1,332 @@
+using System.Collections.Generic;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+
+using NexusLabs.Needlr.Generators.Models;
+
+namespace NexusLabs.Needlr.Generators;
+
+/// <summary>
+/// Discovers <c>[RegisterClosedOverImplementationsOf]</c> markers and expands each into concrete closed
+/// registrations — one per discovered concrete closed implementation of the designated open generic
+/// interface — by closing the composition type over the same type argument(s) via Roslyn
+/// <see cref="INamedTypeSymbol.Construct(ITypeSymbol[])"/> and resolving its constructor dependencies.
+/// </summary>
+internal static class ComposedRegistrationDiscoveryHelper
+{
+    private const string AttributeName = "RegisterClosedOverImplementationsOfAttribute";
+    private const string AttributeNamespace = "NexusLabs.Needlr.Generators";
+    private const string FromKeyedServicesAttributeFullName = "Microsoft.Extensions.DependencyInjection.FromKeyedServicesAttribute";
+
+    private static readonly SymbolDisplayFormat FullyQualified = SymbolDisplayFormat.FullyQualifiedFormat;
+
+    /// <summary>
+    /// A single discovered marker (before assembly/source metadata is attached by the caller).
+    /// </summary>
+    public readonly struct ComposedMarkerInfo
+    {
+        public ComposedMarkerInfo(
+            INamedTypeSymbol compositionType,
+            INamedTypeSymbol sourceOpenGenericInterface,
+            INamedTypeSymbol? asServiceType,
+            GeneratorLifetime lifetime)
+        {
+            CompositionType = compositionType;
+            SourceOpenGenericInterface = sourceOpenGenericInterface;
+            AsServiceType = asServiceType;
+            Lifetime = lifetime;
+        }
+
+        public INamedTypeSymbol CompositionType { get; }
+        public INamedTypeSymbol SourceOpenGenericInterface { get; }
+        public INamedTypeSymbol? AsServiceType { get; }
+        public GeneratorLifetime Lifetime { get; }
+    }
+
+    /// <summary>
+    /// Reads all valid <c>[RegisterClosedOverImplementationsOf]</c> attributes from a type.
+    /// Invalid shapes (non-open-generic source interface, missing facade) are skipped here and surfaced
+    /// to the user by the companion analyzer.
+    /// </summary>
+    public static IReadOnlyList<ComposedMarkerInfo> GetComposedMarkers(INamedTypeSymbol typeSymbol)
+    {
+        var result = new List<ComposedMarkerInfo>();
+
+        foreach (var attribute in typeSymbol.GetAttributes())
+        {
+            var attrClass = attribute.AttributeClass;
+            if (attrClass is null)
+                continue;
+
+            if (attrClass.Name != AttributeName)
+                continue;
+
+            if (attrClass.ContainingNamespace?.ToDisplayString() != AttributeNamespace)
+                continue;
+
+            if (attribute.ConstructorArguments.Length < 1)
+                continue;
+
+            if (attribute.ConstructorArguments[0].Value is not INamedTypeSymbol sourceInterface)
+                continue;
+
+            // Only open generic interfaces drive discovery; the analyzer reports other shapes.
+            if (!sourceInterface.IsUnboundGenericType || sourceInterface.TypeKind != TypeKind.Interface)
+                continue;
+
+            INamedTypeSymbol? asServiceType = null;
+            var lifetime = GeneratorLifetime.Singleton;
+
+            foreach (var namedArg in attribute.NamedArguments)
+            {
+                if (namedArg.Key == "As" && namedArg.Value.Value is INamedTypeSymbol asSymbol)
+                {
+                    asServiceType = asSymbol;
+                }
+                else if (namedArg.Key == "Lifetime" && namedArg.Value.Value is int lifetimeValue)
+                {
+                    lifetime = (GeneratorLifetime)lifetimeValue;
+                }
+            }
+
+            result.Add(new ComposedMarkerInfo(typeSymbol, sourceInterface, asServiceType, lifetime));
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Expands each marker into closed registrations using the discovered candidate implementation types,
+    /// appending resolvable registrations to <paramref name="registrations"/> and constraint violations
+    /// to <paramref name="violations"/>.
+    /// </summary>
+    public static void Expand(
+        IReadOnlyList<DiscoveredComposedMarker> markers,
+        IReadOnlyList<INamedTypeSymbol> candidateTypes,
+        List<DiscoveredComposedRegistration> registrations,
+        List<ComposedConstraintViolation> violations)
+    {
+        foreach (var marker in markers)
+        {
+            // The facade is required; absence is reported by the analyzer, skip emission here.
+            if (marker.AsServiceType is null)
+                continue;
+
+            var facadeTypeName = marker.AsServiceType.ToDisplayString(FullyQualified);
+
+            // Distinct closed implementations of the source interface, ordered for deterministic output.
+            var closedInterfaces = FindClosedSourceInterfaces(marker.SourceOpenGenericInterface, candidateTypes)
+                .OrderBy(i => i.ToDisplayString(FullyQualified), System.StringComparer.Ordinal)
+                .ToList();
+
+            foreach (var closedInterface in closedInterfaces)
+            {
+                var typeArguments = closedInterface.TypeArguments;
+
+                // Only fully closed implementations (concrete type arguments) participate.
+                if (typeArguments.Any(t => t.TypeKind == TypeKind.TypeParameter))
+                    continue;
+
+                // Arity between the source interface and the composition must align to close the composition.
+                if (typeArguments.Length != marker.CompositionType.TypeParameters.Length)
+                    continue;
+
+                if (!SatisfiesConstraints(marker.CompositionType, typeArguments))
+                {
+                    violations.Add(new ComposedConstraintViolation(
+                        marker.CompositionType.ToDisplayString(FullyQualified),
+                        string.Join(", ", typeArguments.Select(t => t.ToDisplayString(FullyQualified))),
+                        marker.SourceOpenGenericInterface.ToDisplayString(FullyQualified),
+                        marker.SourceFilePath));
+                    continue;
+                }
+
+                var closedComposition = marker.CompositionType.Construct(typeArguments.ToArray());
+
+                var constructor = SelectConstructor(closedComposition);
+                if (constructor is null)
+                    continue;
+
+                var arguments = constructor.Parameters
+                    .Select(BuildResolutionExpression)
+                    .ToList();
+
+                registrations.Add(new DiscoveredComposedRegistration(
+                    facadeTypeName,
+                    closedComposition.ToDisplayString(FullyQualified),
+                    arguments,
+                    marker.Lifetime,
+                    marker.AssemblyName,
+                    marker.SourceFilePath));
+            }
+        }
+    }
+
+    private static List<INamedTypeSymbol> FindClosedSourceInterfaces(
+        INamedTypeSymbol sourceOpenGenericInterface,
+        IReadOnlyList<INamedTypeSymbol> candidateTypes)
+    {
+        var sourceDefinition = sourceOpenGenericInterface.OriginalDefinition;
+        var result = new List<INamedTypeSymbol>();
+        var seen = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+
+        foreach (var candidate in candidateTypes)
+        {
+            if (candidate.IsAbstract || candidate.TypeKind != TypeKind.Class)
+                continue;
+
+            foreach (var iface in candidate.AllInterfaces)
+            {
+                if (!iface.IsGenericType)
+                    continue;
+
+                if (!SymbolEqualityComparer.Default.Equals(iface.OriginalDefinition, sourceDefinition))
+                    continue;
+
+                if (seen.Add(iface))
+                    result.Add(iface);
+            }
+        }
+
+        return result;
+    }
+
+    private static IMethodSymbol? SelectConstructor(INamedTypeSymbol closedComposition)
+    {
+        IMethodSymbol? best = null;
+
+        foreach (var ctor in closedComposition.InstanceConstructors)
+        {
+            if (ctor.IsStatic)
+                continue;
+
+            if (ctor.DeclaredAccessibility != Accessibility.Public)
+                continue;
+
+            if (best is null || ctor.Parameters.Length > best.Parameters.Length)
+                best = ctor;
+        }
+
+        return best;
+    }
+
+    private static string BuildResolutionExpression(IParameterSymbol parameter)
+    {
+        var typeName = parameter.Type.ToDisplayString(FullyQualified);
+        var serviceKey = GetFromKeyedServicesKey(parameter);
+
+        return serviceKey is null
+            ? $"sp.GetRequiredService<{typeName}>()"
+            : $"sp.GetRequiredKeyedService<{typeName}>(\"{GeneratorHelpers.EscapeStringLiteral(serviceKey)}\")";
+    }
+
+    private static string? GetFromKeyedServicesKey(IParameterSymbol parameter)
+    {
+        foreach (var attr in parameter.GetAttributes())
+        {
+            if (attr.AttributeClass?.ToDisplayString() != FromKeyedServicesAttributeFullName)
+                continue;
+
+            if (attr.ConstructorArguments.Length > 0 && attr.ConstructorArguments[0].Value is string keyValue)
+                return keyValue;
+        }
+
+        return null;
+    }
+
+    private static bool SatisfiesConstraints(
+        INamedTypeSymbol composition,
+        System.Collections.Immutable.ImmutableArray<ITypeSymbol> typeArguments)
+    {
+        var typeParameters = composition.TypeParameters;
+        if (typeParameters.Length != typeArguments.Length)
+            return false;
+
+        for (var i = 0; i < typeParameters.Length; i++)
+        {
+            if (!SatisfiesConstraint(typeParameters[i], typeArguments[i]))
+                return false;
+        }
+
+        return true;
+    }
+
+    private static bool SatisfiesConstraint(
+        ITypeParameterSymbol typeParameter,
+        ITypeSymbol typeArgument)
+    {
+        if (typeParameter.HasReferenceTypeConstraint && !typeArgument.IsReferenceType)
+            return false;
+
+        if (typeParameter.HasValueTypeConstraint &&
+            (!typeArgument.IsValueType || IsNullableValueType(typeArgument)))
+            return false;
+
+        if (typeParameter.HasUnmanagedTypeConstraint && !typeArgument.IsUnmanagedType)
+            return false;
+
+        if (typeParameter.HasConstructorConstraint && !SatisfiesNewConstraint(typeArgument))
+            return false;
+
+        foreach (var constraintType in typeParameter.ConstraintTypes)
+        {
+            // A constraint that references another type parameter (e.g. where T : IComparable<T>) cannot be
+            // checked without full substitution; treat conservatively as satisfied for v1.
+            if (ContainsTypeParameter(constraintType))
+                continue;
+
+            if (!IsAssignableTo(typeArgument, constraintType))
+                return false;
+        }
+
+        return true;
+    }
+
+    private static bool IsAssignableTo(ITypeSymbol type, ITypeSymbol target)
+    {
+        if (SymbolEqualityComparer.Default.Equals(type, target))
+            return true;
+
+        if (target.TypeKind == TypeKind.Interface)
+            return type.AllInterfaces.Any(i => SymbolEqualityComparer.Default.Equals(i, target));
+
+        for (var baseType = type.BaseType; baseType is not null; baseType = baseType.BaseType)
+        {
+            if (SymbolEqualityComparer.Default.Equals(baseType, target))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool SatisfiesNewConstraint(ITypeSymbol typeArgument)
+    {
+        if (typeArgument.IsValueType)
+            return true;
+
+        if (typeArgument is not INamedTypeSymbol named)
+            return false;
+
+        if (named.IsAbstract)
+            return false;
+
+        return named.InstanceConstructors.Any(c =>
+            !c.IsStatic &&
+            c.Parameters.Length == 0 &&
+            c.DeclaredAccessibility == Accessibility.Public);
+    }
+
+    private static bool IsNullableValueType(ITypeSymbol typeArgument) =>
+        typeArgument is INamedTypeSymbol named &&
+        named.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T;
+
+    private static bool ContainsTypeParameter(ITypeSymbol type)
+    {
+        if (type.TypeKind == TypeKind.TypeParameter)
+            return true;
+
+        return type is INamedTypeSymbol named &&
+            named.TypeArguments.Any(ContainsTypeParameter);
+    }
+}

--- a/src/NexusLabs.Needlr.Generators/ComposedRegistrationDiscoveryHelper.cs
+++ b/src/NexusLabs.Needlr.Generators/ComposedRegistrationDiscoveryHelper.cs
@@ -263,6 +263,9 @@ internal static class ComposedRegistrationDiscoveryHelper
             (!typeArgument.IsValueType || IsNullableValueType(typeArgument)))
             return false;
 
+        if (typeParameter.HasNotNullConstraint && IsNullableValueType(typeArgument))
+            return false;
+
         if (typeParameter.HasUnmanagedTypeConstraint && !typeArgument.IsUnmanagedType)
             return false;
 

--- a/src/NexusLabs.Needlr.Generators/DiagnosticDescriptors.cs
+++ b/src/NexusLabs.Needlr.Generators/DiagnosticDescriptors.cs
@@ -344,6 +344,67 @@ internal static class DiagnosticDescriptors
         helpLinkUri: HelpLinkBase + "NDLRGEN034.md");
 
     // ============================================================================
+    // Composition Analyzers (NDLRGEN035-038)
+    // ============================================================================
+
+    /// <summary>
+    /// NDLRGEN035: [RegisterClosedOverImplementationsOf] source type must be an open generic interface.
+    /// </summary>
+    public static readonly DiagnosticDescriptor ComposedSourceNotOpenGenericInterface = new(
+        id: "NDLRGEN035",
+        title: "[RegisterClosedOverImplementationsOf] source type must be an open generic interface",
+        messageFormat: "Source type argument '{0}' in [RegisterClosedOverImplementationsOf] is not an open generic interface: {1}",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "The [RegisterClosedOverImplementationsOf] attribute requires an open generic interface type whose concrete closed implementations drive registration. Use typeof(IInterface<>) syntax, not a closed generic like typeof(IInterface<string>) or a non-generic type.",
+        helpLinkUri: HelpLinkBase + "NDLRGEN035.md");
+
+    /// <summary>
+    /// NDLRGEN036: [RegisterClosedOverImplementationsOf] composition class must be an open generic with matching arity.
+    /// </summary>
+    public static readonly DiagnosticDescriptor ComposedClassNotOpenGeneric = new(
+        id: "NDLRGEN036",
+        title: "[RegisterClosedOverImplementationsOf] composition must be an open generic class",
+        messageFormat: "Class '{0}' with [RegisterClosedOverImplementationsOf({1})] must be an open generic class with {2} type parameter(s)",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "When using [RegisterClosedOverImplementationsOf(typeof(IInterface<>))], the annotated composition class must be an open generic with the same number of type parameters so it can be closed over each discovered implementation's type argument(s).",
+        helpLinkUri: HelpLinkBase + "NDLRGEN036.md");
+
+    /// <summary>
+    /// NDLRGEN037: [RegisterClosedOverImplementationsOf] composition class must implement the As service type.
+    /// </summary>
+    public static readonly DiagnosticDescriptor ComposedClassNotImplementingAs = new(
+        id: "NDLRGEN037",
+        title: "[RegisterClosedOverImplementationsOf] composition must implement the As service type",
+        messageFormat: "Class '{0}' must implement the 'As' service type specified by [RegisterClosedOverImplementationsOf]",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "Each closed composition is registered as the service type named by 'As', so the annotated class must specify an 'As' type and implement it (directly or transitively). Set As = typeof(IFacade) where the composition implements IFacade.",
+        helpLinkUri: HelpLinkBase + "NDLRGEN037.md");
+
+    /// <summary>
+    /// NDLRGEN038: A discovered type argument cannot legally close the composition type.
+    /// </summary>
+    /// <remarks>
+    /// Emitted by the generator (not the per-attribute analyzer) because only the generator knows the
+    /// full set of discovered implementations. The offending registration is skipped rather than emitting
+    /// code that fails to compile, turning a would-be runtime absence into a build-time signal.
+    /// </remarks>
+    public static readonly DiagnosticDescriptor ComposedTypeArgumentViolatesConstraints = new(
+        id: "NDLRGEN038",
+        title: "[RegisterClosedOverImplementationsOf] discovered type argument violates composition constraints",
+        messageFormat: "Composition '{0}' cannot be closed over type argument(s) '{1}' from an implementation of '{2}' because they violate its generic constraints; the registration was skipped",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "An implementation of the designated open generic interface was discovered whose type argument(s) do not satisfy the composition type's generic constraints. Relax the composition's constraints, constrain the source interface so such implementations cannot exist, or exclude the implementation. The registration is skipped to avoid emitting code that would fail to compile.",
+        helpLinkUri: HelpLinkBase + "NDLRGEN038.md");
+
+    // ============================================================================
     // HttpClient Analyzers (NDLRHTTP001-006)
     // ============================================================================
 

--- a/src/NexusLabs.Needlr.Generators/Models/Composition/ComposedConstraintViolation.cs
+++ b/src/NexusLabs.Needlr.Generators/Models/Composition/ComposedConstraintViolation.cs
@@ -1,0 +1,33 @@
+namespace NexusLabs.Needlr.Generators.Models;
+
+/// <summary>
+/// Records that a discovered type argument cannot legally close a composition type because it violates
+/// the composition's generic constraints. Surfaced as the <c>NDLRGEN038</c> build diagnostic, and the
+/// corresponding registration is skipped rather than emitting code that fails to compile.
+/// </summary>
+internal readonly struct ComposedConstraintViolation
+{
+    public ComposedConstraintViolation(
+        string compositionTypeName,
+        string typeArgumentName,
+        string sourceInterfaceName,
+        string? sourceFilePath)
+    {
+        CompositionTypeName = compositionTypeName;
+        TypeArgumentName = typeArgumentName;
+        SourceInterfaceName = sourceInterfaceName;
+        SourceFilePath = sourceFilePath;
+    }
+
+    /// <summary>The composition type that could not be closed (e.g., FooCore&lt;TData&gt;).</summary>
+    public string CompositionTypeName { get; }
+
+    /// <summary>The offending type argument(s), comma-separated (e.g., StructData).</summary>
+    public string TypeArgumentName { get; }
+
+    /// <summary>The source open generic interface whose implementation produced the type argument.</summary>
+    public string SourceInterfaceName { get; }
+
+    /// <summary>The source file path of the composition type, if available.</summary>
+    public string? SourceFilePath { get; }
+}

--- a/src/NexusLabs.Needlr.Generators/Models/Composition/DiscoveredComposedMarker.cs
+++ b/src/NexusLabs.Needlr.Generators/Models/Composition/DiscoveredComposedMarker.cs
@@ -1,0 +1,44 @@
+using Microsoft.CodeAnalysis;
+
+namespace NexusLabs.Needlr.Generators.Models;
+
+/// <summary>
+/// A discovered <c>[RegisterClosedOverImplementationsOf]</c> marker on an open generic composition type,
+/// captured during type collection for later expansion into closed registrations.
+/// </summary>
+internal readonly struct DiscoveredComposedMarker
+{
+    public DiscoveredComposedMarker(
+        INamedTypeSymbol compositionType,
+        INamedTypeSymbol sourceOpenGenericInterface,
+        INamedTypeSymbol? asServiceType,
+        GeneratorLifetime lifetime,
+        string assemblyName,
+        string? sourceFilePath)
+    {
+        CompositionType = compositionType;
+        SourceOpenGenericInterface = sourceOpenGenericInterface;
+        AsServiceType = asServiceType;
+        Lifetime = lifetime;
+        AssemblyName = assemblyName;
+        SourceFilePath = sourceFilePath;
+    }
+
+    /// <summary>The open generic composition type carrying the attribute (e.g., FooCore{TData}).</summary>
+    public INamedTypeSymbol CompositionType { get; }
+
+    /// <summary>The open generic interface whose closed implementations drive registration (e.g., IFooDefinition{}).</summary>
+    public INamedTypeSymbol SourceOpenGenericInterface { get; }
+
+    /// <summary>The facade service type each closed composition is registered as, or null if unspecified.</summary>
+    public INamedTypeSymbol? AsServiceType { get; }
+
+    /// <summary>The lifetime each closed registration is given.</summary>
+    public GeneratorLifetime Lifetime { get; }
+
+    /// <summary>The name of the assembly that declared the composition type.</summary>
+    public string AssemblyName { get; }
+
+    /// <summary>The source file path of the composition type, if available.</summary>
+    public string? SourceFilePath { get; }
+}

--- a/src/NexusLabs.Needlr.Generators/Models/Composition/DiscoveredComposedRegistration.cs
+++ b/src/NexusLabs.Needlr.Generators/Models/Composition/DiscoveredComposedRegistration.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+
+namespace NexusLabs.Needlr.Generators.Models;
+
+/// <summary>
+/// A fully resolved composed registration: one closed composition type, exposed as a facade service type,
+/// with its constructor dependencies resolved to service-provider expressions. Emitted as a single
+/// <c>services.Add{Lifetime}</c> registration.
+/// </summary>
+internal readonly struct DiscoveredComposedRegistration
+{
+    public DiscoveredComposedRegistration(
+        string facadeTypeName,
+        string closedCompositionTypeName,
+        IReadOnlyList<string> constructorArguments,
+        GeneratorLifetime lifetime,
+        string assemblyName,
+        string? sourceFilePath)
+    {
+        FacadeTypeName = facadeTypeName;
+        ClosedCompositionTypeName = closedCompositionTypeName;
+        ConstructorArguments = constructorArguments;
+        Lifetime = lifetime;
+        AssemblyName = assemblyName;
+        SourceFilePath = sourceFilePath;
+    }
+
+    /// <summary>The fully qualified facade service type the closed composition is registered as.</summary>
+    public string FacadeTypeName { get; }
+
+    /// <summary>The fully qualified closed composition type to instantiate (e.g., global::N.FooCore&lt;global::N.AlphaData&gt;).</summary>
+    public string ClosedCompositionTypeName { get; }
+
+    /// <summary>The constructor argument expressions (e.g., sp.GetRequiredService&lt;...&gt;()), in declaration order.</summary>
+    public IReadOnlyList<string> ConstructorArguments { get; }
+
+    /// <summary>The lifetime this registration is given.</summary>
+    public GeneratorLifetime Lifetime { get; }
+
+    /// <summary>The name of the assembly that declared the composition type.</summary>
+    public string AssemblyName { get; }
+
+    /// <summary>The source file path of the composition type, if available.</summary>
+    public string? SourceFilePath { get; }
+}

--- a/src/NexusLabs.Needlr.Generators/Models/DiscoveryResult.cs
+++ b/src/NexusLabs.Needlr.Generators/Models/DiscoveryResult.cs
@@ -18,7 +18,9 @@ internal readonly struct DiscoveryResult
         IReadOnlyList<DiscoveredOptions> options,
         IReadOnlyList<DiscoveredHostedService> hostedServices,
         IReadOnlyList<DiscoveredProvider> providers,
-        IReadOnlyList<DiscoveredHttpClient> httpClients)
+        IReadOnlyList<DiscoveredHttpClient> httpClients,
+        IReadOnlyList<DiscoveredComposedRegistration> composedRegistrations,
+        IReadOnlyList<ComposedConstraintViolation> composedConstraintViolations)
     {
         InjectableTypes = injectableTypes;
         PluginTypes = pluginTypes;
@@ -31,6 +33,8 @@ internal readonly struct DiscoveryResult
         HostedServices = hostedServices;
         Providers = providers;
         HttpClients = httpClients;
+        ComposedRegistrations = composedRegistrations;
+        ComposedConstraintViolations = composedConstraintViolations;
     }
 
     public IReadOnlyList<DiscoveredType> InjectableTypes { get; }
@@ -44,4 +48,6 @@ internal readonly struct DiscoveryResult
     public IReadOnlyList<DiscoveredHostedService> HostedServices { get; }
     public IReadOnlyList<DiscoveredProvider> Providers { get; }
     public IReadOnlyList<DiscoveredHttpClient> HttpClients { get; }
+    public IReadOnlyList<DiscoveredComposedRegistration> ComposedRegistrations { get; }
+    public IReadOnlyList<ComposedConstraintViolation> ComposedConstraintViolations { get; }
 }

--- a/src/NexusLabs.Needlr.Generators/RegisterClosedOverImplementationsOfAttributeAnalyzer.cs
+++ b/src/NexusLabs.Needlr.Generators/RegisterClosedOverImplementationsOfAttributeAnalyzer.cs
@@ -1,0 +1,180 @@
+using System.Collections.Immutable;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace NexusLabs.Needlr.Generators;
+
+/// <summary>
+/// Analyzer that validates [RegisterClosedOverImplementationsOf] attribute usage:
+/// - NDLRGEN035: Source type argument must be an open generic interface
+/// - NDLRGEN036: Composition class must be an open generic with matching arity
+/// - NDLRGEN037: Composition class must specify and implement the As service type
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class RegisterClosedOverImplementationsOfAttributeAnalyzer : DiagnosticAnalyzer
+{
+    private const string AttributeName = "RegisterClosedOverImplementationsOfAttribute";
+    private const string GeneratorsNamespace = "NexusLabs.Needlr.Generators";
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(
+            DiagnosticDescriptors.ComposedSourceNotOpenGenericInterface,
+            DiagnosticDescriptors.ComposedClassNotOpenGeneric,
+            DiagnosticDescriptors.ComposedClassNotImplementingAs);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterSyntaxNodeAction(AnalyzeAttribute, SyntaxKind.Attribute);
+    }
+
+    private static void AnalyzeAttribute(SyntaxNodeAnalysisContext context)
+    {
+        var attributeSyntax = (AttributeSyntax)context.Node;
+        var attributeSymbol = context.SemanticModel.GetSymbolInfo(attributeSyntax).Symbol?.ContainingType;
+
+        if (attributeSymbol is null)
+            return;
+
+        if (!IsComposedAttribute(attributeSymbol))
+            return;
+
+        if (attributeSyntax.Parent?.Parent is not ClassDeclarationSyntax classDeclaration)
+            return;
+
+        if (context.SemanticModel.GetDeclaredSymbol(classDeclaration) is not INamedTypeSymbol classSymbol)
+            return;
+
+        var sourceType = GetSourceTypeArgument(attributeSyntax, context.SemanticModel);
+        if (sourceType is null)
+            return;
+
+        // NDLRGEN035: source must be an open generic interface.
+        if (!IsOpenGenericInterface(sourceType, out var typeDescription))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                DiagnosticDescriptors.ComposedSourceNotOpenGenericInterface,
+                attributeSyntax.GetLocation(),
+                sourceType.ToDisplayString(),
+                typeDescription));
+            return;
+        }
+
+        if (sourceType is not INamedTypeSymbol sourceInterface)
+            return;
+
+        var expectedArity = sourceInterface.TypeParameters.Length;
+
+        // NDLRGEN036: composition must be an open generic with matching arity.
+        if (!classSymbol.IsGenericType || classSymbol.TypeParameters.Length != expectedArity)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                DiagnosticDescriptors.ComposedClassNotOpenGeneric,
+                attributeSyntax.GetLocation(),
+                classSymbol.Name,
+                sourceInterface.ToDisplayString(),
+                expectedArity));
+            return;
+        }
+
+        // NDLRGEN037: composition must specify and implement the As service type.
+        var asType = GetAsServiceType(attributeSyntax, context.SemanticModel);
+        if (asType is null || !ImplementsServiceType(classSymbol, asType))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                DiagnosticDescriptors.ComposedClassNotImplementingAs,
+                attributeSyntax.GetLocation(),
+                classSymbol.Name));
+        }
+    }
+
+    private static bool IsComposedAttribute(INamedTypeSymbol attributeSymbol) =>
+        attributeSymbol.Name == AttributeName &&
+        attributeSymbol.ContainingNamespace?.ToString() == GeneratorsNamespace;
+
+    private static ITypeSymbol? GetSourceTypeArgument(AttributeSyntax attributeSyntax, SemanticModel semanticModel)
+    {
+        var argumentList = attributeSyntax.ArgumentList;
+        if (argumentList is null || argumentList.Arguments.Count == 0)
+            return null;
+
+        // The first positional argument is the source open generic interface.
+        var firstArgument = argumentList.Arguments.FirstOrDefault(a => a.NameEquals is null);
+        if (firstArgument?.Expression is TypeOfExpressionSyntax typeOfExpression)
+            return semanticModel.GetTypeInfo(typeOfExpression.Type).Type;
+
+        return null;
+    }
+
+    private static ITypeSymbol? GetAsServiceType(AttributeSyntax attributeSyntax, SemanticModel semanticModel)
+    {
+        var argumentList = attributeSyntax.ArgumentList;
+        if (argumentList is null)
+            return null;
+
+        var asArgument = argumentList.Arguments
+            .FirstOrDefault(a => a.NameEquals?.Name.Identifier.Text == "As");
+
+        if (asArgument?.Expression is TypeOfExpressionSyntax typeOfExpression)
+            return semanticModel.GetTypeInfo(typeOfExpression.Type).Type;
+
+        return null;
+    }
+
+    private static bool IsOpenGenericInterface(ITypeSymbol? typeSymbol, out string typeDescription)
+    {
+        if (typeSymbol is null)
+        {
+            typeDescription = "null";
+            return false;
+        }
+
+        if (typeSymbol is not INamedTypeSymbol namedType)
+        {
+            typeDescription = $"{typeSymbol.TypeKind}";
+            return false;
+        }
+
+        if (namedType.TypeKind != TypeKind.Interface)
+        {
+            typeDescription = $"{namedType.TypeKind} (not an interface)";
+            return false;
+        }
+
+        if (!namedType.IsGenericType)
+        {
+            typeDescription = "non-generic interface";
+            return false;
+        }
+
+        if (!namedType.IsUnboundGenericType &&
+            !namedType.TypeArguments.All(t => t.TypeKind == TypeKind.TypeParameter))
+        {
+            typeDescription = "closed generic interface (use typeof(IInterface<>) not typeof(IInterface<T>))";
+            return false;
+        }
+
+        typeDescription = "open generic interface";
+        return true;
+    }
+
+    private static bool ImplementsServiceType(INamedTypeSymbol classSymbol, ITypeSymbol serviceType)
+    {
+        if (serviceType.TypeKind == TypeKind.Interface)
+            return classSymbol.AllInterfaces.Any(i => SymbolEqualityComparer.Default.Equals(i, serviceType));
+
+        for (var baseType = classSymbol.BaseType; baseType is not null; baseType = baseType.BaseType)
+        {
+            if (SymbolEqualityComparer.Default.Equals(baseType, serviceType))
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/src/NexusLabs.Needlr.Generators/TypeRegistryGenerator.cs
+++ b/src/NexusLabs.Needlr.Generators/TypeRegistryGenerator.cs
@@ -69,6 +69,7 @@ public sealed class TypeRegistryGenerator : IIncrementalGenerator
                 discoveryResult.HttpClients.Count == 0 &&
                 discoveryResult.HostedServices.Count == 0 &&
                 discoveryResult.Providers.Count == 0 &&
+                discoveryResult.ComposedRegistrations.Count == 0 &&
                 discoveryResult.InaccessibleTypes.Count == 0 &&
                 discoveryResult.MissingTypeRegistryPlugins.Count == 0 &&
                 referencedAssemblies.Count == 0;
@@ -126,6 +127,18 @@ public sealed class TypeRegistryGenerator : IIncrementalGenerator
 
             // NDLRGEN022: Detect disposable captive dependencies using inferred lifetimes
             CaptiveDependencyAnalyzer.ReportDisposableCaptiveDependencies(spc, discoveryResult);
+
+            // NDLRGEN038: Report skipped composition registrations whose discovered type argument(s)
+            // violate the composition's generic constraints.
+            foreach (var violation in discoveryResult.ComposedConstraintViolations)
+            {
+                spc.ReportDiagnostic(Diagnostic.Create(
+                    DiagnosticDescriptors.ComposedTypeArgumentViolatesConstraints,
+                    Location.None,
+                    violation.CompositionTypeName,
+                    violation.TypeArgumentName,
+                    violation.SourceInterfaceName));
+            }
 
             var sourceText = GenerateTypeRegistrySource(discoveryResult, assemblyName, breadcrumbs, projectDirectory, isAotProject);
             spc.AddSource("TypeRegistry.g.cs", SourceText.From(sourceText, Encoding.UTF8));
@@ -361,6 +374,8 @@ public sealed class TypeRegistryGenerator : IIncrementalGenerator
         var pluginTypes = new List<DiscoveredPlugin>();
         var decorators = new List<DiscoveredDecorator>();
         var openDecorators = new List<DiscoveredOpenDecorator>();
+        var composedMarkers = new List<DiscoveredComposedMarker>();
+        var composedCandidateTypes = new List<INamedTypeSymbol>();
         var interceptedServices = new List<DiscoveredInterceptedService>();
         var factories = new List<DiscoveredFactory>();
         var options = new List<DiscoveredOptions>();
@@ -379,7 +394,7 @@ public sealed class TypeRegistryGenerator : IIncrementalGenerator
         // Collect types from the current compilation if includeSelf is true
         if (includeSelf)
         {
-            CollectTypesFromAssembly(compilation.Assembly, prefixList, excludePrefixList, injectableTypes, pluginTypes, decorators, openDecorators, interceptedServices, factories, options, hostedServices, providers, httpClients, inaccessibleTypes, compilation, isCurrentAssembly: true, generatedNamespace);
+            CollectTypesFromAssembly(compilation.Assembly, prefixList, excludePrefixList, injectableTypes, pluginTypes, decorators, openDecorators, interceptedServices, factories, options, hostedServices, providers, httpClients, inaccessibleTypes, composedMarkers, composedCandidateTypes, compilation, isCurrentAssembly: true, generatedNamespace);
         }
 
         // Collect types from all referenced assemblies
@@ -397,7 +412,7 @@ public sealed class TypeRegistryGenerator : IIncrementalGenerator
                 // For referenced assemblies, they use their own generated namespace
                 var refSafeAssemblyName = GeneratorHelpers.SanitizeIdentifier(assemblySymbol.Name);
                 var refGeneratedNamespace = $"{refSafeAssemblyName}.Generated";
-                CollectTypesFromAssembly(assemblySymbol, prefixList, excludePrefixList, injectableTypes, pluginTypes, decorators, openDecorators, interceptedServices, factories, options, hostedServices, providers, httpClients, inaccessibleTypes, compilation, isCurrentAssembly: false, refGeneratedNamespace);
+                CollectTypesFromAssembly(assemblySymbol, prefixList, excludePrefixList, injectableTypes, pluginTypes, decorators, openDecorators, interceptedServices, factories, options, hostedServices, providers, httpClients, inaccessibleTypes, composedMarkers, composedCandidateTypes, compilation, isCurrentAssembly: false, refGeneratedNamespace);
             }
         }
 
@@ -405,6 +420,18 @@ public sealed class TypeRegistryGenerator : IIncrementalGenerator
         if (openDecorators.Count > 0)
         {
             CodeGen.DecoratorsCodeGenerator.ExpandOpenDecorators(injectableTypes, openDecorators, decorators);
+        }
+
+        // Expand [RegisterClosedOverImplementationsOf] markers into closed composition registrations.
+        var composedRegistrations = new List<DiscoveredComposedRegistration>();
+        var composedConstraintViolations = new List<ComposedConstraintViolation>();
+        if (composedMarkers.Count > 0)
+        {
+            ComposedRegistrationDiscoveryHelper.Expand(
+                composedMarkers,
+                composedCandidateTypes,
+                composedRegistrations,
+                composedConstraintViolations);
         }
 
         // Filter out nested options types (types used as properties in other options types)
@@ -439,7 +466,7 @@ public sealed class TypeRegistryGenerator : IIncrementalGenerator
             }
         }
 
-        return new DiscoveryResult(injectableTypes, pluginTypes, decorators, inaccessibleTypes, missingTypeRegistryPlugins, interceptedServices, factories, options, hostedServices, providers, httpClients);
+        return new DiscoveryResult(injectableTypes, pluginTypes, decorators, inaccessibleTypes, missingTypeRegistryPlugins, interceptedServices, factories, options, hostedServices, providers, httpClients, composedRegistrations, composedConstraintViolations);
     }
 
     private static void CollectTypesFromAssembly(
@@ -457,6 +484,8 @@ public sealed class TypeRegistryGenerator : IIncrementalGenerator
         List<DiscoveredProvider> providers,
         List<DiscoveredHttpClient> httpClients,
         List<InaccessibleType> inaccessibleTypes,
+        List<DiscoveredComposedMarker> composedMarkers,
+        List<INamedTypeSymbol> composedCandidateTypes,
         Compilation compilation,
         bool isCurrentAssembly,
         string generatedNamespace)
@@ -623,6 +652,20 @@ public sealed class TypeRegistryGenerator : IIncrementalGenerator
                     sourceFilePath));
             }
 
+            // Check for RegisterClosedOverImplementationsOf attributes (source-gen only composition markers)
+            var composedMarkerInfos = ComposedRegistrationDiscoveryHelper.GetComposedMarkers(typeSymbol);
+            foreach (var composedMarkerInfo in composedMarkerInfos)
+            {
+                var sourceFilePath = typeSymbol.Locations.FirstOrDefault()?.SourceTree?.FilePath;
+                composedMarkers.Add(new DiscoveredComposedMarker(
+                    composedMarkerInfo.CompositionType,
+                    composedMarkerInfo.SourceOpenGenericInterface,
+                    composedMarkerInfo.AsServiceType,
+                    composedMarkerInfo.Lifetime,
+                    assembly.Name,
+                    sourceFilePath));
+            }
+
             // Check for Intercept attributes and collect intercepted services
             if (InterceptorDiscoveryHelper.HasInterceptAttributes(typeSymbol))
             {
@@ -705,6 +748,12 @@ public sealed class TypeRegistryGenerator : IIncrementalGenerator
                     var isDisposable = TypeDiscoveryHelper.IsDisposableType(typeSymbol);
 
                     injectableTypes.Add(new DiscoveredType(typeName, interfaceNames, assembly.Name, lifetime.Value, constructorParams, serviceKeys, sourceFilePath, sourceLine, isDisposable, interfaceInfos));
+
+                    // Every injectable type is a candidate implementation for [RegisterClosedOverImplementationsOf]
+                    // expansion. Tying collection to the injectable-registration site means a composition composes
+                    // over exactly the set Needlr registers — current assembly plus referenced libraries — so
+                    // cross-assembly definitions are handled the same way decorators expand over injectable types.
+                    composedCandidateTypes.Add(typeSymbol);
                 }
             }
 
@@ -824,7 +873,13 @@ public sealed class TypeRegistryGenerator : IIncrementalGenerator
         }
 
         builder.AppendLine();
-        CodeGen.DecoratorsCodeGenerator.GenerateApplyDecoratorsMethod(builder, discoveryResult.Decorators, discoveryResult.InterceptedServices.Count > 0, discoveryResult.HostedServices.Count > 0, safeAssemblyName, breadcrumbs, projectDirectory);
+        CodeGen.DecoratorsCodeGenerator.GenerateApplyDecoratorsMethod(builder, discoveryResult.Decorators, discoveryResult.InterceptedServices.Count > 0, discoveryResult.HostedServices.Count > 0, discoveryResult.ComposedRegistrations.Count > 0, safeAssemblyName, breadcrumbs, projectDirectory);
+
+        if (discoveryResult.ComposedRegistrations.Count > 0)
+        {
+            builder.AppendLine();
+            CodeGen.ComposedRegistrationsCodeGenerator.GenerateRegisterComposedTypesMethod(builder, discoveryResult.ComposedRegistrations, breadcrumbs, projectDirectory);
+        }
 
         if (discoveryResult.HostedServices.Count > 0)
         {

--- a/src/NexusLabs.Needlr.IntegrationTests/SourceGen/RegisterClosedOverImplementationsOfSourceGenTests.cs
+++ b/src/NexusLabs.Needlr.IntegrationTests/SourceGen/RegisterClosedOverImplementationsOfSourceGenTests.cs
@@ -1,0 +1,139 @@
+using Microsoft.Extensions.DependencyInjection;
+
+using NexusLabs.Needlr.Generators;
+using NexusLabs.Needlr.Injection;
+using NexusLabs.Needlr.Injection.SourceGen;
+
+using Xunit;
+
+namespace NexusLabs.Needlr.IntegrationTests.SourceGen;
+
+/// <summary>
+/// Integration tests for [RegisterClosedOverImplementationsOf] using source-generated discovery.
+/// The generator runs at build time over this assembly; these tests build a real Syringe service
+/// provider and verify that one closed composition is registered per discovered definition, exposed
+/// as the facade, with constructor dependencies resolved from DI.
+/// </summary>
+public sealed class RegisterClosedOverImplementationsOfSourceGenTests
+{
+    private static IServiceProvider BuildProvider() =>
+        new Syringe()
+            .UsingSourceGen()
+            .UsingPostPluginRegistrationCallback(services =>
+                services.AddSingleton(typeof(IShapeStore<>), typeof(DefaultShapeStore<>)))
+            .BuildServiceProvider();
+
+    [Fact]
+    public void Composition_RegistersOneClosedCompositionPerDiscoveredDefinition()
+    {
+        var provider = BuildProvider();
+
+        var shapes = provider.GetServices<IShape>().ToList();
+
+        Assert.Equal(2, shapes.Count);
+        Assert.Contains(shapes, s => s.Name == "circle");
+        Assert.Contains(shapes, s => s.Name == "square");
+    }
+
+    [Fact]
+    public void Composition_ResolvesConstructorDependenciesClosedOverTypeArgument()
+    {
+        var provider = BuildProvider();
+
+        var shapes = provider.GetServices<IShape>().ToList();
+
+        // Each facade is a closed composition (not a definition), and resolution succeeding proves each
+        // composition received its definition and store closed over the same type argument.
+        Assert.All(shapes, s => Assert.Equal(typeof(ShapeCore<>), s.GetType().GetGenericTypeDefinition()));
+    }
+
+    [Fact]
+    public void Composition_EnumerationRoutesByDiscriminatorWithoutKnowingTypeArgument()
+    {
+        var provider = BuildProvider();
+
+        var router = new ShapeRouter(provider.GetServices<IShape>());
+
+        Assert.Equal("square", router.Resolve("square").Name);
+    }
+}
+
+/// <summary>Definition contract auto-discovered and registered by Needlr per closed type argument.</summary>
+public interface IShapeDefinition<TData>
+    where TData : class
+{
+    string Name { get; }
+}
+
+/// <summary>Per-type-argument store, registered as an open generic by a plugin/callback.</summary>
+public interface IShapeStore<TData>
+    where TData : class
+{
+}
+
+/// <summary>Default open-generic store implementation.</summary>
+public sealed class DefaultShapeStore<TData> : IShapeStore<TData>
+    where TData : class
+{
+}
+
+/// <summary>Non-generic facade the rest of the system consumes as IEnumerable&lt;IShape&gt;.</summary>
+public interface IShape
+{
+    string Name { get; }
+}
+
+/// <summary>Marker data type for the circle definition.</summary>
+public sealed class CircleData
+{
+}
+
+/// <summary>Marker data type for the square definition.</summary>
+public sealed class SquareData
+{
+}
+
+/// <summary>Concrete, unattributed definition auto-registered as IShapeDefinition&lt;CircleData&gt;.</summary>
+public sealed class CircleDefinition : IShapeDefinition<CircleData>
+{
+    public string Name => "circle";
+}
+
+/// <summary>Concrete, unattributed definition auto-registered as IShapeDefinition&lt;SquareData&gt;.</summary>
+public sealed class SquareDefinition : IShapeDefinition<SquareData>
+{
+    public string Name => "square";
+}
+
+/// <summary>
+/// Reusable composition closed per discovered TData and exposed as IShape. Composed from a definition
+/// and a per-type store with no inheritance. Not auto-registered (open generic); the generator closes
+/// and registers it once per discovered IShapeDefinition&lt;&gt; implementation.
+/// </summary>
+[RegisterClosedOverImplementationsOf(typeof(IShapeDefinition<>), As = typeof(IShape))]
+public sealed class ShapeCore<TData> : IShape
+    where TData : class
+{
+    private readonly IShapeDefinition<TData> _definition;
+
+    public ShapeCore(IShapeDefinition<TData> definition, IShapeStore<TData> store)
+    {
+        _definition = definition;
+        _ = store;
+    }
+
+    public string Name => _definition.Name;
+}
+
+/// <summary>Consumer that routes over the facade enumeration without knowing any TData.</summary>
+public sealed class ShapeRouter
+{
+    private readonly IEnumerable<IShape> _shapes;
+
+    public ShapeRouter(IEnumerable<IShape> shapes)
+    {
+        _shapes = shapes;
+    }
+
+    public IShape Resolve(string name) => _shapes.Single(s => s.Name == name);
+}


### PR DESCRIPTION
## Summary

Adds `[RegisterClosedOverImplementationsOf]` — a **source-generation-only** marker on an open generic *composition* type. For **each** discovered concrete closed implementation of a designated open generic interface, the generator closes the composition over the *same* type argument(s) and registers it as a designated **facade** service type, resolving the composition's constructor dependencies from DI.

This keeps the "compose-and-expose" pattern — a growing set of typed definitions exposed behind a uniform non-generic facade (`IEnumerable<IFacade>`) — on the source-gen path instead of a hand-maintained per-type registration list (which silently drifts) or runtime reflection (AOT/trimming hostile). It is a sibling to the existing `[OpenDecoratorFor]`.

## Before / After

```csharp
// BEFORE — one hand-maintained line per TData; add a definition and forget the line ⇒ silent runtime absence.
internal sealed class BlocksPlugin : IServiceCollectionPlugin
{
    public void Configure(ServiceCollectionPluginOptions options)
    {
        options.Services.AddSingleton(typeof(IBlockInstanceStore<>), typeof(DefaultBlockInstanceStore<>));
        AddBlockType<VideoBlockData>(options);
        AddBlockType<LeadBlockData>(options);
        // ...one per TData, forever
    }

    private static void AddBlockType<TData>(ServiceCollectionPluginOptions options) where TData : class =>
        options.Services.AddSingleton<IBlockType>(sp => new BlockTypeCore<TData>(
            sp.GetRequiredService<IBlockTypeDefinition<TData>>(),
            sp.GetRequiredService<IBlockInstanceStore<TData>>()));
}

// AFTER — one marker; the per-TData list is deleted. Adding a definition auto-wires.
[RegisterClosedOverImplementationsOf(typeof(IBlockTypeDefinition<>), As = typeof(IBlockType))]
public sealed class BlockTypeCore<TData> : IBlockType where TData : class { /* unchanged */ }

internal sealed class BlocksPlugin : IServiceCollectionPlugin
{
    public void Configure(ServiceCollectionPluginOptions options) =>
        options.Services.AddSingleton(typeof(IBlockInstanceStore<>), typeof(DefaultBlockInstanceStore<>));
}
```

The generator emits one `services.AddSingleton<IBlockType>(sp => new BlockTypeCore<TData>(...))` per discovered definition, resolving each constructor parameter (incl. `[FromKeyedServices]`) closed over the same `TData`.

## What's included (all per-feature layers)

- **Attribute** — `RegisterClosedOverImplementationsOfAttribute` (`As`, `Lifetime`; `AllowMultiple = true`), reusing `InjectableLifetime`.
- **Discovery + models + codegen** — symbol-accurate closing via Roslyn `Construct`; emits a `RegisterComposedTypes` method called from the always-run `ApplyDecorators` (no bootstrap-plumbing changes).
- **Analyzer + diagnostics** — `NDLRGEN035` (source must be open generic interface), `NDLRGEN036` (composition arity), `NDLRGEN037` (composition must specify + implement `As`), and generator-emitted `NDLRGEN038` (a discovered type argument that violates the composition's constraints is **skipped** instead of emitting non-compiling code).
- **Tests** — generator unit tests (11), analyzer tests (9), integration tests (3, real `Syringe` resolving `IEnumerable<facade>`). Red→green demonstrated for the generator and analyzer.
- **Example** — `AotSourceGenConsoleApp` demo prints the composed registrations.
- **Docs** — feature page + four per-diagnostic pages + nav/tables; `mkdocs build --strict` passes.

## Cross-assembly behavior

Candidate definitions are tied to the injectable-registration site, so a composition spans **the current assembly + referenced plain libraries** — the same set `[OpenDecoratorFor]` expands over. A referenced assembly compiled with its **own** `[GenerateTypeRegistry]` self-registers and is force-loaded (not re-scanned), so a marker in assembly A doesn't reach definitions baked into such an assembly B — identical to how auto-registration and decorators already behave.

## Design boundaries (agreed)

- The `NDLRGEN038` constraint check is only *reachable* when the composition's constraints are stricter than the source interface's; with equal constraints it's a latent safety net.
- Missing **transitive** dependencies (e.g. an open-generic store registered in a plugin, or `ILogger<>`) are not statically provable and still throw at runtime — no regression vs. a hand-written factory.

## Known MEDIUM items (non-blocking)

- Greedy constructor selection (no diagnostic if a composition has multiple public constructors).
- Constraint checker is conservative for self-referential constraints (`where T : IComparable<T>`) and does not check `notnull` — those degrade to a raw C# compile error rather than `NDLRGEN038`.
- Multi-arity assumes positional source-arg → composition-type-param mapping.

## Test evidence (local)

- Generators.Tests: **602/602**
- IntegrationTests: **476/476**
- Example app runs; `mkdocs build --strict` clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
