### PR TITLE
ci: exclude versioned API archives from Cloudflare mirror

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,13 +215,21 @@ jobs:
         ref: gh-pages
         path: gh-pages-mirror
 
+    # Cloudflare Pages allows at most 20,000 files per deployment; the
+    # per-version API doc archives under api/v* exceed that on their own, so
+    # they are excluded from this deploy (versions.json is preserved).
+    # Removing the checkout's .git also keeps git internals out of the upload.
+    - name: Trim mirror before Cloudflare deploy
+      if: success() && github.ref == 'refs/heads/main' && github.event_name == 'push'
+      run: rm -rf gh-pages-mirror/.git gh-pages-mirror/api/v[0-9]*
+
     - name: Deploy Documentation to Cloudflare Pages
       if: success() && github.ref == 'refs/heads/main' && github.event_name == 'push'
       uses: cloudflare/wrangler-action@v4
       with:
         apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        command: pages deploy gh-pages-mirror --project-name=needlr --branch=main
+        command: pages deploy gh-pages-mirror --project-name=needlr --branch=main --commit-dirty=true
 
   package-validation:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -257,12 +257,19 @@ jobs:
         ref: gh-pages
         path: gh-pages-mirror
 
+    # Cloudflare Pages allows at most 20,000 files per deployment; the
+    # per-version API doc archives under api/v* exceed that on their own, so
+    # they are excluded from this deploy (versions.json is preserved).
+    # Removing the checkout's .git also keeps git internals out of the upload.
+    - name: Trim mirror before Cloudflare deploy
+      run: rm -rf gh-pages-mirror/.git gh-pages-mirror/api/v[0-9]*
+
     - name: Deploy Documentation to Cloudflare Pages
       uses: cloudflare/wrangler-action@v4
       with:
         apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        command: pages deploy gh-pages-mirror --project-name=needlr --branch=main
+        command: pages deploy gh-pages-mirror --project-name=needlr --branch=main --commit-dirty=true
 
     # NOTE: the "Commit Stable API Docs to Main" step that used to live
     # after Deploy Documentation has been deleted. It tried to commit


### PR DESCRIPTION
The Cloudflare mirror deploy hit Cloudflare Pages' 20,000-file-per-deployment limit (gh-pages holds ~24.6k files; the api/v* per-version archives are ~22k of them). Trims api/v* and the mirror's .git before deploying, leaving ~2.6k files including api/dev, api/stable, and versions.json.

Verified end-to-end locally: deployed 2635 files to the needlr Pages project successfully; api/dev, api/stable, and versions.json all serve 200.