### PR TITLE
ci: host newest 20 API version archives on the canonical site

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,13 +215,13 @@ jobs:
         ref: gh-pages
         path: gh-pages-mirror
 
-    # Cloudflare Pages allows at most 20,000 files per deployment; the
-    # per-version API doc archives under api/v* exceed that on their own, so
-    # they are excluded from this deploy (versions.json is preserved).
-    # Removing the checkout's .git also keeps git internals out of the upload.
+    # Cloudflare Pages allows at most 20,000 files per deployment. Keep only
+    # the newest API version archives (and rewrite versions.json to match);
+    # older archives stay in gh-pages history but are not published here.
+    # Also removes the checkout's .git so it is not uploaded.
     - name: Trim mirror before Cloudflare deploy
       if: success() && github.ref == 'refs/heads/main' && github.event_name == 'push'
-      run: rm -rf gh-pages-mirror/.git gh-pages-mirror/api/v[0-9]*
+      run: python scripts/trim-cloudflare-mirror.py gh-pages-mirror --keep 20
 
     - name: Deploy Documentation to Cloudflare Pages
       if: success() && github.ref == 'refs/heads/main' && github.event_name == 'push'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -251,12 +251,12 @@ jobs:
         ref: gh-pages
         path: gh-pages-mirror
 
-    # Cloudflare Pages allows at most 20,000 files per deployment; the
-    # per-version API doc archives under api/v* exceed that on their own, so
-    # they are excluded from this deploy (versions.json is preserved).
-    # Removing the checkout's .git also keeps git internals out of the upload.
+    # Cloudflare Pages allows at most 20,000 files per deployment. Keep only
+    # the newest API version archives (and rewrite versions.json to match);
+    # older archives stay in gh-pages history but are not published here.
+    # Also removes the checkout's .git so it is not uploaded.
     - name: Trim mirror before Cloudflare deploy
-      run: rm -rf gh-pages-mirror/.git gh-pages-mirror/api/v[0-9]*
+      run: python scripts/trim-cloudflare-mirror.py gh-pages-mirror --keep 20
 
     - name: Deploy Documentation to Cloudflare Pages
       uses: cloudflare/wrangler-action@v4

--- a/docs/javascripts/api-version-switcher.js
+++ b/docs/javascripts/api-version-switcher.js
@@ -22,11 +22,6 @@
 
     const ALREADY_RENDERED_ID = 'needlr-api-version-switcher';
     const API_SEGMENT = '/api/';
-    // Immutable per-version API snapshots (v0.0.x-alpha.N) are served only from
-    // GitHub Pages; the canonical docs host excludes them due to a per-deploy
-    // file-count limit. Selecting one from the canonical site must therefore
-    // jump to this base. dev/stable live on the canonical host.
-    const ARCHIVE_API_BASE = 'https://github.devleader.ca/needlr/api/';
 
     function init() {
         const path = window.location.pathname;
@@ -99,12 +94,8 @@
         }
 
         select.addEventListener('change', function () {
-            // Archived snapshots live only on GitHub Pages, so route to them
-            // there regardless of which host the switcher is rendered on;
-            // dev/stable resolve against the current apiRoot (canonical host).
-            const isArchived = /^v\d/.test(this.value);
-            const base = isArchived ? ARCHIVE_API_BASE : apiRoot;
-            window.location.href = base + this.value + '/' + tail;
+            const target = apiRoot + this.value + '/' + tail;
+            window.location.href = target;
         });
 
         container.appendChild(label);

--- a/scripts/trim-cloudflare-mirror.py
+++ b/scripts/trim-cloudflare-mirror.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Trim the gh-pages mirror before deploying it to the canonical (Cloudflare)
+host, which enforces a per-deployment file-count limit.
+
+The per-version API doc archives under api/v* are numerous (hundreds of files
+each) and would exceed the limit if all were included. This keeps only the
+newest N archives and rewrites api/versions.json so the version switcher only
+offers versions that are actually hosted. Older archives remain in the
+gh-pages branch history; they are simply not published to the canonical host
+(the projects-router redirects their URLs to stable).
+
+Version entries in versions.json are ordered newest-first by the generator, so
+"newest N" is just the first N version entries — no version parsing required.
+
+Usage:
+    python scripts/trim-cloudflare-mirror.py <mirror-dir> [--keep N]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from pathlib import Path
+
+
+def is_version_name(name: str) -> bool:
+    """True for archive directory/entry names like 'v0.0.2-alpha.66'."""
+    return len(name) >= 2 and name[0] == 'v' and name[1].isdigit()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('mirror_dir', type=Path, help='Path to the gh-pages mirror checkout')
+    parser.add_argument('--keep', type=int, default=20,
+                        help='Number of newest api/v* archives to keep (default: 20)')
+    args = parser.parse_args()
+
+    mirror: Path = args.mirror_dir
+    if not mirror.is_dir():
+        print(f'error: {mirror} is not a directory', file=sys.stderr)
+        return 1
+
+    # Drop the checkout's git metadata so it is not uploaded to the host.
+    git_dir = mirror / '.git'
+    if git_dir.exists():
+        shutil.rmtree(git_dir)
+
+    api_dir = mirror / 'api'
+    versions_file = api_dir / 'versions.json'
+
+    keep_paths: set[str] = set()
+    if versions_file.is_file():
+        data = json.loads(versions_file.read_text(encoding='utf-8'))
+        entries = data.get('entries', [])
+
+        kept_count = 0
+        new_entries = []
+        for entry in entries:
+            path = str(entry.get('path', ''))
+            if not entry.get('separator') and is_version_name(path):
+                if kept_count < args.keep:
+                    new_entries.append(entry)
+                    keep_paths.add(path)
+                    kept_count += 1
+            else:
+                new_entries.append(entry)
+
+        # Avoid a dangling separator left above an emptied version list.
+        while new_entries and new_entries[-1].get('separator'):
+            new_entries.pop()
+
+        data['entries'] = new_entries
+        versions_file.write_text(json.dumps(data, indent=2) + '\n', encoding='utf-8')
+    else:
+        print(f'warn: {versions_file} not found; removing all api/v* archives', file=sys.stderr)
+
+    removed = 0
+    if api_dir.is_dir():
+        for child in api_dir.iterdir():
+            if child.is_dir() and is_version_name(child.name) and child.name not in keep_paths:
+                shutil.rmtree(child)
+                removed += 1
+
+    print(f'Kept {len(keep_paths)} version archive(s); removed {removed} older archive dir(s).')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
Replaces the mirror trim that dropped all api/v* archives with one that keeps the newest 20 (~14.3k files, under the 20k-per-deployment limit) and rewrites api/versions.json to match, so the switcher only offers hosted versions. Older archives remain in gh-pages history. Reverts the switcher to relative navigation now that archives live on the canonical host.

Verified locally: trim keeps exactly 20 newest dirs + consistent versions.json (14288 files); a test deploy served kept archives (alpha.66/55/46) 200 and dropped ones (alpha.45/19) 404.