### PR TITLE
fix(langfuse): harden lifecycle, cancellation, and trace context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## [Unreleased]
 
+### Added
+
+- **`NexusLabs.Needlr.AgentFramework.Langfuse` now exposes bounded final shutdown for standalone sessions.** `ILangfuseSession.Shutdown(timeout)` shares one timeout budget across trace and metric providers, returns a structured `LangfuseShutdownOutcome`, releases all owned resources, and is idempotent across repeated callers. `LangfuseOptions.ShutdownTimeout` controls the bounded best-effort shutdown performed by `Dispose()` and defaults to five seconds; `Timeout.InfiniteTimeSpan` remains available as an explicit opt-in. The result describes local OpenTelemetry provider drain only and does not claim durable Langfuse ingestion. (#29)
+
+### Fixed
+
+- **Standalone Langfuse session disposal can no longer block indefinitely by default.** Disposal previously performed an unbounded `ForceFlush` before releasing the OpenTelemetry providers and HTTP resources. It now performs final provider shutdown within the configured timeout and releases resources even when the drain is incomplete. Enabled-session tests cover successful, timed-out, repeated, concurrent, and explicit-infinite shutdown. (#29)
+- **Caller cancellation now propagates through every Langfuse REST publication path.** `LangfuseApiClient` and `LangfuseScoreApiClient` no longer translate caller-requested cancellation into `LangfuseException`; nonfatal score, comment, and experiment-link policies therefore cannot swallow cancellation. Cancelling an experiment-item link also disposes the scenario activity before propagating the exception. Transport timeouts remain Langfuse failures. (#30)
+- **Langfuse span enrichment no longer exports arbitrary inherited OpenTelemetry baggage.** Needlr now propagates only the supported trace name, tags, metadata, version, session id, user id, and internal prompt-link context to in-process child spans without placing scenario data in W3C baggage. This is a privacy-hardening behavior change for consumers that relied on unrelated baggage becoming Langfuse attributes; pass filterable values through the scenario's explicit context APIs instead. Parallel and nested propagation, distinct scenario trace IDs, sensitive-baggage exclusion, and ambient-context restoration are covered by regression tests and the no-server conformance example. (#31)
+
 ## [0.0.2-alpha.66] - 2026-06-26
 
 ### Added

--- a/docs/langfuse.md
+++ b/docs/langfuse.md
@@ -17,8 +17,8 @@ Install the package and start a session from environment variables:
 ```bash
 export LANGFUSE_PUBLIC_KEY="pk-lf-..."
 export LANGFUSE_SECRET_KEY="sk-lf-..."
-# Optional — defaults to Langfuse Cloud (EU). Set for self-hosted or other regions:
-# export LANGFUSE_HOST="http://localhost:3000"
+# Required unless Region is configured in code:
+export LANGFUSE_HOST="http://localhost:3000"
 ```
 
 ```csharp
@@ -45,12 +45,27 @@ using (var scenario = langfuse.BeginScenario(
     await result.RecordLangfuseScoresAsync(scenario);
 }
 
-langfuse.Flush();
+var shutdown = langfuse.Shutdown(TimeSpan.FromSeconds(5));
+Console.WriteLine($"traces={shutdown.Traces}, metrics={shutdown.Metrics}");
 ```
 
 That is the entire integration. When `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY`
 are not set (or no `Host`/`Region` target is chosen), the session is disabled and
 every call becomes a no-op, so the same code runs unchanged in credential-less CI.
+
+### Flush versus final shutdown
+
+`Flush(timeout)` asks the active session to export telemetry buffered before the call and
+keeps the session open. Use an explicit timeout when flushing before read-back operations.
+
+`Shutdown(timeout)` is final: it shares one timeout budget across trace and metric providers,
+releases every resource owned by the standalone session, and rejects new session operations.
+It returns a `LangfuseShutdownOutcome` with separate trace and metric statuses. Those statuses
+describe the local OpenTelemetry drain only—they do **not** guarantee durable Langfuse ingestion.
+
+`Dispose()` performs the same final shutdown with `LangfuseOptions.ShutdownTimeout`, which
+defaults to five seconds. Set `Timeout.InfiniteTimeSpan` only when an unbounded process-exit wait
+is explicitly required.
 
 ### Even shorter: evaluate and record in one call
 
@@ -116,6 +131,9 @@ verdict, so a transient Langfuse outage must not turn a green eval red. By defau
 and invokes `ScoreErrorCallback` (wire it to your logger) but does **not** throw. Set
 `ScoreFailureMode.Strict` if a missing score should hard-fail the caller.
 
+Caller-requested cancellation is never converted into a non-fatal score or publication
+failure. An `OperationCanceledException` propagates so a cancelled evaluation stops promptly.
+
 ```csharp
 var options = LangfuseOptions.FromEnvironment();
 options.ScoreErrorCallback = e => logger.LogWarning(e.Exception, "Langfuse score {Name} not recorded", e.ScoreName);
@@ -137,12 +155,12 @@ depend on implicit inference:
   provider/SDK model names such as Copilot's will not match Langfuse's built-in table,
   so `costDetails` stays empty until you add a custom model definition.)
 
-!!! note "Trace-level filtering is by trace, not by observation"
-    Trace-level attributes (`name`, `tags`, `metadata`) are set on the scenario root span,
-    which is what Langfuse uses to build the trace. `session.id` and `user.id` are also
-    propagated to child spans (via baggage) so you can filter observations by them. Filtering
-    individual *observations* by `tags`/`metadata` is not supported — those live at the trace
-    level, which matches the per-scenario grouping model.
+!!! note "Trace context is propagated through an allowlist"
+    Needlr propagates the scenario name, tags, metadata, version, session id, and user id to
+    in-process child spans so Langfuse can filter and aggregate observations reliably. Scenario
+    context is not stored in W3C baggage, and arbitrary inherited OpenTelemetry baggage is **not**
+    copied into exported span attributes. This prevents unrelated, sensitive, or high-cardinality
+    application context from being sent to Langfuse or downstream services accidentally.
 
 ## Experiments (datasets and runs)
 
@@ -370,6 +388,7 @@ the `gen_ai.client.token.usage` histogram.
 | `NormalizeScoreNames` | `false` | When `true`, score names are normalised to `snake_case` for consistent dashboard filtering. |
 | `DiagnosticsCallback` | _(none)_ | Receives library diagnostic messages (e.g. the "no export target" warning). Wire to your logger. |
 | `SamplingRatio` | `1.0` | Head-based trace sampling ratio (eval workloads want `1.0`). |
+| `ShutdownTimeout` | `5 seconds` | Total trace + metric timeout budget used by standalone-session disposal. |
 | `AgentActivitySourceName` | `NexusLabs.Needlr.AgentFramework` | Needlr agent span source to export. |
 | `GenAiMeterName` | `Experimental.Microsoft.Extensions.AI` | Meter owning `gen_ai.client.token.usage`. |
 | `AdditionalActivitySources` / `AdditionalMeters` | _(empty)_ | Extra sources/meters to export. |

--- a/src/Examples/AgentFramework/LangfuseConformanceApp/Program.cs
+++ b/src/Examples/AgentFramework/LangfuseConformanceApp/Program.cs
@@ -23,13 +23,14 @@
 //
 // ── RESILIENCY MODE (no server required) ─────────────────────────────────────
 // Run with the argument `resiliency` to prove the opposite case: that an eval
-// still PASSES when Langfuse is unreachable. It points the exporter + score
-// client at a dead port, runs a scenario, and asserts the run completes (exit 0)
-// while every dropped score is surfaced via ScoresFailed + ScoreErrorCallback:
+// still PASSES when Langfuse is unreachable. It proves cancellation propagates,
+// unrelated baggage is not exported, final shutdown is bounded, and every failed
+// score is surfaced via ScoresFailed + ScoreErrorCallback:
 //
 //     dotnet run --project src/Examples/AgentFramework/LangfuseConformanceApp -- resiliency
 // =============================================================================
 
+using System.Diagnostics;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
@@ -54,8 +55,7 @@ Console.WriteLine();
 
 // Two modes:
 //   (default)      live read-back conformance — requires a running Langfuse.
-//   "resiliency"   Langfuse-down resiliency — points at a dead port, needs NO server,
-//                  and proves an eval still passes when score uploads fail.
+//   "resiliency"   Langfuse-down lifecycle and resiliency checks — needs NO server.
 if (args.Length > 0 && string.Equals(args[0], "resiliency", StringComparison.OrdinalIgnoreCase))
 {
     return await RunResiliencyCheckAsync();
@@ -251,10 +251,9 @@ if (passed)
 Console.WriteLine("CONFORMANCE FAILED — see above. (Increase the poll window if your instance is slow.)");
 return 1;
 
-// ── Resiliency mode: prove an eval survives Langfuse being unreachable ───────
-// Points the exporter and score client at a dead local port (no server needed),
-// runs a real scenario, and asserts the eval completes (exit 0) while the score
-// failures are surfaced via ScoresFailed + ScoreErrorCallback (never swallowed).
+// ── Resiliency mode: prove safe behavior when Langfuse is unreachable ────────
+// Exercises cancellation, trace-context propagation, score failure reporting,
+// and bounded final shutdown against a dead local port (no server required).
 static async Task<int> RunResiliencyCheckAsync()
 {
     Console.WriteLine("[mode] Resiliency: simulating Langfuse DOWN (dead port, no server required).");
@@ -272,6 +271,8 @@ static async Task<int> RunResiliencyCheckAsync()
         ScoreFailureMode = LangfuseScoreFailureMode.NonFatal,
         ScoreErrorCallback = _ => Interlocked.Increment(ref callbackFired),
     };
+    using var contextProbeSource = new ActivitySource("Needlr.Langfuse.Conformance.ContextProbe");
+    options.AdditionalActivitySources.Add(contextProbeSource.Name);
 
     var serviceProvider = new Syringe()
         .UsingReflection()
@@ -290,9 +291,50 @@ static async Task<int> RunResiliencyCheckAsync()
         return 1;
     }
 
-    var recordedScores = 0;
-    using (var scenario = langfuse.BeginScenario("resiliency: cached-summary", sessionId: "resiliency-run", tags: ["resiliency"]))
+    var cancellationPropagated = false;
+    using (var cancellation = new CancellationTokenSource())
     {
+        cancellation.Cancel();
+        try
+        {
+            await langfuse.Datasets.EnsureDatasetAsync("cancelled-operation", cancellationToken: cancellation.Token);
+        }
+        catch (OperationCanceledException exception) when (exception.CancellationToken == cancellation.Token)
+        {
+            cancellationPropagated = true;
+        }
+    }
+
+    var recordedScores = 0;
+    var contextPropagationSafe = false;
+    using (var externalContext = new Activity("resiliency-parent").Start())
+    {
+        externalContext.SetBaggage("authorization", "must-not-export");
+        using var scenario = langfuse.BeginScenario(
+            "resiliency: cached-summary",
+            sessionId: "resiliency-run",
+            userId: "resiliency-user",
+            tags: ["resiliency", "offline"],
+            metadata: new Dictionary<string, string> { ["suite"] = "conformance" });
+        scenario.SetVersion("resiliency-v1");
+
+        using var contextProbe = contextProbeSource.StartActivity("context-probe");
+        if (contextProbe is null)
+        {
+            Console.WriteLine("[error] Context probe activity was not sampled.");
+            return 1;
+        }
+
+        contextPropagationSafe =
+            Equals(contextProbe.GetTagItem("langfuse.trace.name"), "resiliency: cached-summary") &&
+            Equals(contextProbe.GetTagItem("session.id"), "resiliency-run") &&
+            Equals(contextProbe.GetTagItem("user.id"), "resiliency-user") &&
+            Equals(contextProbe.GetTagItem("langfuse.version"), "resiliency-v1") &&
+            Equals(contextProbe.GetTagItem("langfuse.trace.metadata.suite"), "conformance") &&
+            contextProbe.GetTagItem("langfuse.trace.tags") is string[] tags &&
+            tags.SequenceEqual(["resiliency", "offline"]) &&
+            contextProbe.GetTagItem("authorization") is null;
+
         var loopOptions = new IterativeLoopOptions
         {
             Instructions = "You summarise cached prompt content.",
@@ -329,25 +371,38 @@ static async Task<int> RunResiliencyCheckAsync()
         recordedScores = results.SelectMany(r => r.Metrics.Values).Count(HasValue);
     }
 
-    langfuse.Flush(TimeSpan.FromSeconds(2));
+    var shutdownTimeout = TimeSpan.FromSeconds(2);
+    var shutdownStopwatch = Stopwatch.StartNew();
+    var shutdown = langfuse.Shutdown(shutdownTimeout);
+    shutdownStopwatch.Stop();
+    var shutdownBounded =
+        shutdownStopwatch.Elapsed <= shutdownTimeout + TimeSpan.FromSeconds(3);
 
-    // The eval reached this point without throwing — that alone proves NonFatal worked.
-    // The failures must still be surfaced (not silently swallowed): counter + callback.
     var resilient =
+        cancellationPropagated &&
+        contextPropagationSafe &&
         recordedScores > 0 &&
         langfuse.ScoresFailed == recordedScores &&
-        callbackFired == recordedScores;
+        callbackFired == recordedScores &&
+        shutdown.IsFinal &&
+        shutdownBounded &&
+        shutdown.Metrics == LangfuseProviderShutdownStatus.NotConfigured;
 
     Console.WriteLine();
+    Console.WriteLine($"  caller cancellation:       {(cancellationPropagated ? "propagated" : "FAILED")}");
+    Console.WriteLine($"  trace context allowlist:   {(contextPropagationSafe ? "safe" : "FAILED")}");
     Console.WriteLine($"  scores attempted:          {recordedScores}");
     Console.WriteLine($"  ScoresFailed (session):    {langfuse.ScoresFailed}");
     Console.WriteLine($"  ScoreErrorCallback fired:  {callbackFired}");
+    Console.WriteLine($"  trace shutdown:            {shutdown.Traces}");
+    Console.WriteLine($"  metric shutdown:           {shutdown.Metrics}");
+    Console.WriteLine($"  shutdown elapsed:          {shutdownStopwatch.Elapsed.TotalMilliseconds:F0} ms");
     Console.WriteLine();
 
     if (resilient)
     {
-        Console.WriteLine("RESILIENCY PASSED — the eval completed despite Langfuse being down,");
-        Console.WriteLine("and every dropped score was surfaced (counter + callback), not swallowed.");
+        Console.WriteLine("RESILIENCY PASSED — cancellation propagated, trace context was safely");
+        Console.WriteLine("allowlisted, score failures were surfaced, and final shutdown was bounded.");
         return 0;
     }
 

--- a/src/Examples/AgentFramework/LangfuseEvaluationApp/Program.cs
+++ b/src/Examples/AgentFramework/LangfuseEvaluationApp/Program.cs
@@ -4,10 +4,11 @@
 // Demonstrates how little code it takes to send Needlr agent telemetry AND
 // Microsoft.Extensions.AI.Evaluation scores to Langfuse.
 //
-// The Langfuse integration is just three calls:
+// The Langfuse integration is four calls:
 //   1. LangfuseTelemetry.Start(...)        -> exports gen_ai traces/metrics
 //   2. session.BeginScenario(...)          -> one Langfuse trace per eval scenario
 //   3. scenario.RecordEvaluationAsync(...) -> evaluator metrics become Langfuse scores
+//   4. session.Shutdown(...)                -> bounded final drain + resource release
 //
 // Everything else here is an ordinary Needlr agent run + evaluation. A mock
 // chat client is used so the example runs with no LLM credentials, and the
@@ -143,8 +144,9 @@ using (var scenario = langfuse.BeginScenario(
     }
 }
 
-// Scenario disposed (root span ended); flush so the completed trace is exported.
-langfuse.Flush();
+// Scenario disposed (root span ended); perform one bounded final drain.
+var shutdown = langfuse.Shutdown(langfuseOptions.ShutdownTimeout);
+Console.WriteLine($"[langfuse] Shutdown: traces={shutdown.Traces}, metrics={shutdown.Metrics}");
 
 Console.WriteLine();
 Console.WriteLine("Done. With credentials set, open Langfuse and find the trace named");

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/ControlledExporter.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/ControlledExporter.cs
@@ -1,0 +1,68 @@
+using OpenTelemetry;
+
+namespace NexusLabs.Needlr.AgentFramework.Langfuse.Tests;
+
+/// <summary>
+/// OpenTelemetry exporter boundary helper with deterministic shutdown coordination.
+/// </summary>
+internal sealed class ControlledExporter<T> : BaseExporter<T>
+    where T : class
+{
+    private readonly ManualResetEventSlim _shutdownEntered = new(initialState: false);
+    private readonly ManualResetEventSlim _shutdownRelease = new(initialState: true);
+    private int _disposeCalls;
+    private int _shutdownCalls;
+
+    public bool ShutdownSucceeds { get; set; } = true;
+
+    public int DisposeCalls => Volatile.Read(ref _disposeCalls);
+
+    public int ShutdownCalls => Volatile.Read(ref _shutdownCalls);
+
+    public int? LastShutdownTimeoutMilliseconds { get; private set; }
+
+    public override ExportResult Export(in Batch<T> batch) => ExportResult.Success;
+
+    public void BlockShutdown() => _shutdownRelease.Reset();
+
+    public void ReleaseShutdown() => _shutdownRelease.Set();
+
+    public void WaitForShutdown(CancellationToken cancellationToken) =>
+        _shutdownEntered.Wait(cancellationToken);
+
+    protected override bool OnShutdown(int timeoutMilliseconds)
+    {
+        Interlocked.Increment(ref _shutdownCalls);
+        LastShutdownTimeoutMilliseconds = timeoutMilliseconds;
+        _shutdownEntered.Set();
+
+        if (_shutdownRelease.IsSet)
+        {
+            return ShutdownSucceeds;
+        }
+
+        var released = timeoutMilliseconds == Timeout.Infinite
+            ? WaitIndefinitely()
+            : _shutdownRelease.Wait(timeoutMilliseconds);
+
+        return released && ShutdownSucceeds;
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            Interlocked.Increment(ref _disposeCalls);
+            _shutdownEntered.Dispose();
+            _shutdownRelease.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+
+    private bool WaitIndefinitely()
+    {
+        _shutdownRelease.Wait();
+        return true;
+    }
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/LangfuseCancellationTests.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/LangfuseCancellationTests.cs
@@ -1,0 +1,209 @@
+using System.Diagnostics;
+using System.Net;
+
+namespace NexusLabs.Needlr.AgentFramework.Langfuse.Tests;
+
+[Collection("Langfuse activity")]
+public sealed class LangfuseCancellationTests
+{
+    private readonly CancellationToken _testCancellationToken = TestContext.Current.CancellationToken;
+
+    [Fact]
+    public async Task ApiClientPostAsync_WhenCallerCancels_PropagatesCancellation()
+    {
+        using var cancellation = CreateCanceledTokenSource();
+        using var httpClient = CreateHttpClient(
+            (_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+        var client = new LangfuseApiClient(httpClient, new Uri("https://lf.example/"), "Basic x");
+
+        var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            client.PostAsync("api/public/datasets", new { name = "evals" }, cancellation.Token));
+
+        Assert.Equal(cancellation.Token, exception.CancellationToken);
+    }
+
+    [Fact]
+    public async Task ScoreApiClientCreateAsync_WhenCallerCancels_PropagatesCancellation()
+    {
+        using var cancellation = CreateCanceledTokenSource();
+        using var httpClient = CreateHttpClient(
+            (_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+        var client = new LangfuseScoreApiClient(
+            httpClient,
+            new Uri("https://lf.example/api/public/scores"),
+            "Basic x");
+
+        var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            client.CreateAsync(CreateScore(), cancellation.Token));
+
+        Assert.Equal(cancellation.Token, exception.CancellationToken);
+    }
+
+    [Fact]
+    public async Task ScenarioRecordScoreAsync_NonFatalMode_WhenCallerCancels_DoesNotRecordFailure()
+    {
+        using var cancellation = CreateCanceledTokenSource();
+        using var listener = LangfuseTestFactory.StartListener();
+        using var httpClient = CreateHttpClient(
+            (_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+
+        LangfuseScoreError? capturedError = null;
+        var failureSink = new LangfuseScoreFailureSink(
+            LangfuseScoreFailureMode.NonFatal,
+            error => capturedError = error);
+        var recorder = new LangfuseScoreRecorder(
+            new LangfuseScoreApiClient(
+                httpClient,
+                new Uri("https://lf.example/api/public/scores"),
+                "Basic x"),
+            failureSink,
+            normalizeNames: false);
+
+        using var scenario = new LangfuseScenario(recorder, "scenario", null, null, null, null);
+
+        var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            scenario.RecordScoreAsync("correctness", 1.0, cancellationToken: cancellation.Token));
+
+        Assert.Equal(cancellation.Token, exception.CancellationToken);
+        Assert.Equal(0, failureSink.FailedCount);
+        Assert.Null(capturedError);
+    }
+
+    [Fact]
+    public async Task CommentRecorder_WhenCallerCancels_DoesNotReportDiagnostic()
+    {
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(_testCancellationToken);
+        var requestStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var pendingResponse = new TaskCompletionSource<HttpResponseMessage>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        using var httpClient = CreateHttpClient(
+            (_, token) =>
+            {
+                requestStarted.SetResult();
+                return pendingResponse.Task.WaitAsync(token);
+            });
+        var apiClient = new LangfuseApiClient(httpClient, new Uri("https://lf.example/"), "Basic x");
+
+        string? diagnostic = null;
+        var recorder = new LangfuseCommentRecorder(apiClient, message => diagnostic = message);
+
+        var commentTask = recorder.AddTraceCommentAsync("trace-1", "comment", cancellation.Token);
+        await requestStarted.Task.WaitAsync(_testCancellationToken);
+        cancellation.Cancel();
+
+        var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            commentTask);
+
+        Assert.Equal(cancellation.Token, exception.CancellationToken);
+        Assert.Null(diagnostic);
+    }
+
+    [Fact]
+    public async Task ExperimentRunBeginItemAsync_WhenCallerCancels_StopsScenarioWithoutReportingDiagnostic()
+    {
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(_testCancellationToken);
+        var requestStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var pendingResponse = new TaskCompletionSource<HttpResponseMessage>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var stoppedActivities = 0;
+        using var listener = StartListener(_ => Interlocked.Increment(ref stoppedActivities));
+        using var httpClient = CreateHttpClient(
+            (_, token) =>
+            {
+                requestStarted.SetResult();
+                return pendingResponse.Task.WaitAsync(token);
+            });
+        var apiClient = new LangfuseApiClient(httpClient, new Uri("https://lf.example/"), "Basic x");
+
+        string? diagnostic = null;
+        var run = new LangfuseExperimentRun(
+            apiClient,
+            LangfuseTestFactory.OkScoreRecorder(),
+            datasetName: "evals",
+            runName: "run-1",
+            runDescription: null,
+            diagnostics: message => diagnostic = message);
+
+        var beginTask = run.BeginItemAsync("case-1", cancellationToken: cancellation.Token);
+        await requestStarted.Task.WaitAsync(_testCancellationToken);
+        cancellation.Cancel();
+
+        var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            beginTask);
+
+        Assert.Equal(cancellation.Token, exception.CancellationToken);
+        Assert.Equal(1, stoppedActivities);
+        Assert.Null(diagnostic);
+    }
+
+    [Fact]
+    public async Task ApiClientPostAsync_WhenTransportTimesOut_WrapsLangfuseException()
+    {
+        using var httpClient = CreateHttpClient(
+            (_, _) => Task.FromException<HttpResponseMessage>(new TaskCanceledException("simulated timeout")));
+        var client = new LangfuseApiClient(httpClient, new Uri("https://lf.example/"), "Basic x");
+
+        var exception = await Assert.ThrowsAsync<LangfuseException>(() =>
+            client.PostAsync("api/public/datasets", new { name = "evals" }, _testCancellationToken));
+
+        Assert.IsType<TaskCanceledException>(exception.InnerException);
+    }
+
+    [Fact]
+    public async Task ScoreApiClientCreateAsync_WhenTransportTimesOut_WrapsLangfuseException()
+    {
+        using var httpClient = CreateHttpClient(
+            (_, _) => Task.FromException<HttpResponseMessage>(new TaskCanceledException("simulated timeout")));
+        var client = new LangfuseScoreApiClient(
+            httpClient,
+            new Uri("https://lf.example/api/public/scores"),
+            "Basic x");
+
+        var exception = await Assert.ThrowsAsync<LangfuseException>(() =>
+            client.CreateAsync(CreateScore(), _testCancellationToken));
+
+        Assert.IsType<TaskCanceledException>(exception.InnerException);
+    }
+
+    private CancellationTokenSource CreateCanceledTokenSource()
+    {
+        var cancellation = CancellationTokenSource.CreateLinkedTokenSource(_testCancellationToken);
+        cancellation.Cancel();
+        return cancellation;
+    }
+
+    private static LangfuseScore CreateScore() =>
+        new()
+        {
+            TraceId = "trace-1",
+            Name = "correctness",
+            Value = 1.0,
+            DataType = "NUMERIC",
+        };
+
+    private static HttpClient CreateHttpClient(
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> sendAsync) =>
+        new(new DelegateHttpMessageHandler(sendAsync));
+
+    private static ActivityListener StartListener(Action<Activity> onStopped)
+    {
+        var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == LangfuseActivitySource.Name,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = onStopped,
+        };
+        ActivitySource.AddActivityListener(listener);
+        return listener;
+    }
+
+    private sealed class DelegateHttpMessageHandler(
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> sendAsync)
+        : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) =>
+            sendAsync(request, cancellationToken);
+    }
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/LangfuseOptionsTests.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/LangfuseOptionsTests.cs
@@ -39,6 +39,7 @@ public sealed class LangfuseOptionsTests
         Assert.False(options.NormalizeScoreNames);
         Assert.Equal(LangfuseScoreFailureMode.NonFatal, options.ScoreFailureMode);
         Assert.Equal(1.0, options.SamplingRatio);
+        Assert.Equal(TimeSpan.FromSeconds(5), options.ShutdownTimeout);
     }
 
     [Fact]

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/LangfuseProcessorContextTests.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/LangfuseProcessorContextTests.cs
@@ -53,20 +53,16 @@ public sealed class LangfuseProcessorContextTests
     }
 
     [Fact]
-    public void OnStart_GenerationSpanWithPromptBaggage_StampsObservationPrompt()
+    public void OnStart_GenerationSpanWithPromptContext_StampsObservationPrompt()
     {
         var processor = new LangfuseTraceAttributeProcessor();
         using var activity = new Activity("agent.chat");
-        activity.SetBaggage("langfuse.prompt.name", "trip-planner");
-        activity.SetBaggage("langfuse.prompt.version", "7");
+        SetPromptContext(activity, "trip-planner", 7);
 
         processor.OnStart(activity);
 
         Assert.Equal("trip-planner", activity.GetTagItem("langfuse.observation.prompt.name"));
         Assert.Equal(7, activity.GetTagItem("langfuse.observation.prompt.version"));
-        // The raw prompt baggage keys are NOT copied verbatim as tags (prompt is generation-only).
-        Assert.Null(activity.GetTagItem("langfuse.prompt.name"));
-        Assert.Null(activity.GetTagItem("langfuse.prompt.version"));
     }
 
     [Fact]
@@ -74,7 +70,7 @@ public sealed class LangfuseProcessorContextTests
     {
         var processor = new LangfuseTraceAttributeProcessor();
         using var activity = new Activity("agent.chat");
-        activity.SetBaggage("langfuse.prompt.name", "trip-planner");
+        SetPromptContext(activity, "trip-planner", version: null);
 
         processor.OnStart(activity);
 
@@ -83,14 +79,24 @@ public sealed class LangfuseProcessorContextTests
     }
 
     [Fact]
-    public void OnStart_ToolSpanWithPromptBaggage_DoesNotStampPrompt()
+    public void OnStart_ToolSpanWithPromptContext_DoesNotStampPrompt()
     {
         var processor = new LangfuseTraceAttributeProcessor();
         using var activity = new Activity("agent.tool search");
-        activity.SetBaggage("langfuse.prompt.name", "trip-planner");
+        SetPromptContext(activity, "trip-planner", version: null);
 
         processor.OnStart(activity);
 
         Assert.Null(activity.GetTagItem("langfuse.observation.prompt.name"));
     }
+
+    private static void SetPromptContext(Activity activity, string name, int? version) =>
+        activity.SetCustomProperty(
+            LangfuseTraceContext.ActivityPropertyName,
+            new LangfuseTraceContext
+            {
+                Name = "scenario",
+                PromptName = name,
+                PromptVersion = version,
+            });
 }

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/LangfuseScenarioContextTests.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/LangfuseScenarioContextTests.cs
@@ -1,5 +1,9 @@
+using System.Diagnostics;
 using System.Net;
 using System.Text.Json;
+
+using OpenTelemetry;
+using OpenTelemetry.Trace;
 
 namespace NexusLabs.Needlr.AgentFramework.Langfuse.Tests;
 
@@ -86,5 +90,108 @@ public sealed class LangfuseScenarioContextTests
 
         Assert.Equal("trip-planner", child.GetTagItem("langfuse.observation.prompt.name"));
         Assert.Equal(4, child.GetTagItem("langfuse.observation.prompt.version"));
+    }
+
+    [Fact]
+    public void TraceContext_PropagatesSupportedAttributesWithoutExportingInheritedBaggage()
+    {
+        using var external = new Activity("external").Start();
+        external.SetBaggage("authorization", "secret");
+        using var listener = LangfuseTestFactory.StartListener();
+        using var scenario = new LangfuseScenario(
+            LangfuseTestFactory.OkScoreRecorder(),
+            "evaluation-case",
+            sessionId: "session-1",
+            userId: "user-1",
+            tags: ["regression", "parallel"],
+            metadata: new Dictionary<string, string> { ["dataset"] = "v2" });
+        scenario.SetVersion("v3");
+
+        var processor = new LangfuseTraceAttributeProcessor();
+        using var child = LangfuseActivitySource.Source.StartActivity("agent.tool work")!;
+        processor.OnStart(child);
+
+        Assert.Equal("evaluation-case", child.GetTagItem("langfuse.trace.name"));
+        Assert.Equal("session-1", child.GetTagItem("session.id"));
+        Assert.Equal("user-1", child.GetTagItem("user.id"));
+        Assert.Equal("v3", child.GetTagItem("langfuse.version"));
+        Assert.Equal("v2", child.GetTagItem("langfuse.trace.metadata.dataset"));
+        Assert.Equal(
+            ["regression", "parallel"],
+            Assert.IsType<string[]>(child.GetTagItem("langfuse.trace.tags")));
+        Assert.Null(child.GetTagItem("authorization"));
+    }
+
+    [Fact]
+    public void NestedScenario_ReplacesOuterTraceContextInsteadOfMergingIt()
+    {
+        using var provider = Sdk.CreateTracerProviderBuilder()
+            .AddSource(LangfuseActivitySource.Name)
+            .AddProcessor(new LangfuseTraceAttributeProcessor())
+            .Build();
+        using var outer = new LangfuseScenario(
+            LangfuseTestFactory.OkScoreRecorder(),
+            "outer",
+            sessionId: "outer-session",
+            userId: "outer-user",
+            tags: ["outer-a", "outer-b"],
+            metadata: new Dictionary<string, string> { ["outer"] = "value" });
+        outer.SetVersion("outer-version");
+
+        using var inner = new LangfuseScenario(
+            LangfuseTestFactory.OkScoreRecorder(),
+            "inner",
+            sessionId: "inner-session",
+            userId: null,
+            tags: ["inner"],
+            metadata: new Dictionary<string, string> { ["inner"] = "value" });
+
+        Assert.NotEqual(outer.TraceId, inner.TraceId);
+        var innerActivity = inner.Activity!;
+        Assert.Equal("inner", innerActivity.GetTagItem("langfuse.trace.name"));
+        Assert.Equal("inner-session", innerActivity.GetTagItem("langfuse.session.id"));
+        Assert.Null(innerActivity.GetTagItem("session.id"));
+        Assert.Null(innerActivity.GetTagItem("user.id"));
+        Assert.Null(innerActivity.GetTagItem("langfuse.version"));
+        Assert.Equal("value", innerActivity.GetTagItem("langfuse.trace.metadata.inner"));
+        Assert.Null(innerActivity.GetTagItem("langfuse.trace.metadata.outer"));
+        Assert.Equal(["inner"], Assert.IsType<string[]>(innerActivity.GetTagItem("langfuse.trace.tags")));
+        using var child = LangfuseActivitySource.Source.StartActivity("agent.tool nested")!;
+
+        Assert.Equal("inner", child.GetTagItem("langfuse.trace.name"));
+        Assert.Equal("inner-session", child.GetTagItem("session.id"));
+        Assert.Null(child.GetTagItem("user.id"));
+        Assert.Null(child.GetTagItem("langfuse.version"));
+        Assert.Equal("value", child.GetTagItem("langfuse.trace.metadata.inner"));
+        Assert.Null(child.GetTagItem("langfuse.trace.metadata.outer"));
+        Assert.Equal(["inner"], Assert.IsType<string[]>(child.GetTagItem("langfuse.trace.tags")));
+    }
+
+    [Fact]
+    public void NestedScenario_DisposeRestoresOuterActivity()
+    {
+        using var listener = LangfuseTestFactory.StartListener();
+        using var outer = new LangfuseScenario(
+            LangfuseTestFactory.OkScoreRecorder(),
+            "outer",
+            sessionId: null,
+            userId: null,
+            tags: null,
+            metadata: null);
+
+        Assert.Same(outer.Activity, Activity.Current);
+        using (var inner = new LangfuseScenario(
+            LangfuseTestFactory.OkScoreRecorder(),
+            "inner",
+            sessionId: null,
+            userId: null,
+            tags: null,
+            metadata: null))
+        {
+            Assert.Same(inner.Activity, Activity.Current);
+            Assert.NotEqual(outer.TraceId, inner.TraceId);
+        }
+
+        Assert.Same(outer.Activity, Activity.Current);
     }
 }

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/LangfuseScenarioTests.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/LangfuseScenarioTests.cs
@@ -36,8 +36,8 @@ public sealed class LangfuseScenarioTests
         var tags = Assert.IsType<string[]>(activity.GetTagItem("langfuse.trace.tags"));
         Assert.Equal(["happy-path", "regression"], tags);
 
-        Assert.Equal("run-1", activity.GetBaggageItem("session.id"));
-        Assert.Equal("user-9", activity.GetBaggageItem("user.id"));
+        Assert.Null(activity.GetBaggageItem("session.id"));
+        Assert.Null(activity.GetBaggageItem("user.id"));
         Assert.False(string.IsNullOrEmpty(scenario.TraceId));
     }
 
@@ -132,25 +132,30 @@ public sealed class LangfuseScenarioTests
         using var listener = StartListener();
         var recorder = new LangfuseScoreRecorder(CreateApiClient(out _), StrictSink(), normalizeNames: false);
         var processor = new LangfuseTraceAttributeProcessor();
+        var scenarioAReady = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var scenarioBReady = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        async Task<(string? Session, string? User)> RunScenario(string id)
+        async Task<(string? Session, string? User)> RunScenario(
+            string id,
+            TaskCompletionSource ownReady,
+            Task otherReady)
         {
-            await Task.Yield();
             using var scenario = new LangfuseScenario(
                 recorder, $"scenario-{id}", sessionId: id, userId: $"user-{id}", tags: null, metadata: null);
 
-            await Task.Delay(15);
+            ownReady.SetResult();
+            await otherReady.WaitAsync(TestContext.Current.CancellationToken);
             using var child = LangfuseActivitySource.Source.StartActivity("agent.tool work")!;
             processor.OnStart(child);
-            await Task.Delay(15);
 
             return (child.GetTagItem("session.id") as string, child.GetTagItem("user.id") as string);
         }
 
-        var results = await Task.WhenAll(RunScenario("A"), RunScenario("B"));
+        var results = await Task.WhenAll(
+            RunScenario("A", scenarioAReady, scenarioBReady.Task),
+            RunScenario("B", scenarioBReady, scenarioAReady.Task));
 
-        Assert.Contains(("A", "user-A"), results);
-        Assert.Contains(("B", "user-B"), results);
+        Assert.Equal([("A", "user-A"), ("B", "user-B")], results);
     }
 
     private static LangfuseScoreFailureSink StrictSink() => new(LangfuseScoreFailureMode.Strict, null);

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/LangfuseServiceCollectionExtensionsTests.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/LangfuseServiceCollectionExtensionsTests.cs
@@ -38,6 +38,8 @@ public sealed class LangfuseServiceCollectionExtensionsTests
         {
             o.PublicKey = "pk-lf-1";
             o.SecretKey = "sk-lf-2";
+            o.Host = null;
+            o.Region = null;
         });
 
         using var provider = services.BuildServiceProvider();

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/LangfuseSessionShutdownTests.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/LangfuseSessionShutdownTests.cs
@@ -1,0 +1,254 @@
+using System.Diagnostics;
+
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+namespace NexusLabs.Needlr.AgentFramework.Langfuse.Tests;
+
+public sealed class LangfuseSessionShutdownTests
+{
+    private readonly CancellationToken _cancellationToken = TestContext.Current.CancellationToken;
+
+    [Fact]
+    public void Shutdown_EnabledSession_DrainsProvidersAndReleasesOwnedResourcesExactlyOnce()
+    {
+        var (session, traceExporter, metricExporter, handler) = CreateSession(
+            TimeSpan.FromSeconds(5),
+            includeMetrics: true);
+
+        Assert.True(session.IsEnabled, "Expected the lifecycle test to exercise an active session.");
+
+        var first = session.Shutdown(TimeSpan.FromSeconds(1));
+        var second = session.Shutdown(TimeSpan.Zero);
+        session.Dispose();
+
+        Assert.True(first.IsFinal, "Expected the owner shutdown call to return a final outcome.");
+        Assert.Equal(LangfuseProviderShutdownStatus.Completed, first.Traces);
+        Assert.Equal(LangfuseProviderShutdownStatus.Completed, first.Metrics);
+        Assert.Same(first, second);
+        Assert.Equal(1, traceExporter.ShutdownCalls);
+        Assert.Equal(1, metricExporter!.ShutdownCalls);
+        Assert.Equal(1, traceExporter.DisposeCalls);
+        Assert.Equal(1, metricExporter.DisposeCalls);
+        Assert.Equal(1, handler.DisposeCalls);
+    }
+
+    [Fact]
+    public void Shutdown_UsesOneDeadlineAcrossTraceAndMetricProviders()
+    {
+        var (session, traceExporter, metricExporter, _) = CreateSession(
+            TimeSpan.FromSeconds(5),
+            includeMetrics: true);
+        traceExporter.BlockShutdown();
+
+        var outcome = session.Shutdown(TimeSpan.FromMilliseconds(25));
+
+        Assert.True(outcome.IsFinal, "Expected the shutdown timeout to produce a final outcome.");
+        Assert.Equal(LangfuseProviderShutdownStatus.Incomplete, outcome.Traces);
+        Assert.Equal(LangfuseProviderShutdownStatus.Incomplete, outcome.Metrics);
+        Assert.Equal(25, traceExporter.LastShutdownTimeoutMilliseconds);
+        Assert.Equal(0, metricExporter!.LastShutdownTimeoutMilliseconds);
+    }
+
+    [Fact]
+    public void Shutdown_ReportsTraceAndMetricCompletionIndependently()
+    {
+        var (session, _, metricExporter, _) = CreateSession(
+            TimeSpan.FromSeconds(5),
+            includeMetrics: true);
+        metricExporter!.BlockShutdown();
+
+        var outcome = session.Shutdown(TimeSpan.FromMilliseconds(25));
+
+        Assert.True(outcome.IsFinal, "Expected provider-specific statuses in the final outcome.");
+        Assert.Equal(LangfuseProviderShutdownStatus.Completed, outcome.Traces);
+        Assert.Equal(LangfuseProviderShutdownStatus.Incomplete, outcome.Metrics);
+    }
+
+    [Fact]
+    public async Task Shutdown_ConcurrentCallerReturnsDeterministicallyWithoutRepeatingDrain()
+    {
+        var (session, traceExporter, metricExporter, _) = CreateSession(
+            TimeSpan.FromSeconds(5),
+            includeMetrics: true);
+        traceExporter.BlockShutdown();
+
+        var ownerTask = Task.Run(
+            () => session.Shutdown(TimeSpan.FromSeconds(5)),
+            _cancellationToken);
+        traceExporter.WaitForShutdown(_cancellationToken);
+
+        var concurrent = session.Shutdown(TimeSpan.FromSeconds(1));
+
+        Assert.False(concurrent.IsFinal, "Expected a concurrent non-owner call to report shutdown in progress.");
+        Assert.Equal(LangfuseProviderShutdownStatus.NotAttempted, concurrent.Traces);
+        Assert.Equal(LangfuseProviderShutdownStatus.NotAttempted, concurrent.Metrics);
+
+        traceExporter.ReleaseShutdown();
+        var owner = await ownerTask.WaitAsync(_cancellationToken);
+        var repeated = session.Shutdown(TimeSpan.Zero);
+
+        Assert.True(owner.IsFinal, "Expected the owner call to publish the final shutdown outcome.");
+        Assert.Same(owner, repeated);
+        Assert.Equal(1, traceExporter.ShutdownCalls);
+        Assert.Equal(1, metricExporter!.ShutdownCalls);
+    }
+
+    [Fact]
+    public void Dispose_UsesConfiguredBoundedTimeoutAndReleasesResourcesAfterIncompleteDrain()
+    {
+        var (session, traceExporter, metricExporter, handler) = CreateSession(
+            TimeSpan.FromMilliseconds(20),
+            includeMetrics: true);
+        traceExporter.BlockShutdown();
+
+        session.Dispose();
+        session.Dispose();
+
+        Assert.Equal(20, traceExporter.LastShutdownTimeoutMilliseconds);
+        Assert.Equal(0, metricExporter!.LastShutdownTimeoutMilliseconds);
+        Assert.Equal(1, traceExporter.ShutdownCalls);
+        Assert.Equal(1, metricExporter.ShutdownCalls);
+        Assert.Equal(1, traceExporter.DisposeCalls);
+        Assert.Equal(1, metricExporter.DisposeCalls);
+        Assert.Equal(1, handler.DisposeCalls);
+    }
+
+    [Fact]
+    public void Shutdown_AfterCompletionRejectsNewSessionOperations()
+    {
+        var (session, _, _, _) = CreateSession(
+            TimeSpan.FromSeconds(5),
+            includeMetrics: false);
+        session.Shutdown(TimeSpan.FromSeconds(1));
+
+        Assert.Throws<ObjectDisposedException>(() => session.Flush(TimeSpan.Zero));
+        Assert.Throws<ObjectDisposedException>(() => session.BeginScenario("after-shutdown"));
+        Assert.Throws<ObjectDisposedException>(() => session.BeginExperimentRun("dataset", "run"));
+        Assert.Throws<ObjectDisposedException>(() =>
+        {
+            _ = session.AddTraceCommentAsync(
+                "trace-id",
+                "after-shutdown",
+                _cancellationToken);
+        });
+    }
+
+    [Fact]
+    public void Shutdown_InfiniteWaitRequiresExplicitInfiniteTimeSpan()
+    {
+        var (session, traceExporter, _, _) = CreateSession(
+            TimeSpan.FromSeconds(5),
+            includeMetrics: false);
+
+        var outcome = session.Shutdown(Timeout.InfiniteTimeSpan);
+
+        Assert.True(outcome.IsFinal, "Expected the explicit infinite timeout call to complete.");
+        Assert.Equal(Timeout.Infinite, traceExporter.LastShutdownTimeoutMilliseconds);
+        Assert.Equal(LangfuseProviderShutdownStatus.Completed, outcome.Traces);
+        Assert.Equal(LangfuseProviderShutdownStatus.NotConfigured, outcome.Metrics);
+    }
+
+    [Fact]
+    public void Shutdown_InvalidNegativeTimeoutThrowsWithoutStartingShutdown()
+    {
+        var (session, traceExporter, _, _) = CreateSession(
+            TimeSpan.FromSeconds(5),
+            includeMetrics: false);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => session.Shutdown(TimeSpan.FromMilliseconds(-2)));
+
+        Assert.Equal(0, traceExporter.ShutdownCalls);
+
+        var outcome = session.Shutdown(TimeSpan.Zero);
+        Assert.True(outcome.IsFinal, "Expected a valid call after validation failure to own shutdown.");
+    }
+
+    [Fact]
+    public void Start_EnabledSessionRejectsInvalidDefaultShutdownTimeout()
+    {
+        var options = new LangfuseOptions
+        {
+            PublicKey = "pk",
+            SecretKey = "sk",
+            Host = "https://lf.example",
+            ShutdownTimeout = TimeSpan.FromMilliseconds(-2),
+        };
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => LangfuseTelemetry.Start(options));
+    }
+
+    [Fact]
+    public void ShutdownOutcome_PublicConstructorPreservesExternalImplementationValues()
+    {
+        Assert.Single(typeof(LangfuseShutdownOutcome).GetConstructors());
+
+        var outcome = new LangfuseShutdownOutcome(
+            isFinal: true,
+            LangfuseProviderShutdownStatus.Completed,
+            LangfuseProviderShutdownStatus.NotConfigured);
+
+        Assert.True(outcome.IsFinal, "Expected the supplied final-state value to be preserved.");
+        Assert.Equal(LangfuseProviderShutdownStatus.Completed, outcome.Traces);
+        Assert.Equal(LangfuseProviderShutdownStatus.NotConfigured, outcome.Metrics);
+    }
+
+    private static (
+        LangfuseSession Session,
+        ControlledExporter<Activity> TraceExporter,
+        ControlledExporter<Metric>? MetricExporter,
+        TrackingHttpMessageHandler Handler) CreateSession(
+            TimeSpan defaultShutdownTimeout,
+            bool includeMetrics)
+    {
+        var traceExporter = new ControlledExporter<Activity>();
+        var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource("LangfuseSessionShutdownTests")
+            .AddProcessor(new SimpleActivityExportProcessor(traceExporter))
+            .Build();
+
+        ControlledExporter<Metric>? metricExporter = null;
+        MeterProvider? meterProvider = null;
+        if (includeMetrics)
+        {
+            metricExporter = new ControlledExporter<Metric>();
+            meterProvider = Sdk.CreateMeterProviderBuilder()
+                .AddReader(new BaseExportingMetricReader(metricExporter))
+                .Build();
+        }
+
+        var handler = new TrackingHttpMessageHandler();
+        var httpClient = new HttpClient(handler, disposeHandler: true);
+        var scoreApiClient = new LangfuseScoreApiClient(
+            httpClient,
+            new Uri("https://lf.example/api/public/scores"),
+            "Basic x");
+        var apiClient = new LangfuseApiClient(
+            httpClient,
+            new Uri("https://lf.example"),
+            "Basic x");
+        var failureSink = new LangfuseScoreFailureSink(
+            LangfuseScoreFailureMode.Strict,
+            callback: null);
+        var recorder = new LangfuseScoreRecorder(
+            scoreApiClient,
+            failureSink,
+            normalizeNames: false);
+        var commentRecorder = new LangfuseCommentRecorder(
+            apiClient,
+            diagnostics: null);
+        var session = new LangfuseSession(
+            tracerProvider,
+            meterProvider,
+            httpClient,
+            recorder,
+            failureSink,
+            commentRecorder,
+            apiClient,
+            diagnostics: null,
+            defaultShutdownTimeout);
+
+        return (session, traceExporter, metricExporter, handler);
+    }
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/LangfuseTelemetryDisabledTests.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/LangfuseTelemetryDisabledTests.cs
@@ -9,6 +9,14 @@ public sealed class LangfuseTelemetryDisabledTests
 
         Assert.False(session.IsEnabled);
         Assert.True(session.Flush());
+
+        var first = session.Shutdown(TimeSpan.Zero);
+        var second = session.Shutdown(TimeSpan.Zero);
+
+        Assert.True(first.IsFinal, "Expected disabled shutdown to complete synchronously.");
+        Assert.Equal(LangfuseProviderShutdownStatus.NotConfigured, first.Traces);
+        Assert.Equal(LangfuseProviderShutdownStatus.NotConfigured, first.Metrics);
+        Assert.Same(first, second);
     }
 
     [Fact]

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/LangfuseTraceAttributeProcessorTests.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/LangfuseTraceAttributeProcessorTests.cs
@@ -6,17 +6,45 @@ namespace NexusLabs.Needlr.AgentFramework.Langfuse.Tests;
 public sealed class LangfuseTraceAttributeProcessorTests
 {
     [Fact]
-    public void OnStart_CopiesBaggageToTags_WithoutOverwritingExistingTags()
+    public void OnStart_AppliesTraceContextWithoutOverwritingExistingTags()
     {
         using var scope = StartActivity("op", out var activity);
-        activity.SetBaggage("session.id", "run-9");
         activity.SetTag("user.id", "preset");
-        activity.SetBaggage("user.id", "from-baggage");
+        activity.SetCustomProperty(
+            LangfuseTraceContext.ActivityPropertyName,
+            new LangfuseTraceContext
+            {
+                Name = "scenario",
+                SessionId = "run-9",
+                UserId = "from-context",
+                Version = "v3",
+                Tags = ["regression", "parallel"],
+                Metadata = new Dictionary<string, string> { ["dataset"] = "regression" },
+            });
 
         new LangfuseTraceAttributeProcessor().OnStart(activity);
 
         Assert.Equal("run-9", activity.GetTagItem("session.id"));
         Assert.Equal("preset", activity.GetTagItem("user.id"));
+        Assert.Equal("v3", activity.GetTagItem("langfuse.version"));
+        Assert.Equal("scenario", activity.GetTagItem("langfuse.trace.name"));
+        Assert.Equal(
+            ["regression", "parallel"],
+            Assert.IsType<string[]>(activity.GetTagItem("langfuse.trace.tags")));
+        Assert.Equal("regression", activity.GetTagItem("langfuse.trace.metadata.dataset"));
+    }
+
+    [Fact]
+    public void OnStart_DoesNotExportUnrecognizedBaggage()
+    {
+        using var scope = StartActivity("op", out var activity);
+        activity.SetBaggage("authorization", "secret");
+        activity.SetBaggage("tenant.internal.routing-key", "route-7");
+
+        new LangfuseTraceAttributeProcessor().OnStart(activity);
+
+        Assert.Null(activity.GetTagItem("authorization"));
+        Assert.Null(activity.GetTagItem("tenant.internal.routing-key"));
     }
 
     [Theory]

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/TrackingHttpMessageHandler.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/TrackingHttpMessageHandler.cs
@@ -1,0 +1,28 @@
+using System.Net;
+
+namespace NexusLabs.Needlr.AgentFramework.Langfuse.Tests;
+
+/// <summary>
+/// HTTP boundary helper that records whether its owning <see cref="HttpClient"/> released it.
+/// </summary>
+internal sealed class TrackingHttpMessageHandler : HttpMessageHandler
+{
+    private int _disposeCalls;
+
+    public int DisposeCalls => Volatile.Read(ref _disposeCalls);
+
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken) =>
+        Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            Interlocked.Increment(ref _disposeCalls);
+        }
+
+        base.Dispose(disposing);
+    }
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/DisabledLangfuseSession.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/DisabledLangfuseSession.cs
@@ -6,6 +6,11 @@ namespace NexusLabs.Needlr.AgentFramework.Langfuse;
 /// </summary>
 internal sealed class DisabledLangfuseSession : ILangfuseSession
 {
+    private static readonly LangfuseShutdownOutcome ShutdownOutcome = new(
+        isFinal: true,
+        LangfuseProviderShutdownStatus.NotConfigured,
+        LangfuseProviderShutdownStatus.NotConfigured);
+
     /// <inheritdoc />
     public bool IsEnabled => false;
 
@@ -29,6 +34,13 @@ internal sealed class DisabledLangfuseSession : ILangfuseSession
 
     /// <inheritdoc />
     public bool Flush(TimeSpan? timeout = null) => true;
+
+    /// <inheritdoc />
+    public LangfuseShutdownOutcome Shutdown(TimeSpan timeout)
+    {
+        _ = LangfuseTimeout.ToShutdownMilliseconds(timeout);
+        return ShutdownOutcome;
+    }
 
     /// <inheritdoc />
     public ILangfuseScenario BeginScenario(

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/ILangfuseSession.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/ILangfuseSession.cs
@@ -2,12 +2,12 @@ namespace NexusLabs.Needlr.AgentFramework.Langfuse;
 
 /// <summary>
 /// Represents an active Langfuse export session. Owns the OpenTelemetry tracer/meter providers
-/// that forward Needlr agent telemetry to Langfuse and flushes pending telemetry on disposal.
+/// that forward Needlr agent telemetry to Langfuse and performs bounded final shutdown on disposal.
 /// </summary>
 /// <remarks>
 /// Obtain an instance from <see cref="LangfuseTelemetry.Start(LangfuseOptions)"/>. Keep it alive
 /// for the lifetime over which agent runs and evaluations should be captured (for example, an
-/// xUnit collection fixture), then dispose it to force a final flush.
+/// xUnit collection fixture), then dispose it to perform a bounded, best-effort final drain.
 /// </remarks>
 public interface ILangfuseSession : IDisposable
 {
@@ -36,6 +36,40 @@ public interface ILangfuseSession : IDisposable
     /// </param>
     /// <returns><see langword="true"/> if the flush succeeded; otherwise <see langword="false"/>.</returns>
     bool Flush(TimeSpan? timeout = null);
+
+    /// <summary>
+    /// Performs final local OpenTelemetry provider shutdown and releases all resources owned by the
+    /// session.
+    /// </summary>
+    /// <param name="timeout">
+    /// The total timeout budget shared by trace and metric provider shutdown, or
+    /// <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> to explicitly wait indefinitely.
+    /// </param>
+    /// <returns>
+    /// An outcome describing whether local trace and metric provider shutdown completed. This does
+    /// not guarantee durable ingestion by Langfuse.
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// Exactly one caller performs final shutdown. Concurrent callers return immediately with
+    /// <see cref="LangfuseShutdownOutcome.IsFinal"/> equal to <see langword="false"/>. Calls made
+    /// after shutdown completes return the same cached final outcome.
+    /// </para>
+    /// <para>
+    /// Once shutdown begins, an enabled session rejects new operations with
+    /// <see cref="ObjectDisposedException"/>.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="timeout"/> is negative and is not
+    /// <see cref="System.Threading.Timeout.InfiniteTimeSpan"/>.
+    /// </exception>
+    /// <exception cref="NotSupportedException">
+    /// The session implementation predates explicit shutdown and does not override this member.
+    /// </exception>
+    LangfuseShutdownOutcome Shutdown(TimeSpan timeout) =>
+        throw new NotSupportedException(
+            "This ILangfuseSession implementation does not support explicit final shutdown.");
 
     /// <summary>
     /// Begins a Langfuse trace scoped to a single eval scenario or agent run. Agent telemetry

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseApiClient.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseApiClient.cs
@@ -134,6 +134,10 @@ internal sealed class LangfuseApiClient
         {
             response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
         {
             throw new LangfuseException($"Langfuse request {method} '{uri}' failed.", ex);

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseExperimentRun.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseExperimentRun.cs
@@ -49,6 +49,7 @@ internal sealed class LangfuseExperimentRun : ILangfuseExperimentRun
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(datasetItemId);
+        cancellationToken.ThrowIfCancellationRequested();
 
         var name = string.IsNullOrWhiteSpace(scenarioName)
             ? $"{DatasetName}: {datasetItemId}"
@@ -62,18 +63,26 @@ internal sealed class LangfuseExperimentRun : ILangfuseExperimentRun
             tags,
             metadata);
 
-        if (scenario.TraceId is { Length: > 0 } traceId)
+        try
         {
-            await LinkRunItemAsync(datasetItemId, traceId, cancellationToken).ConfigureAwait(false);
-        }
-        else
-        {
-            _diagnostics?.Invoke(
-                $"Langfuse dataset run item skipped for item '{datasetItemId}' in run '{RunName}': " +
-                "no sampled trace was available to link.");
-        }
+            if (scenario.TraceId is { Length: > 0 } traceId)
+            {
+                await LinkRunItemAsync(datasetItemId, traceId, cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                _diagnostics?.Invoke(
+                    $"Langfuse dataset run item skipped for item '{datasetItemId}' in run '{RunName}': " +
+                    "no sampled trace was available to link.");
+            }
 
-        return scenario;
+            return scenario;
+        }
+        catch
+        {
+            scenario.Dispose();
+            throw;
+        }
     }
 
     private async Task LinkRunItemAsync(string datasetItemId, string traceId, CancellationToken cancellationToken)

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseOptions.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseOptions.cs
@@ -156,6 +156,17 @@ public sealed class LangfuseOptions
     public double SamplingRatio { get; set; } = 1.0;
 
     /// <summary>
+    /// Gets or sets the total timeout budget used by <see cref="System.IDisposable.Dispose"/> for
+    /// final local trace and metric provider shutdown. Defaults to five seconds.
+    /// </summary>
+    /// <remarks>
+    /// Set this to <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> only when an unbounded
+    /// disposal wait is explicitly desired. Other negative values are invalid for an enabled
+    /// standalone session.
+    /// </remarks>
+    public TimeSpan ShutdownTimeout { get; set; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>
     /// Gets or sets the name of Needlr's agent <see cref="System.Diagnostics.ActivitySource"/>
     /// to export. Defaults to <see cref="AgentFrameworkMetricsOptions.MeterName"/>'s default.
     /// </summary>

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseProviderShutdownStatus.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseProviderShutdownStatus.cs
@@ -1,0 +1,29 @@
+namespace NexusLabs.Needlr.AgentFramework.Langfuse;
+
+/// <summary>
+/// Describes the local OpenTelemetry shutdown state for one telemetry provider.
+/// </summary>
+public enum LangfuseProviderShutdownStatus
+{
+    /// <summary>
+    /// The provider completed its local shutdown and drain within the supplied timeout budget.
+    /// </summary>
+    Completed,
+
+    /// <summary>
+    /// The provider did not complete its local shutdown and drain within the supplied timeout
+    /// budget, or OpenTelemetry otherwise reported shutdown failure.
+    /// </summary>
+    Incomplete,
+
+    /// <summary>
+    /// The provider was not configured for this session.
+    /// </summary>
+    NotConfigured,
+
+    /// <summary>
+    /// This call observed another caller performing shutdown, so it did not attempt provider
+    /// shutdown and returned immediately.
+    /// </summary>
+    NotAttempted,
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseScenario.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseScenario.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Globalization;
 using System.Text.Json;
 
 using Microsoft.Extensions.AI.Evaluation;
@@ -13,8 +12,11 @@ namespace NexusLabs.Needlr.AgentFramework.Langfuse;
 internal sealed class LangfuseScenario : ILangfuseScenario
 {
     private readonly Activity? _activity;
+    private readonly Activity? _previousActivity;
     private readonly LangfuseScoreRecorder _recorder;
     private readonly string? _sessionId;
+    private LangfuseTraceContext _traceContext;
+    private int _disposed;
 
     public LangfuseScenario(
         LangfuseScoreRecorder recorder,
@@ -29,9 +31,25 @@ internal sealed class LangfuseScenario : ILangfuseScenario
 
         _recorder = recorder;
         _sessionId = sessionId;
-        _activity = LangfuseActivitySource.Source.StartActivity(name, ActivityKind.Internal);
+        _traceContext = CreateTraceContext(name, sessionId, userId, tags, metadata);
+        _previousActivity = Activity.Current;
+        Activity? activity = null;
+        Activity.Current = null;
+        try
+        {
+            activity = LangfuseActivitySource.Source.StartActivity(name, ActivityKind.Internal);
+        }
+        finally
+        {
+            if (activity is null)
+            {
+                Activity.Current = _previousActivity;
+            }
+        }
+        _activity = activity;
 
-        ApplyTraceAttributes(_activity, name, sessionId, userId, tags, metadata);
+        ApplyTraceAttributes(_activity, _traceContext);
+        LangfuseTraceContext.Attach(_activity, _traceContext);
     }
 
     /// <inheritdoc />
@@ -69,7 +87,20 @@ internal sealed class LangfuseScenario : ILangfuseScenario
     }
 
     /// <inheritdoc />
-    public void Dispose() => _activity?.Dispose();
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        var restorePreviousActivity = ReferenceEquals(Activity.Current, _activity);
+        _activity?.Dispose();
+        if (restorePreviousActivity)
+        {
+            Activity.Current = _previousActivity;
+        }
+    }
 
     /// <inheritdoc />
     public void SetTracePublic(bool isPublic = true) =>
@@ -80,6 +111,8 @@ internal sealed class LangfuseScenario : ILangfuseScenario
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(version);
         _activity?.SetTag("langfuse.version", version);
+        _traceContext = _traceContext with { Version = version };
+        LangfuseTraceContext.Attach(_activity, _traceContext);
     }
 
     /// <inheritdoc />
@@ -100,20 +133,8 @@ internal sealed class LangfuseScenario : ILangfuseScenario
     public void SetPrompt(string name, int? version = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
-
-        if (_activity is null)
-        {
-            return;
-        }
-
-        _activity.SetBaggage(LangfuseTraceAttributeProcessor.PromptNameBaggageKey, name);
-
-        if (version is { } v)
-        {
-            _activity.SetBaggage(
-                LangfuseTraceAttributeProcessor.PromptVersionBaggageKey,
-                v.ToString(CultureInfo.InvariantCulture));
-        }
+        _traceContext = _traceContext with { PromptName = name, PromptVersion = version };
+        LangfuseTraceContext.Attach(_activity, _traceContext);
     }
 
     /// <inheritdoc />
@@ -151,51 +172,58 @@ internal sealed class LangfuseScenario : ILangfuseScenario
             "Pass a sessionId when beginning the scenario to enable session-level scoring.",
             cancellationToken);
 
-    private static void ApplyTraceAttributes(
-        Activity? activity,
+    private static LangfuseTraceContext CreateTraceContext(
         string name,
         string? sessionId,
         string? userId,
         IEnumerable<string>? tags,
         IReadOnlyDictionary<string, string>? metadata)
     {
+        var tagArray = tags?
+            .Where(tag => !string.IsNullOrWhiteSpace(tag))
+            .ToArray() ?? [];
+        var metadataCopy = metadata?
+            .Where(entry => !string.IsNullOrWhiteSpace(entry.Key))
+            .ToDictionary(entry => entry.Key, entry => entry.Value, StringComparer.Ordinal)
+            ?? new Dictionary<string, string>(StringComparer.Ordinal);
+
+        return new LangfuseTraceContext
+        {
+            Name = name,
+            SessionId = string.IsNullOrWhiteSpace(sessionId) ? null : sessionId,
+            UserId = string.IsNullOrWhiteSpace(userId) ? null : userId,
+            Tags = tagArray,
+            Metadata = metadataCopy,
+        };
+    }
+
+    private static void ApplyTraceAttributes(Activity? activity, LangfuseTraceContext context)
+    {
         if (activity is null)
         {
             return;
         }
 
-        activity.SetTag("langfuse.trace.name", name);
+        activity.SetTag("langfuse.trace.name", context.Name);
 
-        if (!string.IsNullOrWhiteSpace(sessionId))
+        if (context.SessionId is not null)
         {
-            activity.SetTag("langfuse.session.id", sessionId);
-            activity.SetBaggage("session.id", sessionId);
+            activity.SetTag("langfuse.session.id", context.SessionId);
         }
 
-        if (!string.IsNullOrWhiteSpace(userId))
+        if (context.UserId is not null)
         {
-            activity.SetTag("langfuse.user.id", userId);
-            activity.SetBaggage("user.id", userId);
+            activity.SetTag("langfuse.user.id", context.UserId);
         }
 
-        if (tags is not null)
+        if (context.Tags.Count > 0)
         {
-            var tagArray = tags.Where(t => !string.IsNullOrWhiteSpace(t)).ToArray();
-            if (tagArray.Length > 0)
-            {
-                activity.SetTag("langfuse.trace.tags", tagArray);
-            }
+            activity.SetTag("langfuse.trace.tags", context.Tags.ToArray());
         }
 
-        if (metadata is not null)
+        foreach (var entry in context.Metadata)
         {
-            foreach (var entry in metadata)
-            {
-                if (!string.IsNullOrWhiteSpace(entry.Key))
-                {
-                    activity.SetTag($"langfuse.trace.metadata.{entry.Key}", entry.Value);
-                }
-            }
+            activity.SetTag($"langfuse.trace.metadata.{entry.Key}", entry.Value);
         }
     }
 }

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseScoreApiClient.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseScoreApiClient.cs
@@ -61,6 +61,10 @@ internal sealed class LangfuseScoreApiClient
                 .PostAsJsonAsync(_scoresEndpoint, score, SerializerOptions, cancellationToken)
                 .ConfigureAwait(false);
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
         {
             throw new LangfuseException(

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseSession.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseSession.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Threading;
 
 using OpenTelemetry;
@@ -20,7 +21,14 @@ internal sealed class LangfuseSession : ILangfuseSession
     private readonly LangfuseCommentRecorder _commentRecorder;
     private readonly LangfuseApiClient _apiClient;
     private readonly Action<string>? _diagnostics;
-    private int _disposed;
+    private readonly int _defaultShutdownTimeoutMilliseconds;
+    private LangfuseShutdownOutcome? _shutdownOutcome;
+    private int _shutdownState;
+
+    private static readonly LangfuseShutdownOutcome ShutdownInProgressOutcome = new(
+        isFinal: false,
+        LangfuseProviderShutdownStatus.NotAttempted,
+        LangfuseProviderShutdownStatus.NotAttempted);
 
     public LangfuseSession(
         TracerProvider tracerProvider,
@@ -30,7 +38,8 @@ internal sealed class LangfuseSession : ILangfuseSession
         LangfuseScoreFailureSink failureSink,
         LangfuseCommentRecorder commentRecorder,
         LangfuseApiClient apiClient,
-        Action<string>? diagnostics)
+        Action<string>? diagnostics,
+        TimeSpan defaultShutdownTimeout)
     {
         ArgumentNullException.ThrowIfNull(tracerProvider);
         ArgumentNullException.ThrowIfNull(httpClient);
@@ -47,6 +56,7 @@ internal sealed class LangfuseSession : ILangfuseSession
         _commentRecorder = commentRecorder;
         _apiClient = apiClient;
         _diagnostics = diagnostics;
+        _defaultShutdownTimeoutMilliseconds = LangfuseTimeout.ToShutdownMilliseconds(defaultShutdownTimeout);
 
         Datasets = new LangfuseDatasetClient(apiClient);
         ScoreConfigs = new LangfuseScoreConfigClient(apiClient);
@@ -79,11 +89,17 @@ internal sealed class LangfuseSession : ILangfuseSession
     /// <inheritdoc />
     public bool Flush(TimeSpan? timeout = null)
     {
-        var timeoutMs = ToTimeoutMilliseconds(timeout);
+        ThrowIfShutdownStarted();
+
+        var timeoutMs = LangfuseTimeout.ToFlushMilliseconds(timeout);
         var traces = _tracerProvider.ForceFlush(timeoutMs);
         var metrics = _meterProvider?.ForceFlush(timeoutMs) ?? true;
         return traces && metrics;
     }
+
+    /// <inheritdoc />
+    public LangfuseShutdownOutcome Shutdown(TimeSpan timeout) =>
+        Shutdown(LangfuseTimeout.ToShutdownMilliseconds(timeout));
 
     /// <inheritdoc />
     public ILangfuseScenario BeginScenario(
@@ -91,12 +107,16 @@ internal sealed class LangfuseSession : ILangfuseSession
         string? sessionId = null,
         string? userId = null,
         IEnumerable<string>? tags = null,
-        IReadOnlyDictionary<string, string>? metadata = null) =>
-        new LangfuseScenario(_recorder, name, sessionId, userId, tags, metadata);
+        IReadOnlyDictionary<string, string>? metadata = null)
+    {
+        ThrowIfShutdownStarted();
+        return new LangfuseScenario(_recorder, name, sessionId, userId, tags, metadata);
+    }
 
     /// <inheritdoc />
     public ILangfuseExperimentRun BeginExperimentRun(string datasetName, string runName, string? runDescription = null)
     {
+        ThrowIfShutdownStarted();
         ArgumentException.ThrowIfNullOrWhiteSpace(datasetName);
         ArgumentException.ThrowIfNullOrWhiteSpace(runName);
 
@@ -110,36 +130,114 @@ internal sealed class LangfuseSession : ILangfuseSession
     }
 
     /// <inheritdoc />
-    public Task AddTraceCommentAsync(string traceId, string content, CancellationToken cancellationToken = default) =>
-        _commentRecorder.AddTraceCommentAsync(traceId, content, cancellationToken);
-
-    /// <inheritdoc />
-    public void Dispose()
+    public Task AddTraceCommentAsync(string traceId, string content, CancellationToken cancellationToken = default)
     {
-        if (Interlocked.Exchange(ref _disposed, 1) != 0)
-        {
-            return;
-        }
-
-        Flush();
-        _tracerProvider.Dispose();
-        _meterProvider?.Dispose();
-        _httpClient.Dispose();
+        ThrowIfShutdownStarted();
+        return _commentRecorder.AddTraceCommentAsync(traceId, content, cancellationToken);
     }
 
-    private static int ToTimeoutMilliseconds(TimeSpan? timeout)
+    /// <inheritdoc />
+    public void Dispose() => _ = Shutdown(_defaultShutdownTimeoutMilliseconds);
+
+    private LangfuseShutdownOutcome Shutdown(int timeoutMilliseconds)
     {
-        if (timeout is null)
+        if (Interlocked.CompareExchange(ref _shutdownState, 1, 0) != 0)
+        {
+            return Volatile.Read(ref _shutdownOutcome) ?? ShutdownInProgressOutcome;
+        }
+
+        LangfuseShutdownOutcome? outcome = null;
+        try
+        {
+            var stopwatch = timeoutMilliseconds == Timeout.Infinite
+                ? null
+                : Stopwatch.StartNew();
+            var tracesCompleted = _tracerProvider.Shutdown(timeoutMilliseconds);
+            var traceStatus = tracesCompleted
+                ? LangfuseProviderShutdownStatus.Completed
+                : LangfuseProviderShutdownStatus.Incomplete;
+
+            LangfuseProviderShutdownStatus metricStatus;
+            if (_meterProvider is null)
+            {
+                metricStatus = LangfuseProviderShutdownStatus.NotConfigured;
+            }
+            else
+            {
+                var remainingTimeoutMilliseconds = GetRemainingTimeoutMilliseconds(
+                    timeoutMilliseconds,
+                    stopwatch);
+                var metricsCompleted = _meterProvider.Shutdown(remainingTimeoutMilliseconds);
+                metricStatus = metricsCompleted
+                    ? LangfuseProviderShutdownStatus.Completed
+                    : LangfuseProviderShutdownStatus.Incomplete;
+            }
+
+            outcome = new LangfuseShutdownOutcome(
+                isFinal: true,
+                traceStatus,
+                metricStatus);
+            return outcome;
+        }
+        finally
+        {
+            try
+            {
+                DisposeOwnedResources();
+            }
+            finally
+            {
+                outcome ??= new LangfuseShutdownOutcome(
+                    isFinal: true,
+                    LangfuseProviderShutdownStatus.Incomplete,
+                    _meterProvider is null
+                        ? LangfuseProviderShutdownStatus.NotConfigured
+                        : LangfuseProviderShutdownStatus.Incomplete);
+                Volatile.Write(ref _shutdownOutcome, outcome);
+                Volatile.Write(ref _shutdownState, 2);
+            }
+        }
+    }
+
+    private static int GetRemainingTimeoutMilliseconds(
+        int timeoutMilliseconds,
+        Stopwatch? stopwatch)
+    {
+        if (timeoutMilliseconds == Timeout.Infinite)
         {
             return Timeout.Infinite;
         }
 
-        if (timeout.Value == Timeout.InfiniteTimeSpan)
-        {
-            return Timeout.Infinite;
-        }
+        var elapsedMilliseconds = stopwatch is null
+            ? 0
+            : (long)Math.Ceiling(stopwatch.Elapsed.TotalMilliseconds);
+        return (int)Math.Max(timeoutMilliseconds - elapsedMilliseconds, 0);
+    }
 
-        var ms = (long)timeout.Value.TotalMilliseconds;
-        return ms < 0 ? Timeout.Infinite : (int)Math.Min(ms, int.MaxValue);
+    private void DisposeOwnedResources()
+    {
+        try
+        {
+            _tracerProvider.Dispose();
+        }
+        finally
+        {
+            try
+            {
+                _meterProvider?.Dispose();
+            }
+            finally
+            {
+                _httpClient.Dispose();
+            }
+        }
+    }
+
+    private void ThrowIfShutdownStarted()
+    {
+        if (Volatile.Read(ref _shutdownState) != 0)
+        {
+            throw new ObjectDisposedException(nameof(LangfuseSession));
+        }
     }
 }

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseShutdownOutcome.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseShutdownOutcome.cs
@@ -1,0 +1,50 @@
+namespace NexusLabs.Needlr.AgentFramework.Langfuse;
+
+/// <summary>
+/// Reports whether local OpenTelemetry trace and metric provider shutdown completed.
+/// </summary>
+/// <remarks>
+/// This outcome only describes local provider shutdown and drain. It does not guarantee that
+/// Langfuse durably ingested the exported telemetry.
+/// </remarks>
+public sealed record LangfuseShutdownOutcome
+{
+    /// <summary>
+    /// Initializes a shutdown outcome.
+    /// </summary>
+    /// <param name="isFinal">
+    /// Whether this is the session's final cached outcome rather than an observation that another
+    /// caller currently owns shutdown.
+    /// </param>
+    /// <param name="traces">The local trace-provider shutdown status.</param>
+    /// <param name="metrics">The local metric-provider shutdown status.</param>
+    public LangfuseShutdownOutcome(
+        bool isFinal,
+        LangfuseProviderShutdownStatus traces,
+        LangfuseProviderShutdownStatus metrics)
+    {
+        IsFinal = isFinal;
+        Traces = traces;
+        Metrics = metrics;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether this is the session's final cached shutdown outcome.
+    /// </summary>
+    /// <remarks>
+    /// <see langword="false"/> means another caller currently owns final shutdown. In that case
+    /// <see cref="Traces"/> and <see cref="Metrics"/> are
+    /// <see cref="LangfuseProviderShutdownStatus.NotAttempted"/>.
+    /// </remarks>
+    public bool IsFinal { get; }
+
+    /// <summary>
+    /// Gets the local trace-provider shutdown status.
+    /// </summary>
+    public LangfuseProviderShutdownStatus Traces { get; }
+
+    /// <summary>
+    /// Gets the local metric-provider shutdown status.
+    /// </summary>
+    public LangfuseProviderShutdownStatus Metrics { get; }
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseTelemetry.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseTelemetry.cs
@@ -14,8 +14,8 @@ namespace NexusLabs.Needlr.AgentFramework.Langfuse;
 /// <para>
 /// <see cref="Start(LangfuseOptions)"/> constructs standalone OpenTelemetry tracer and meter
 /// providers that subscribe to Needlr's <c>gen_ai</c> activity source and meters and export them
-/// to Langfuse over OTLP/HTTP. Dispose the returned <see cref="ILangfuseSession"/> to flush and
-/// tear them down.
+/// to Langfuse over OTLP/HTTP. Dispose the returned <see cref="ILangfuseSession"/> to perform
+/// bounded final shutdown using <see cref="LangfuseOptions.ShutdownTimeout"/>.
 /// </para>
 /// <para>
 /// For ASP.NET Core / generic-host applications that already call <c>AddOpenTelemetry()</c>, use
@@ -56,6 +56,8 @@ public static class LangfuseTelemetry
             LangfuseExportGuard.WarnIfCredentialsWithoutTarget(options);
             return new DisabledLangfuseSession();
         }
+
+        _ = LangfuseTimeout.ToShutdownMilliseconds(options.ShutdownTimeout);
 
         var endpoints = LangfuseEndpoints.Resolve(options);
         var resource = BuildResource(options);
@@ -104,7 +106,8 @@ public static class LangfuseTelemetry
             failureSink,
             commentRecorder,
             apiClient,
-            options.DiagnosticsCallback);
+            options.DiagnosticsCallback,
+            options.ShutdownTimeout);
     }
 
     private static ResourceBuilder BuildResource(LangfuseOptions options)

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseTimeout.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseTimeout.cs
@@ -1,0 +1,40 @@
+namespace NexusLabs.Needlr.AgentFramework.Langfuse;
+
+/// <summary>
+/// Converts Langfuse timeout contracts to the millisecond representation used by OpenTelemetry.
+/// </summary>
+internal static class LangfuseTimeout
+{
+    public static int ToFlushMilliseconds(TimeSpan? timeout)
+    {
+        if (timeout is null || timeout.Value == Timeout.InfiniteTimeSpan)
+        {
+            return Timeout.Infinite;
+        }
+
+        var milliseconds = (long)timeout.Value.TotalMilliseconds;
+        return milliseconds < 0
+            ? Timeout.Infinite
+            : (int)Math.Min(milliseconds, int.MaxValue);
+    }
+
+    public static int ToShutdownMilliseconds(TimeSpan timeout)
+    {
+        if (timeout == Timeout.InfiniteTimeSpan)
+        {
+            return Timeout.Infinite;
+        }
+
+        if (timeout < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(timeout),
+                timeout,
+                $"Shutdown timeout must be non-negative or {nameof(Timeout)}.{nameof(Timeout.InfiniteTimeSpan)}.");
+        }
+
+        return (int)Math.Min(
+            Math.Ceiling(timeout.TotalMilliseconds),
+            int.MaxValue);
+    }
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseTraceAttributeProcessor.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseTraceAttributeProcessor.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Globalization;
 using System.Text.Json;
 
 using OpenTelemetry;
@@ -12,8 +11,8 @@ namespace NexusLabs.Needlr.AgentFramework.Langfuse;
 /// <remarks>
 /// <list type="bullet">
 /// <item>
-/// Copies <see cref="Activity.Baggage"/> entries (trace-level <c>session.id</c> / <c>user.id</c>
-/// set on the scenario root) onto each span's tags so per-observation filtering works.
+/// Copies the nearest scenario's explicit Langfuse trace context onto each in-process child span
+/// so per-observation filtering works without using cross-process baggage.
 /// </item>
 /// <item>
 /// Sets <c>langfuse.observation.type</c> explicitly — <c>generation</c> for chat-completion spans
@@ -40,12 +39,6 @@ internal sealed class LangfuseTraceAttributeProcessor : BaseProcessor<Activity>
     private const string ChatStreamActivityName = "agent.chat.stream";
     private const string ToolActivityPrefix = "agent.tool";
 
-    // Baggage keys set by ILangfuseScenario.SetPrompt. Distinct from the Langfuse observation
-    // attribute keys so they can be propagated to children without being copied verbatim onto
-    // every span by CopyBaggageToTags — prompt linking is generation-only.
-    internal const string PromptNameBaggageKey = "langfuse.prompt.name";
-    internal const string PromptVersionBaggageKey = "langfuse.prompt.version";
-
     private readonly string? _environment;
     private readonly string? _release;
 
@@ -71,9 +64,10 @@ internal sealed class LangfuseTraceAttributeProcessor : BaseProcessor<Activity>
     {
         ArgumentNullException.ThrowIfNull(data);
 
-        CopyBaggageToTags(data);
+        var traceContext = LangfuseTraceContext.FindNearest(data);
+        ApplyTraceContext(data, traceContext);
         SetObservationType(data);
-        SetPromptLink(data);
+        SetPromptLink(data, traceContext);
         SetContextAttributes(data);
     }
 
@@ -98,19 +92,34 @@ internal sealed class LangfuseTraceAttributeProcessor : BaseProcessor<Activity>
         }
     }
 
-    private static void CopyBaggageToTags(Activity data)
+    private static void ApplyTraceContext(Activity data, LangfuseTraceContext? context)
     {
-        foreach (var entry in data.Baggage)
+        if (context is null)
         {
-            if (entry.Key is PromptNameBaggageKey or PromptVersionBaggageKey)
-            {
-                continue;
-            }
+            return;
+        }
 
-            if (entry.Value is not null && data.GetTagItem(entry.Key) is null)
-            {
-                data.SetTag(entry.Key, entry.Value);
-            }
+        SetTagIfMissing(data, "langfuse.trace.name", context.Name);
+        SetTagIfMissing(data, "session.id", context.SessionId);
+        SetTagIfMissing(data, "user.id", context.UserId);
+        SetTagIfMissing(data, "langfuse.version", context.Version);
+
+        if (context.Tags.Count > 0 && data.GetTagItem("langfuse.trace.tags") is null)
+        {
+            data.SetTag("langfuse.trace.tags", context.Tags.ToArray());
+        }
+
+        foreach (var entry in context.Metadata)
+        {
+            SetTagIfMissing(data, $"langfuse.trace.metadata.{entry.Key}", entry.Value);
+        }
+    }
+
+    private static void SetTagIfMissing(Activity data, string key, string? value)
+    {
+        if (!string.IsNullOrWhiteSpace(value) && data.GetTagItem(key) is null)
+        {
+            data.SetTag(key, value);
         }
     }
 
@@ -131,26 +140,21 @@ internal sealed class LangfuseTraceAttributeProcessor : BaseProcessor<Activity>
         }
     }
 
-    private static void SetPromptLink(Activity data)
+    private static void SetPromptLink(Activity data, LangfuseTraceContext? context)
     {
-        if (!IsGeneration(data) || data.GetTagItem("langfuse.observation.prompt.name") is not null)
+        if (!IsGeneration(data)
+            || context is null
+            || string.IsNullOrWhiteSpace(context.PromptName)
+            || data.GetTagItem("langfuse.observation.prompt.name") is not null)
         {
             return;
         }
 
-        var name = data.GetBaggageItem(PromptNameBaggageKey);
-        if (string.IsNullOrWhiteSpace(name))
-        {
-            return;
-        }
+        data.SetTag("langfuse.observation.prompt.name", context.PromptName);
 
-        data.SetTag("langfuse.observation.prompt.name", name);
-
-        var version = data.GetBaggageItem(PromptVersionBaggageKey);
-        if (!string.IsNullOrWhiteSpace(version)
-            && int.TryParse(version, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))
+        if (context.PromptVersion is { } version)
         {
-            data.SetTag("langfuse.observation.prompt.version", parsed);
+            data.SetTag("langfuse.observation.prompt.version", version);
         }
     }
 

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseTraceContext.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseTraceContext.cs
@@ -1,0 +1,51 @@
+using System.Diagnostics;
+
+namespace NexusLabs.Needlr.AgentFramework.Langfuse;
+
+/// <summary>
+/// Carries the explicit Langfuse trace context associated with one scenario to its in-process
+/// child activities without placing application data in cross-process OpenTelemetry baggage.
+/// </summary>
+internal sealed record LangfuseTraceContext
+{
+    internal const string ActivityPropertyName =
+        "NexusLabs.Needlr.AgentFramework.Langfuse.TraceContext";
+
+    public required string Name { get; init; }
+
+    public string? SessionId { get; init; }
+
+    public string? UserId { get; init; }
+
+    public IReadOnlyList<string> Tags { get; init; } = [];
+
+    public IReadOnlyDictionary<string, string> Metadata { get; init; } =
+        new Dictionary<string, string>(StringComparer.Ordinal);
+
+    public string? Version { get; init; }
+
+    public string? PromptName { get; init; }
+
+    public int? PromptVersion { get; init; }
+
+    public static LangfuseTraceContext? FindNearest(Activity activity)
+    {
+        ArgumentNullException.ThrowIfNull(activity);
+
+        for (var current = activity; current is not null; current = current.Parent)
+        {
+            if (current.GetCustomProperty(ActivityPropertyName) is LangfuseTraceContext context)
+            {
+                return context;
+            }
+        }
+
+        return null;
+    }
+
+    public static void Attach(Activity? activity, LangfuseTraceContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        activity?.SetCustomProperty(ActivityPropertyName, context);
+    }
+}


### PR DESCRIPTION
## Summary

- add bounded, idempotent final shutdown for standalone Langfuse sessions with structured trace/metric outcomes
- preserve caller cancellation through REST, score, comment, and experiment-link paths while keeping transport timeouts as Langfuse failures
- replace W3C baggage-based scenario propagation with isolated in-process trace context
- guarantee one distinct trace per scenario, including nested scenarios, and restore the prior ambient activity on disposal
- update the Langfuse docs, changelog, credential-free example, and no-server conformance mode

Closes #29
Closes #30
Closes #31

## Validation

- `NexusLabs.Needlr.AgentFramework.Langfuse.Tests`: **102 passed, 0 failed, 0 skipped**
- CI-equivalent repository matrix: **4,261 passed, 0 failed, 0 skipped** across 34 test projects
- full Release build: **0 errors**; 2 existing generated-code `CS0162` warnings
- `python -m mkdocs build --strict`: passed
- solution pack + `scripts/test-packages.ps1 -NoBuild`: passed
- package validation built all **65 example projects** and passed 5 example test projects
- `LangfuseEvaluationApp`: credential-free end-to-end run passed
- `LangfuseConformanceApp -- resiliency`: cancellation propagation, context allowlisting, score-failure reporting, and bounded shutdown passed against an unreachable endpoint
- external compatibility probe: a pre-existing `ILangfuseSession` implementation without `Shutdown` compiled and received the default `NotSupportedException`; external construction of `LangfuseShutdownOutcome` succeeded
- final read-only code review: no high-confidence findings

## Behavioral notes

- `Dispose()` now uses `LangfuseOptions.ShutdownTimeout` (5 seconds by default); unbounded disposal requires explicit `Timeout.InfiniteTimeSpan`
- `Shutdown` reports local OpenTelemetry drain status, not durable Langfuse ingestion
- manual `Flush()` without an explicit timeout retains its existing unbounded behavior
- scenario context is propagated only to in-process child spans; it is intentionally not placed in cross-process baggage
- external `ILangfuseSession` implementations remain compatible through a default interface member and must override `Shutdown` to support explicit shutdown