### PR TITLE
feat(langfuse): expose complete non-owning DI facade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,6 +273,10 @@ jobs:
       run: sudo apt-get update && sudo apt-get install -y clang zlib1g-dev
 
     - name: Publish AOT Console App
+      env:
+        GITHUB_ENV: /tmp/discard-aot-console-env
+        GITHUB_OUTPUT: /tmp/discard-aot-console-output
+        GITHUB_STEP_SUMMARY: /tmp/discard-aot-console-summary
       run: |
         dotnet publish src/Examples/SourceGen/AotSourceGenConsoleApp/AotSourceGenConsoleApp.csproj \
           -c Release \
@@ -307,6 +311,10 @@ jobs:
       run: sudo apt-get update && sudo apt-get install -y clang zlib1g-dev
 
     - name: Publish AOT Web App
+      env:
+        GITHUB_ENV: /tmp/discard-aot-web-env
+        GITHUB_OUTPUT: /tmp/discard-aot-web-output
+        GITHUB_STEP_SUMMARY: /tmp/discard-aot-web-summary
       run: |
         dotnet publish src/Examples/SourceGen/AotSourceGenApp/AotSourceGenApp.csproj \
           -c Release \
@@ -338,6 +346,10 @@ jobs:
       run: sudo apt-get update && sudo apt-get install -y clang zlib1g-dev
 
     - name: Publish AOT Agent Framework App
+      env:
+        GITHUB_ENV: /tmp/discard-aot-agent-env
+        GITHUB_OUTPUT: /tmp/discard-aot-agent-output
+        GITHUB_STEP_SUMMARY: /tmp/discard-aot-agent-summary
       run: |
         dotnet publish src/Examples/AgentFramework/AotAgentFrameworkApp/AotAgentFrameworkApp.csproj \
           -c Release \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ### Added
 
+- **`NexusLabs.Needlr.AgentFramework.Langfuse` now exposes a complete non-owning `ILangfuseClient` facade through dependency injection.** `AddNeedlrLangfuse(...)` registers scenario creation, experiment runs, known-trace scoring, datasets, score configs, metrics, model pricing, prompts, comments, enabled state, and score-failure health without creating or exposing an exporter-owning `ILangfuseSession`. The facade and every individually resolved specialized interface share the exact same instances, while the host owns the single OpenTelemetry provider pipeline and DI owns the REST transport. Standalone `ILangfuseSession` now composes the same internal client implementation and adds only flush/shutdown/disposal ownership. Enabled, disabled, custom-facade, custom-specialized-client, keyed-registration, sampler, transport-disposal, and experiment-linking paths are covered by tests and a new no-server `LangfuseConformanceApp -- dependency-injection` mode. (#32)
 - **`NexusLabs.Needlr.AgentFramework.Langfuse` now exposes bounded final shutdown for standalone sessions.** `ILangfuseSession.Shutdown(timeout)` shares one timeout budget across trace and metric providers, returns a structured `LangfuseShutdownOutcome`, releases all owned resources, and is idempotent across repeated callers. `LangfuseOptions.ShutdownTimeout` controls the bounded best-effort shutdown performed by `Dispose()` and defaults to five seconds; `Timeout.InfiniteTimeSpan` remains available as an explicit opt-in. The result describes local OpenTelemetry provider drain only and does not claim durable Langfuse ingestion. (#29)
+
+### Changed
+
+- **Unkeyed Langfuse DI overrides must preserve singleton facade identity.** A pre-registered `ILangfuseClient` override must be a singleton instance; its specialized clients become the authoritative unkeyed registrations without transferring disposal ownership to DI. Individual specialized-client overrides are supported only as singletons because the hosted facade is singleton. Disabled registration replaces all unkeyed facade/specialized overrides with one coherent no-op composition, while keyed registrations remain untouched. (#32)
+- **BREAKING (alpha): custom `ILangfuseSession` implementations must implement the new `ILangfuseClient` contract directly.** Needlr intentionally does not carry a default-interface compatibility shim for the previous session member layout; alpha consumers should update implementations to provide `Scores` and the inherited facade members rather than imposing permanent dispatch and documentation duplication on the stable API. (#32)
 
 ### Fixed
 

--- a/docs/langfuse.md
+++ b/docs/langfuse.md
@@ -8,7 +8,8 @@ Needlr already emits OpenTelemetry traces and metrics using the GenAI semantic
 conventions (`gen_ai.*`), which Langfuse understands natively. The
 `NexusLabs.Needlr.AgentFramework.Langfuse` package adds the missing piece: an OTLP
 exporter pointed at Langfuse, per-scenario trace grouping, and a bridge that turns
-evaluator metrics into Langfuse scores.
+evaluator metrics into Langfuse scores. It supports both exporter-owning standalone
+sessions and a complete non-owning facade for dependency-injection-based hosts.
 
 ## Quick Start
 
@@ -89,7 +90,9 @@ using (var scenario = langfuse.BeginScenario("trip-planner", sessionId: runId))
 Two runnable examples live under `src/Examples/AgentFramework/`:
 
 - `LangfuseEvaluationApp` — the full flow with no LLM or Langfuse credentials required (no-ops cleanly without keys).
-- `LangfuseConformanceApp` — a small Langfuse-supported eval that **reads the trace and scores back** from a live Langfuse (local Docker by default) to prove ingestion. Not part of CI; run it by hand after standing Langfuse up. Run it with the `resiliency` argument to instead prove **graceful degradation when Langfuse is unreachable** (no server required): the eval still passes and every dropped score is surfaced.
+- `LangfuseConformanceApp` — a small Langfuse-supported eval that **reads the trace and scores back** from a live Langfuse (local Docker by default) to prove ingestion. It also has no-server modes:
+  - `resiliency` proves cancellation, safe context propagation, score-failure reporting, and bounded shutdown while Langfuse is unreachable.
+  - `dependency-injection` proves `ILangfuseClient` exposes the complete evaluation surface through one host-owned telemetry pipeline without registering a standalone session.
 
 ## What appears in Langfuse
 
@@ -424,29 +427,68 @@ builder.Services.AddNeedlrLangfuse(options =>
 ```
 
 This wires the OTLP exporter into the host's tracer and meter providers so they
-share the application lifecycle, and registers an `ILangfuseScoreClient` for scoring
-request traces by id:
+share the application lifecycle, and registers the complete non-owning
+`ILangfuseClient` facade:
 
 ```csharp
-public sealed class MyHandler(ILangfuseScoreClient scores)
+public sealed class MyEvalRunner(ILangfuseClient langfuse)
 {
-    public async Task HandleAsync(/* ... */)
+    public async Task RunAsync(CancellationToken cancellationToken)
     {
-        var traceId = System.Diagnostics.Activity.Current?.TraceId.ToString();
-        if (traceId is not null)
+        using var scenario = langfuse.BeginScenario(
+            "support-agent: refund",
+            sessionId: "ci-run-42",
+            tags: ["regression"]);
+
+        var response = await RunAgentAsync(cancellationToken);
+        await scenario.RecordScoreAsync(
+            "resolved",
+            response.Resolved,
+            cancellationToken: cancellationToken);
+
+        var experiment = langfuse.BeginExperimentRun(
+            "support-agent-regression",
+            "commit-abc123");
+        using var item = await experiment.BeginItemAsync(
+            "refund-case",
+            cancellationToken: cancellationToken);
+
+        if (item.TraceId is { } traceId)
         {
-            await scores.RecordScoreAsync(traceId, "helpfulness", value: true);
+            await langfuse.Scores.RecordScoreAsync(
+                traceId,
+                "reviewed",
+                value: true,
+                cancellationToken: cancellationToken);
         }
     }
 }
 ```
 
-When Langfuse is not configured, a disabled no-op `ILangfuseScoreClient` is registered,
-so injection always succeeds and host code never needs to branch on configuration.
+`ILangfuseClient` deliberately does not implement `IDisposable` and exposes no flush or
+shutdown methods. The host owns the `TracerProvider`, optional `MeterProvider`, and shared
+HTTP transport; disposing the host releases them in the correct order. No
+`ILangfuseSession` is registered in dependency injection.
 
-`AddNeedlrLangfuse` also registers `ILangfuseDatasetClient` and `ILangfuseScoreConfigClient`
-(both disabled no-ops when unconfigured) for managing datasets and score configs from a host
-application.
+Every specialized interface (`ILangfuseScoreClient`, `ILangfuseDatasetClient`,
+`ILangfuseScoreConfigClient`, `ILangfuseMetricsClient`, `ILangfuseModelClient`, and
+`ILangfusePromptClient`) resolves to the exact instance exposed by the facade. When Langfuse
+is not configured, the facade and all specialized interfaces are one coherent set of disabled
+no-ops, so host code does not branch on credentials.
+
+!!! note "DI override ownership"
+    A custom unkeyed `ILangfuseClient` must be registered as a singleton **instance** before
+    `AddNeedlrLangfuse`; its specialized clients are then exposed as externally owned instance
+    aliases. Alternatively, individual specialized interfaces may be overridden as singletons
+    and are composed into Needlr's facade. Scoped and transient overrides are rejected because a
+    singleton facade cannot safely capture them. Keyed registrations are independent and remain
+    untouched.
+
+Run the no-server ownership check:
+
+```bash
+dotnet run --project src/Examples/AgentFramework/LangfuseConformanceApp -- dependency-injection
+```
 
 ## Langfuse Cloud vs self-hosted
 

--- a/src/Examples/AgentFramework/LangfuseConformanceApp/Program.cs
+++ b/src/Examples/AgentFramework/LangfuseConformanceApp/Program.cs
@@ -28,6 +28,9 @@
 // score is surfaced via ScoresFailed + ScoreErrorCallback:
 //
 //     dotnet run --project src/Examples/AgentFramework/LangfuseConformanceApp -- resiliency
+//
+// Run with `dependency-injection` to prove that AddNeedlrLangfuse registers a
+// complete non-owning facade backed by one host-owned OpenTelemetry pipeline.
 // =============================================================================
 
 using System.Diagnostics;
@@ -39,6 +42,8 @@ using Microsoft.Extensions.AI;
 using Microsoft.Extensions.AI.Evaluation;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+
+using OpenTelemetry.Trace;
 
 using NexusLabs.Needlr.AgentFramework;
 using NexusLabs.Needlr.AgentFramework.Diagnostics;
@@ -59,6 +64,11 @@ Console.WriteLine();
 if (args.Length > 0 && string.Equals(args[0], "resiliency", StringComparison.OrdinalIgnoreCase))
 {
     return await RunResiliencyCheckAsync();
+}
+
+if (args.Length > 0 && string.Equals(args[0], "dependency-injection", StringComparison.OrdinalIgnoreCase))
+{
+    return RunDependencyInjectionCheck();
 }
 
 // "experiments" mode exercises the dataset/experiment, score-config, comment,
@@ -407,6 +417,78 @@ static async Task<int> RunResiliencyCheckAsync()
     }
 
     Console.WriteLine("RESILIENCY FAILED — failures were not surfaced as expected.");
+    return 1;
+}
+
+static int RunDependencyInjectionCheck()
+{
+    Console.WriteLine("[mode] Dependency injection: complete non-owning Langfuse facade.");
+    Console.WriteLine();
+
+    var services = new ServiceCollection();
+    services.AddNeedlrLangfuse(options =>
+    {
+        options.PublicKey = "pk-lf-di-conformance";
+        options.SecretKey = "sk-lf-di-conformance";
+        options.Host = "http://127.0.0.1:1";
+        options.ServiceName = "needlr-langfuse-di-conformance";
+    });
+
+    var provider = services.BuildServiceProvider();
+    var passed = false;
+    try
+    {
+        var client = provider.GetRequiredService<ILangfuseClient>();
+        var tracerProviders = provider.GetServices<TracerProvider>().ToArray();
+        using var scenario = client.BeginScenario(
+            "di: hosted-scenario",
+            sessionId: "di-run",
+            tags: ["dependency-injection"]);
+        var experiment = client.BeginExperimentRun("di-dataset", "di-experiment");
+
+        var identitiesMatch =
+            ReferenceEquals(client.Scores, provider.GetRequiredService<ILangfuseScoreClient>()) &&
+            ReferenceEquals(client.Datasets, provider.GetRequiredService<ILangfuseDatasetClient>()) &&
+            ReferenceEquals(client.ScoreConfigs, provider.GetRequiredService<ILangfuseScoreConfigClient>()) &&
+            ReferenceEquals(client.Metrics, provider.GetRequiredService<ILangfuseMetricsClient>()) &&
+            ReferenceEquals(client.Models, provider.GetRequiredService<ILangfuseModelClient>()) &&
+            ReferenceEquals(client.Prompts, provider.GetRequiredService<ILangfusePromptClient>());
+
+        passed =
+            client.IsEnabled &&
+            client is not IDisposable &&
+            provider.GetService<ILangfuseSession>() is null &&
+            tracerProviders.Length == 1 &&
+            scenario.TraceId is { Length: > 0 } &&
+            experiment.DatasetName == "di-dataset" &&
+            experiment.RunName == "di-experiment" &&
+            identitiesMatch;
+
+        Console.WriteLine($"  facade enabled:            {client.IsEnabled}");
+        Console.WriteLine($"  facade owns lifecycle:     {client is IDisposable}");
+        Console.WriteLine($"  ILangfuseSession in DI:    {provider.GetService<ILangfuseSession>() is not null}");
+        Console.WriteLine($"  TracerProvider count:      {tracerProviders.Length}");
+        Console.WriteLine($"  scenario trace id:         {scenario.TraceId}");
+        Console.WriteLine($"  experiment:                {experiment.DatasetName}/{experiment.RunName}");
+        Console.WriteLine($"  specialized identities:    {(identitiesMatch ? "shared" : "MISMATCH")}");
+    }
+    finally
+    {
+        var disposalStopwatch = Stopwatch.StartNew();
+        provider.Dispose();
+        disposalStopwatch.Stop();
+        Console.WriteLine($"  provider disposal:         {disposalStopwatch.Elapsed.TotalMilliseconds:F0} ms");
+    }
+
+    Console.WriteLine();
+    if (passed)
+    {
+        Console.WriteLine("DEPENDENCY INJECTION PASSED — one host telemetry pipeline owns lifecycle,");
+        Console.WriteLine("while ILangfuseClient provides the complete non-owning evaluation surface.");
+        return 0;
+    }
+
+    Console.WriteLine("DEPENDENCY INJECTION FAILED — hosted facade ownership or identity was incorrect.");
     return 1;
 }
 

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/ControlledExporter.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/ControlledExporter.cs
@@ -8,10 +8,18 @@ namespace NexusLabs.Needlr.AgentFramework.Langfuse.Tests;
 internal sealed class ControlledExporter<T> : BaseExporter<T>
     where T : class
 {
+    private readonly Func<int>? _getDependencyDisposeCalls;
     private readonly ManualResetEventSlim _shutdownEntered = new(initialState: false);
     private readonly ManualResetEventSlim _shutdownRelease = new(initialState: true);
     private int _disposeCalls;
     private int _shutdownCalls;
+
+    public ControlledExporter(Func<int>? getDependencyDisposeCalls = null)
+    {
+        _getDependencyDisposeCalls = getDependencyDisposeCalls;
+    }
+
+    public int? DependencyDisposeCallsAtDispose { get; private set; }
 
     public bool ShutdownSucceeds { get; set; } = true;
 
@@ -52,6 +60,7 @@ internal sealed class ControlledExporter<T> : BaseExporter<T>
     {
         if (disposing)
         {
+            DependencyDisposeCallsAtDispose ??= _getDependencyDisposeCalls?.Invoke();
             Interlocked.Increment(ref _disposeCalls);
             _shutdownEntered.Dispose();
             _shutdownRelease.Dispose();

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/LangfuseClientFacadeTests.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/LangfuseClientFacadeTests.cs
@@ -1,0 +1,404 @@
+using System.Diagnostics;
+using System.Net;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using OpenTelemetry;
+using OpenTelemetry.Trace;
+
+namespace NexusLabs.Needlr.AgentFramework.Langfuse.Tests;
+
+[Collection("Langfuse activity")]
+public sealed class LangfuseClientFacadeTests
+{
+    private readonly CancellationToken _cancellationToken = TestContext.Current.CancellationToken;
+
+    [Fact]
+    public void AddNeedlrLangfuse_Configured_RegistersCompleteNonOwningFacadeWithExactSpecializedIdentities()
+    {
+        var handler = new TrackingHttpMessageHandler();
+        var services = CreateConfiguredServices(handler);
+
+        using var provider = services.BuildServiceProvider();
+        var client = provider.GetRequiredService<ILangfuseClient>();
+        var tracerProviders = provider.GetServices<TracerProvider>().ToArray();
+
+        Assert.Single(tracerProviders);
+        Assert.True(client.IsEnabled, "Expected configured Langfuse registration to enable the facade.");
+        Assert.Equal(0, client.ScoresFailed);
+        Assert.Null(provider.GetService<ILangfuseSession>());
+        Assert.False(client is IDisposable, "Expected the hosted facade to expose no telemetry lifecycle ownership.");
+        Assert.Same(client.Scores, provider.GetRequiredService<ILangfuseScoreClient>());
+        Assert.Same(client.Datasets, provider.GetRequiredService<ILangfuseDatasetClient>());
+        Assert.Same(client.ScoreConfigs, provider.GetRequiredService<ILangfuseScoreConfigClient>());
+        Assert.Same(client.Metrics, provider.GetRequiredService<ILangfuseMetricsClient>());
+        Assert.Same(client.Models, provider.GetRequiredService<ILangfuseModelClient>());
+        Assert.Same(client.Prompts, provider.GetRequiredService<ILangfusePromptClient>());
+
+        using var scenario = client.BeginScenario("hosted-scenario", sessionId: "session-1");
+
+        Assert.NotNull(scenario.Activity);
+        Assert.NotNull(scenario.TraceId);
+        Assert.Equal(scenario.Activity!.TraceId.ToHexString(), scenario.TraceId);
+    }
+
+    [Fact]
+    public void AddNeedlrLangfuse_Configured_PreservesHostSampler()
+    {
+        var services = new ServiceCollection();
+        services
+            .AddOpenTelemetry()
+            .WithTracing(tracing => tracing.SetSampler(new AlwaysOffSampler()));
+        services.AddNeedlrLangfuse(options =>
+        {
+            options.PublicKey = "pk";
+            options.SecretKey = "sk";
+            options.Host = "http://127.0.0.1:1";
+            options.SamplingRatio = 1;
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var client = provider.GetRequiredService<ILangfuseClient>();
+
+        using var scenario = client.BeginScenario("host-sampler");
+
+        Assert.NotNull(scenario.Activity);
+        Assert.Equal(ActivityTraceFlags.None, scenario.Activity.ActivityTraceFlags);
+        Assert.Single(provider.GetServices<TracerProvider>());
+    }
+
+    [Fact]
+    public async Task AddNeedlrLangfuse_Configured_ComposesFacadeFromPreRegisteredSpecializedClients()
+    {
+        using var scoreHttp = LangfuseHttpStub.Create(
+            _ => new HttpResponseMessage(HttpStatusCode.InternalServerError),
+            []);
+        var scores = CreateScoreClient(scoreHttp);
+        await scores.RecordScoreAsync(
+            "trace",
+            "failure",
+            1.0,
+            cancellationToken: _cancellationToken);
+        var datasets = new DisabledLangfuseDatasetClient();
+        var scoreConfigs = new DisabledLangfuseScoreConfigClient();
+        var metrics = new DisabledLangfuseMetricsClient();
+        var models = new DisabledLangfuseModelClient();
+        var prompts = new DisabledLangfusePromptClient();
+        var services = new ServiceCollection();
+        services.AddSingleton<ILangfuseScoreClient>(scores);
+        services.AddSingleton<ILangfuseDatasetClient>(datasets);
+        services.AddSingleton<ILangfuseScoreConfigClient>(scoreConfigs);
+        services.AddSingleton<ILangfuseMetricsClient>(metrics);
+        services.AddSingleton<ILangfuseModelClient>(models);
+        services.AddSingleton<ILangfusePromptClient>(prompts);
+        services.AddNeedlrLangfuse(options =>
+        {
+            options.PublicKey = "pk";
+            options.SecretKey = "sk";
+            options.Host = "http://127.0.0.1:1";
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var client = provider.GetRequiredService<ILangfuseClient>();
+        using var scenario = client.BeginScenario(
+            "custom-score-client",
+            sessionId: "custom-session");
+        await scenario.RecordScoreAsync(
+            "scenario-failure",
+            1.0,
+            cancellationToken: _cancellationToken);
+        await scenario.RecordSessionScoreAsync(
+            "session-failure",
+            1.0,
+            cancellationToken: _cancellationToken);
+
+        Assert.Same(scores, client.Scores);
+        Assert.Equal(3, scores.ScoresFailed);
+        Assert.Equal(scores.ScoresFailed, client.ScoresFailed);
+        Assert.Same(datasets, client.Datasets);
+        Assert.Same(scoreConfigs, client.ScoreConfigs);
+        Assert.Same(metrics, client.Metrics);
+        Assert.Same(models, client.Models);
+        Assert.Same(prompts, client.Prompts);
+    }
+
+    [Fact]
+    public void AddNeedlrLangfuse_Configured_PreRegisteredFacadeIsAuthoritativeForSpecializedClients()
+    {
+        var customFacade = new DisabledLangfuseClient();
+        var services = new ServiceCollection();
+        services.AddSingleton<ILangfuseClient>(customFacade);
+        services.AddNeedlrLangfuse(options =>
+        {
+            options.PublicKey = "pk";
+            options.SecretKey = "sk";
+            options.Host = "http://127.0.0.1:1";
+        });
+
+        Assert.Same(
+            customFacade.Scores,
+            services.Last(descriptor =>
+                descriptor.ServiceType == typeof(ILangfuseScoreClient)
+                && descriptor.ServiceKey is null).ImplementationInstance);
+        Assert.Same(
+            customFacade.Datasets,
+            services.Last(descriptor =>
+                descriptor.ServiceType == typeof(ILangfuseDatasetClient)
+                && descriptor.ServiceKey is null).ImplementationInstance);
+
+        using var provider = services.BuildServiceProvider();
+        var client = provider.GetRequiredService<ILangfuseClient>();
+
+        Assert.Same(customFacade, client);
+        Assert.Same(client.Scores, provider.GetRequiredService<ILangfuseScoreClient>());
+        Assert.Same(client.Datasets, provider.GetRequiredService<ILangfuseDatasetClient>());
+        Assert.Same(client.ScoreConfigs, provider.GetRequiredService<ILangfuseScoreConfigClient>());
+        Assert.Same(client.Metrics, provider.GetRequiredService<ILangfuseMetricsClient>());
+        Assert.Same(client.Models, provider.GetRequiredService<ILangfuseModelClient>());
+        Assert.Same(client.Prompts, provider.GetRequiredService<ILangfusePromptClient>());
+    }
+
+    [Fact]
+    public void AddNeedlrLangfuse_Configured_PreRegisteredFacadeFactoryIsRejected()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<ILangfuseClient>(_ => new DisabledLangfuseClient());
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            services.AddNeedlrLangfuse(options =>
+            {
+                options.PublicKey = "pk";
+                options.SecretKey = "sk";
+                options.Host = "http://127.0.0.1:1";
+            }));
+
+        Assert.Contains(nameof(ILangfuseClient), exception.Message, StringComparison.Ordinal);
+        Assert.Contains("instance", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void AddNeedlrLangfuse_Configured_KeyedFacadeDoesNotReplaceUnkeyedBuiltInFacade()
+    {
+        var keyedFacade = new DisabledLangfuseClient();
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<ILangfuseClient>("custom", keyedFacade);
+        services.AddNeedlrLangfuse(options =>
+        {
+            options.PublicKey = "pk";
+            options.SecretKey = "sk";
+            options.Host = "http://127.0.0.1:1";
+            options.SamplingRatio = 0;
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var client = provider.GetRequiredService<ILangfuseClient>();
+
+        Assert.True(client.IsEnabled, "Expected a keyed facade not to suppress the default facade.");
+        Assert.Same(keyedFacade, provider.GetRequiredKeyedService<ILangfuseClient>("custom"));
+        Assert.Same(client.Scores, provider.GetRequiredService<ILangfuseScoreClient>());
+    }
+
+    [Fact]
+    public void AddNeedlrLangfuse_Configured_KeyedScopedSpecializedClientDoesNotAffectDefaultFacade()
+    {
+        var services = new ServiceCollection();
+        services.AddKeyedScoped<ILangfuseScoreClient, DisabledLangfuseScoreClient>("custom");
+
+        services.AddNeedlrLangfuse(options =>
+        {
+            options.PublicKey = "pk";
+            options.SecretKey = "sk";
+            options.Host = "http://127.0.0.1:1";
+            options.SamplingRatio = 0;
+        });
+
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+        var client = provider.GetRequiredService<ILangfuseClient>();
+
+        Assert.True(client.Scores.IsEnabled, "Expected the unkeyed specialized client to remain enabled.");
+        Assert.False(
+            scope.ServiceProvider.GetRequiredKeyedService<ILangfuseScoreClient>("custom").IsEnabled,
+            "Expected the keyed specialized registration to remain available independently.");
+    }
+
+    [Theory]
+    [InlineData(ServiceLifetime.Scoped)]
+    [InlineData(ServiceLifetime.Transient)]
+    public void AddNeedlrLangfuse_Configured_NonSingletonSpecializedOverrideIsRejected(
+        ServiceLifetime lifetime)
+    {
+        var services = new ServiceCollection();
+        if (lifetime == ServiceLifetime.Scoped)
+        {
+            services.AddScoped<ILangfuseScoreClient, DisabledLangfuseScoreClient>();
+        }
+        else
+        {
+            services.AddTransient<ILangfuseScoreClient, DisabledLangfuseScoreClient>();
+        }
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            services.AddNeedlrLangfuse(options =>
+            {
+                options.PublicKey = "pk";
+                options.SecretKey = "sk";
+                options.Host = "http://127.0.0.1:1";
+            }));
+
+        Assert.Contains(nameof(ILangfuseScoreClient), exception.Message, StringComparison.Ordinal);
+        Assert.Contains("singleton", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task AddNeedlrLangfuse_Configured_FacadeBeginsAndLinksExperimentRun()
+    {
+        var handler = new TrackingHttpMessageHandler();
+        var services = CreateConfiguredServices(handler);
+
+        using var provider = services.BuildServiceProvider();
+        var client = provider.GetRequiredService<ILangfuseClient>();
+        var run = client.BeginExperimentRun("dataset-a", "run-42", "facade run");
+
+        using var scenario = await run.BeginItemAsync(
+            "item-7",
+            scenarioName: "facade-item",
+            cancellationToken: _cancellationToken);
+
+        var request = Assert.Single(handler.CapturedRequests);
+        Assert.Equal(HttpMethod.Post, request.Method);
+        Assert.Equal("/api/public/dataset-run-items", request.Uri.AbsolutePath);
+        Assert.Contains("\"runName\":\"run-42\"", request.Body, StringComparison.Ordinal);
+        Assert.Contains("\"datasetItemId\":\"item-7\"", request.Body, StringComparison.Ordinal);
+        Assert.Contains($"\"traceId\":\"{scenario.TraceId}\"", request.Body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task AddNeedlrLangfuse_Disabled_RegistersCoherentNoOpFacadeWithExactSpecializedIdentities()
+    {
+        var services = new ServiceCollection();
+        services.AddNeedlrLangfuse(options => options.Enabled = false);
+
+        using var provider = services.BuildServiceProvider();
+        var client = provider.GetRequiredService<ILangfuseClient>();
+
+        Assert.Empty(provider.GetServices<TracerProvider>());
+        Assert.False(client.IsEnabled, "Expected disabled Langfuse registration to provide an inert facade.");
+        Assert.Equal(0, client.ScoresFailed);
+        Assert.Null(provider.GetService<ILangfuseSession>());
+        Assert.False(client is IDisposable, "Expected the disabled facade to remain non-owning.");
+        Assert.Same(client.Scores, provider.GetRequiredService<ILangfuseScoreClient>());
+        Assert.Same(client.Datasets, provider.GetRequiredService<ILangfuseDatasetClient>());
+        Assert.Same(client.ScoreConfigs, provider.GetRequiredService<ILangfuseScoreConfigClient>());
+        Assert.Same(client.Metrics, provider.GetRequiredService<ILangfuseMetricsClient>());
+        Assert.Same(client.Models, provider.GetRequiredService<ILangfuseModelClient>());
+        Assert.Same(client.Prompts, provider.GetRequiredService<ILangfusePromptClient>());
+
+        using var scenario = client.BeginScenario("disabled");
+        var run = client.BeginExperimentRun("dataset", "run");
+        using var item = await run.BeginItemAsync("item", cancellationToken: _cancellationToken);
+        await client.Scores.RecordScoreAsync(
+            "trace",
+            "score",
+            1.0,
+            cancellationToken: _cancellationToken);
+        await client.AddTraceCommentAsync("trace", "comment", _cancellationToken);
+
+        Assert.Null(scenario.TraceId);
+        Assert.Null(item.TraceId);
+        Assert.Empty(provider.GetServices<TracerProvider>());
+    }
+
+    [Fact]
+    public void AddNeedlrLangfuse_Disabled_ReplacesPreRegisteredSpecializedClientWithCoherentNoOp()
+    {
+        using var scoreHttp = LangfuseHttpStub.Create(
+            _ => new HttpResponseMessage(HttpStatusCode.OK),
+            []);
+        var preRegisteredScores = CreateScoreClient(scoreHttp);
+        var preRegisteredFacade = new DisabledLangfuseClient();
+        var keyedScores = new DisabledLangfuseScoreClient();
+        var services = new ServiceCollection();
+        services.AddSingleton<ILangfuseClient>(preRegisteredFacade);
+        services.AddSingleton<ILangfuseScoreClient>(preRegisteredScores);
+        services.AddKeyedSingleton<ILangfuseScoreClient>("custom", keyedScores);
+        services.AddNeedlrLangfuse(options => options.Enabled = false);
+
+        using var provider = services.BuildServiceProvider();
+        var client = provider.GetRequiredService<ILangfuseClient>();
+        var scores = provider.GetRequiredService<ILangfuseScoreClient>();
+
+        Assert.Same(client.Scores, scores);
+        Assert.NotSame(preRegisteredFacade, client);
+        Assert.NotSame(preRegisteredScores, scores);
+        Assert.False(scores.IsEnabled, "Expected disabled registration to replace specialized clients with no-ops.");
+        Assert.Same(
+            keyedScores,
+            provider.GetRequiredKeyedService<ILangfuseScoreClient>("custom"));
+    }
+
+    [Fact]
+    public void AddNeedlrLangfuse_ProviderDisposal_ShutsDownTracerBeforeDiOwnedHttpTransport()
+    {
+        var handler = new TrackingHttpMessageHandler();
+        var exporter = new ControlledExporter<Activity>(() => handler.DisposeCalls);
+        var services = new ServiceCollection();
+        services
+            .AddOpenTelemetry()
+            .WithTracing(tracing => tracing
+                .AddSource("LangfuseClientFacadeTests.Disposal")
+                .AddProcessor(new SimpleActivityExportProcessor(exporter)));
+        services.AddSingleton(_ => new LangfuseHttpTransport(
+            new HttpClient(handler, disposeHandler: true)));
+        services.AddNeedlrLangfuse(options =>
+        {
+            options.PublicKey = "pk";
+            options.SecretKey = "sk";
+            options.Host = "http://127.0.0.1:1";
+            options.SamplingRatio = 0;
+        });
+
+        var provider = services.BuildServiceProvider();
+        var client = provider.GetRequiredService<ILangfuseClient>();
+        _ = provider.GetRequiredService<TracerProvider>();
+
+        Assert.False(client is IDisposable, "Expected callers to have no facade disposal path.");
+        Assert.Equal(0, handler.DisposeCalls);
+
+        provider.Dispose();
+
+        Assert.Equal(0, exporter.DependencyDisposeCallsAtDispose);
+        Assert.Equal(1, handler.DisposeCalls);
+    }
+
+    private static ServiceCollection CreateConfiguredServices(TrackingHttpMessageHandler handler)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(_ => new LangfuseHttpTransport(
+            new HttpClient(handler, disposeHandler: true)));
+        services.AddNeedlrLangfuse(options =>
+        {
+            options.PublicKey = "pk";
+            options.SecretKey = "sk";
+            options.Host = "http://127.0.0.1:1";
+            options.SamplingRatio = 0;
+        });
+        return services;
+    }
+
+    private static LangfuseScoreClient CreateScoreClient(HttpClient httpClient)
+    {
+        var failureSink = new LangfuseScoreFailureSink(
+            LangfuseScoreFailureMode.NonFatal,
+            callback: null);
+        var apiClient = new LangfuseScoreApiClient(
+            httpClient,
+            new Uri("https://lf.example/api/public/scores"),
+            "Basic dGVzdA==");
+        var recorder = new LangfuseScoreRecorder(
+            apiClient,
+            failureSink,
+            normalizeNames: false);
+        return new LangfuseScoreClient(recorder, failureSink);
+    }
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/LangfuseSessionShutdownTests.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/LangfuseSessionShutdownTests.cs
@@ -219,34 +219,24 @@ public sealed class LangfuseSessionShutdownTests
         }
 
         var handler = new TrackingHttpMessageHandler();
-        var httpClient = new HttpClient(handler, disposeHandler: true);
-        var scoreApiClient = new LangfuseScoreApiClient(
-            httpClient,
-            new Uri("https://lf.example/api/public/scores"),
-            "Basic x");
-        var apiClient = new LangfuseApiClient(
-            httpClient,
-            new Uri("https://lf.example"),
-            "Basic x");
-        var failureSink = new LangfuseScoreFailureSink(
-            LangfuseScoreFailureMode.Strict,
-            callback: null);
-        var recorder = new LangfuseScoreRecorder(
-            scoreApiClient,
-            failureSink,
-            normalizeNames: false);
-        var commentRecorder = new LangfuseCommentRecorder(
-            apiClient,
-            diagnostics: null);
+        var transport = new LangfuseHttpTransport(
+            new HttpClient(handler, disposeHandler: true));
+        var options = new LangfuseOptions
+        {
+            PublicKey = "pk",
+            SecretKey = "sk",
+            Host = "https://lf.example",
+            ScoreFailureMode = LangfuseScoreFailureMode.Strict,
+        };
+        var client = new LangfuseClient(
+            transport,
+            LangfuseEndpoints.Resolve(options),
+            options);
         var session = new LangfuseSession(
             tracerProvider,
             meterProvider,
-            httpClient,
-            recorder,
-            failureSink,
-            commentRecorder,
-            apiClient,
-            diagnostics: null,
+            transport,
+            client,
             defaultShutdownTimeout);
 
         return (session, traceExporter, metricExporter, handler);

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/LangfuseStandaloneCompositionTests.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/LangfuseStandaloneCompositionTests.cs
@@ -1,0 +1,85 @@
+using System.Diagnostics;
+
+using OpenTelemetry;
+using OpenTelemetry.Trace;
+
+namespace NexusLabs.Needlr.AgentFramework.Langfuse.Tests;
+
+[Collection("Langfuse activity")]
+public sealed class LangfuseStandaloneCompositionTests
+{
+    [Fact]
+    public void SessionContract_InheritsAbstractClientSurfaceWithoutRedeclaringFacadeMembers()
+    {
+        Assert.Contains(typeof(ILangfuseClient), typeof(ILangfuseSession).GetInterfaces());
+        Assert.Empty(typeof(ILangfuseSession).GetProperties(
+            System.Reflection.BindingFlags.Public |
+            System.Reflection.BindingFlags.Instance |
+            System.Reflection.BindingFlags.DeclaredOnly));
+        Assert.Equal(
+            ["Flush", "Shutdown"],
+            typeof(ILangfuseSession)
+                .GetMethods(
+                    System.Reflection.BindingFlags.Public |
+                    System.Reflection.BindingFlags.Instance |
+                    System.Reflection.BindingFlags.DeclaredOnly)
+                .Select(method => method.Name)
+                .OrderBy(name => name)
+                .ToArray());
+        Assert.All(
+            typeof(ILangfuseClient)
+                .GetMethods(
+                    System.Reflection.BindingFlags.Public |
+                    System.Reflection.BindingFlags.Instance |
+                    System.Reflection.BindingFlags.DeclaredOnly),
+            method => Assert.True(
+                method.IsAbstract,
+                $"Expected {method.Name} to remain an abstract client contract member."));
+    }
+
+    [Fact]
+    public void Session_ComposesSharedClientAndOwnsOnlyStandaloneLifecycleResources()
+    {
+        var options = new LangfuseOptions
+        {
+            PublicKey = "pk",
+            SecretKey = "sk",
+            Host = "https://lf.example",
+            SamplingRatio = 0,
+        };
+        var handler = new TrackingHttpMessageHandler();
+        var transport = new LangfuseHttpTransport(new HttpClient(handler, disposeHandler: true));
+        var client = new LangfuseClient(transport, LangfuseEndpoints.Resolve(options), options);
+        var exporter = new ControlledExporter<Activity>();
+        var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .SetSampler(new AlwaysOffSampler())
+            .AddSource(LangfuseActivitySource.Name)
+            .AddProcessor(new SimpleActivityExportProcessor(exporter))
+            .Build();
+        var session = new LangfuseSession(
+            tracerProvider,
+            meterProvider: null,
+            transport,
+            client,
+            options.ShutdownTimeout);
+
+        Assert.IsAssignableFrom<ILangfuseClient>(session);
+        Assert.Same(client.Scores, session.Scores);
+        Assert.Same(client.Datasets, session.Datasets);
+        Assert.Same(client.ScoreConfigs, session.ScoreConfigs);
+        Assert.Same(client.Metrics, session.Metrics);
+        Assert.Same(client.Models, session.Models);
+        Assert.Same(client.Prompts, session.Prompts);
+
+        using var scenario = session.BeginScenario("standalone-composition");
+
+        Assert.NotNull(scenario.TraceId);
+        Assert.Equal(0, handler.DisposeCalls);
+
+        session.Dispose();
+
+        Assert.Equal(1, exporter.ShutdownCalls);
+        Assert.Equal(1, exporter.DisposeCalls);
+        Assert.Equal(1, handler.DisposeCalls);
+    }
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/TrackingHttpMessageHandler.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse.Tests/TrackingHttpMessageHandler.cs
@@ -7,14 +7,39 @@ namespace NexusLabs.Needlr.AgentFramework.Langfuse.Tests;
 /// </summary>
 internal sealed class TrackingHttpMessageHandler : HttpMessageHandler
 {
+    private readonly List<CapturedRequest> _capturedRequests = [];
     private int _disposeCalls;
+
+    public IReadOnlyList<CapturedRequest> CapturedRequests
+    {
+        get
+        {
+            lock (_capturedRequests)
+            {
+                return [.. _capturedRequests];
+            }
+        }
+    }
 
     public int DisposeCalls => Volatile.Read(ref _disposeCalls);
 
-    protected override Task<HttpResponseMessage> SendAsync(
+    protected override async Task<HttpResponseMessage> SendAsync(
         HttpRequestMessage request,
-        CancellationToken cancellationToken) =>
-        Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        CancellationToken cancellationToken)
+    {
+        var body = request.Content is null
+            ? null
+            : await request.Content.ReadAsStringAsync(cancellationToken);
+        lock (_capturedRequests)
+        {
+            _capturedRequests.Add(new CapturedRequest(
+                request.Method,
+                request.RequestUri!,
+                body));
+        }
+
+        return new HttpResponseMessage(HttpStatusCode.OK);
+    }
 
     protected override void Dispose(bool disposing)
     {

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/DisabledLangfuseClient.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/DisabledLangfuseClient.cs
@@ -1,0 +1,64 @@
+namespace NexusLabs.Needlr.AgentFramework.Langfuse;
+
+/// <summary>
+/// Coherent no-op <see cref="ILangfuseClient"/> used when Langfuse is disabled or unconfigured.
+/// </summary>
+internal sealed class DisabledLangfuseClient : ILangfuseClient
+{
+    public DisabledLangfuseClient()
+    {
+        Scores = new DisabledLangfuseScoreClient();
+        Datasets = new DisabledLangfuseDatasetClient();
+        ScoreConfigs = new DisabledLangfuseScoreConfigClient();
+        Metrics = new DisabledLangfuseMetricsClient();
+        Models = new DisabledLangfuseModelClient();
+        Prompts = new DisabledLangfusePromptClient();
+    }
+
+    /// <inheritdoc />
+    public bool IsEnabled => false;
+
+    /// <inheritdoc />
+    public int ScoresFailed => 0;
+
+    /// <inheritdoc />
+    public ILangfuseScoreClient Scores { get; }
+
+    /// <inheritdoc />
+    public ILangfuseDatasetClient Datasets { get; }
+
+    /// <inheritdoc />
+    public ILangfuseScoreConfigClient ScoreConfigs { get; }
+
+    /// <inheritdoc />
+    public ILangfuseMetricsClient Metrics { get; }
+
+    /// <inheritdoc />
+    public ILangfuseModelClient Models { get; }
+
+    /// <inheritdoc />
+    public ILangfusePromptClient Prompts { get; }
+
+    /// <inheritdoc />
+    public ILangfuseScenario BeginScenario(
+        string name,
+        string? sessionId = null,
+        string? userId = null,
+        IEnumerable<string>? tags = null,
+        IReadOnlyDictionary<string, string>? metadata = null) =>
+        new DisabledLangfuseScenario();
+
+    /// <inheritdoc />
+    public ILangfuseExperimentRun BeginExperimentRun(
+        string datasetName,
+        string runName,
+        string? runDescription = null) =>
+        new DisabledLangfuseExperimentRun(datasetName, runName);
+
+    /// <inheritdoc />
+    public Task AddTraceCommentAsync(
+        string traceId,
+        string content,
+        CancellationToken cancellationToken = default) =>
+        Task.CompletedTask;
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/DisabledLangfuseSession.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/DisabledLangfuseSession.cs
@@ -6,31 +6,47 @@ namespace NexusLabs.Needlr.AgentFramework.Langfuse;
 /// </summary>
 internal sealed class DisabledLangfuseSession : ILangfuseSession
 {
+    private readonly ILangfuseClient _client;
+
     private static readonly LangfuseShutdownOutcome ShutdownOutcome = new(
         isFinal: true,
         LangfuseProviderShutdownStatus.NotConfigured,
         LangfuseProviderShutdownStatus.NotConfigured);
 
-    /// <inheritdoc />
-    public bool IsEnabled => false;
+    public DisabledLangfuseSession()
+        : this(new DisabledLangfuseClient())
+    {
+    }
+
+    public DisabledLangfuseSession(ILangfuseClient client)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        _client = client;
+    }
 
     /// <inheritdoc />
-    public int ScoresFailed => 0;
+    public bool IsEnabled => _client.IsEnabled;
 
     /// <inheritdoc />
-    public ILangfuseDatasetClient Datasets { get; } = new DisabledLangfuseDatasetClient();
+    public int ScoresFailed => _client.ScoresFailed;
 
     /// <inheritdoc />
-    public ILangfuseScoreConfigClient ScoreConfigs { get; } = new DisabledLangfuseScoreConfigClient();
+    public ILangfuseScoreClient Scores => _client.Scores;
 
     /// <inheritdoc />
-    public ILangfuseMetricsClient Metrics { get; } = new DisabledLangfuseMetricsClient();
+    public ILangfuseDatasetClient Datasets => _client.Datasets;
 
     /// <inheritdoc />
-    public ILangfuseModelClient Models { get; } = new DisabledLangfuseModelClient();
+    public ILangfuseScoreConfigClient ScoreConfigs => _client.ScoreConfigs;
 
     /// <inheritdoc />
-    public ILangfusePromptClient Prompts { get; } = new DisabledLangfusePromptClient();
+    public ILangfuseMetricsClient Metrics => _client.Metrics;
+
+    /// <inheritdoc />
+    public ILangfuseModelClient Models => _client.Models;
+
+    /// <inheritdoc />
+    public ILangfusePromptClient Prompts => _client.Prompts;
 
     /// <inheritdoc />
     public bool Flush(TimeSpan? timeout = null) => true;
@@ -49,15 +65,15 @@ internal sealed class DisabledLangfuseSession : ILangfuseSession
         string? userId = null,
         IEnumerable<string>? tags = null,
         IReadOnlyDictionary<string, string>? metadata = null) =>
-        new DisabledLangfuseScenario();
+        _client.BeginScenario(name, sessionId, userId, tags, metadata);
 
     /// <inheritdoc />
     public ILangfuseExperimentRun BeginExperimentRun(string datasetName, string runName, string? runDescription = null) =>
-        new DisabledLangfuseExperimentRun(datasetName, runName);
+        _client.BeginExperimentRun(datasetName, runName, runDescription);
 
     /// <inheritdoc />
     public Task AddTraceCommentAsync(string traceId, string content, CancellationToken cancellationToken = default) =>
-        Task.CompletedTask;
+        _client.AddTraceCommentAsync(traceId, content, cancellationToken);
 
     /// <inheritdoc />
     public void Dispose()

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/ILangfuseClient.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/ILangfuseClient.cs
@@ -1,0 +1,113 @@
+namespace NexusLabs.Needlr.AgentFramework.Langfuse;
+
+/// <summary>
+/// Provides the complete non-owning Langfuse client surface for scenarios, experiments, datasets,
+/// score configuration, metrics, model pricing, prompts, comments, and known-trace scoring.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Resolve this interface from dependency injection after calling
+/// <see cref="LangfuseServiceCollectionExtensions.AddNeedlrLangfuse(Microsoft.Extensions.DependencyInjection.IServiceCollection, Action{LangfuseOptions}?)"/>.
+/// The facade does not own the host's OpenTelemetry providers or HTTP transport and does not
+/// implement <see cref="IDisposable"/>.
+/// </para>
+/// <para>
+/// For standalone applications that must own and explicitly shut down their OpenTelemetry
+/// providers, use <see cref="LangfuseTelemetry.Start(LangfuseOptions)"/> and retain the returned
+/// <see cref="ILangfuseSession"/>.
+/// </para>
+/// </remarks>
+public interface ILangfuseClient
+{
+    /// <summary>
+    /// Gets a value indicating whether Langfuse export and API operations are enabled.
+    /// <see langword="false"/> indicates a coherent no-op client.
+    /// </summary>
+    bool IsEnabled { get; }
+
+    /// <summary>
+    /// Gets the cumulative number of evaluation-score uploads that failed in non-fatal mode.
+    /// </summary>
+    int ScoresFailed { get; }
+
+    /// <summary>
+    /// Gets the client for recording scores against known trace, observation, and session ids.
+    /// </summary>
+    ILangfuseScoreClient Scores { get; }
+
+    /// <summary>
+    /// Begins a Langfuse trace scoped to a single evaluation scenario or agent run.
+    /// </summary>
+    /// <param name="name">The trace name shown in Langfuse.</param>
+    /// <param name="sessionId">An optional Langfuse session id used to group related traces.</param>
+    /// <param name="userId">An optional end-user identifier associated with the trace.</param>
+    /// <param name="tags">Optional tags used to categorize the trace.</param>
+    /// <param name="metadata">Optional filterable key/value metadata attached to the trace.</param>
+    /// <returns>
+    /// An <see cref="ILangfuseScenario"/> to dispose when the scenario completes. A disabled client
+    /// returns an inert no-op scenario.
+    /// </returns>
+    /// <exception cref="ArgumentException"><paramref name="name"/> is <see langword="null"/> or whitespace.</exception>
+    ILangfuseScenario BeginScenario(
+        string name,
+        string? sessionId = null,
+        string? userId = null,
+        IEnumerable<string>? tags = null,
+        IReadOnlyDictionary<string, string>? metadata = null);
+
+    /// <summary>
+    /// Gets the client for creating and populating Langfuse datasets.
+    /// </summary>
+    ILangfuseDatasetClient Datasets { get; }
+
+    /// <summary>
+    /// Gets the client for idempotently registering Langfuse score configurations.
+    /// </summary>
+    ILangfuseScoreConfigClient ScoreConfigs { get; }
+
+    /// <summary>
+    /// Gets the client for reading aggregates from the Langfuse Metrics API.
+    /// </summary>
+    ILangfuseMetricsClient Metrics { get; }
+
+    /// <summary>
+    /// Gets the client for registering Langfuse model price definitions.
+    /// </summary>
+    ILangfuseModelClient Models { get; }
+
+    /// <summary>
+    /// Gets the client for fetching and creating prompts in Langfuse prompt management.
+    /// </summary>
+    ILangfusePromptClient Prompts { get; }
+
+    /// <summary>
+    /// Begins a Langfuse experiment run whose item traces are linked to an existing dataset.
+    /// </summary>
+    /// <param name="datasetName">The existing dataset to score against.</param>
+    /// <param name="runName">A caller-supplied run name used for experiment comparison.</param>
+    /// <param name="runDescription">An optional description applied to the run.</param>
+    /// <returns>
+    /// An <see cref="ILangfuseExperimentRun"/>. A disabled client returns an inert no-op run.
+    /// </returns>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="datasetName"/> or <paramref name="runName"/> is <see langword="null"/> or whitespace.
+    /// </exception>
+    ILangfuseExperimentRun BeginExperimentRun(
+        string datasetName,
+        string runName,
+        string? runDescription = null);
+
+    /// <summary>
+    /// Attaches a comment to an existing Langfuse trace.
+    /// </summary>
+    /// <param name="traceId">The id of an existing Langfuse trace.</param>
+    /// <param name="content">The comment content.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>
+    /// A task that completes when Langfuse accepts the comment or a non-fatal failure is reported.
+    /// </returns>
+    Task AddTraceCommentAsync(
+        string traceId,
+        string content,
+        CancellationToken cancellationToken = default);
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/ILangfuseScenario.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/ILangfuseScenario.cs
@@ -6,7 +6,7 @@ namespace NexusLabs.Needlr.AgentFramework.Langfuse;
 
 /// <summary>
 /// Represents a single Langfuse trace scoped to one eval scenario or agent run. Created via
-/// <see cref="ILangfuseSession.BeginScenario"/>.
+/// <see cref="ILangfuseClient.BeginScenario"/>.
 /// </summary>
 /// <remarks>
 /// <para>

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/ILangfuseScoreClient.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/ILangfuseScoreClient.cs
@@ -10,8 +10,8 @@ namespace NexusLabs.Needlr.AgentFramework.Langfuse;
 /// <remarks>
 /// In a host application the OTLP exporter assigns each operation an OpenTelemetry trace id
 /// (<c>Activity.Current?.TraceId</c>). Pass that id here to attach evaluation scores to the
-/// corresponding Langfuse trace. For the eval/console flow, prefer
-/// <see cref="ILangfuseSession.BeginScenario"/>, which manages the trace for you.
+/// corresponding Langfuse trace. When creating a new trace, prefer
+/// <see cref="ILangfuseClient.BeginScenario"/>, which manages the trace for you.
 /// </remarks>
 public interface ILangfuseScoreClient
 {

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/ILangfuseSession.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/ILangfuseSession.cs
@@ -1,38 +1,22 @@
 namespace NexusLabs.Needlr.AgentFramework.Langfuse;
 
 /// <summary>
-/// Represents an active Langfuse export session. Owns the OpenTelemetry tracer/meter providers
-/// that forward Needlr agent telemetry to Langfuse and performs bounded final shutdown on disposal.
+/// Represents a standalone Langfuse export owner. Extends the non-owning
+/// <see cref="ILangfuseClient"/> facade with explicit flush, shutdown, and disposal lifecycle.
 /// </summary>
 /// <remarks>
 /// Obtain an instance from <see cref="LangfuseTelemetry.Start(LangfuseOptions)"/>. Keep it alive
-/// for the lifetime over which agent runs and evaluations should be captured (for example, an
-/// xUnit collection fixture), then dispose it to perform a bounded, best-effort final drain.
+/// for the lifetime over which agent runs and evaluations should be captured, then dispose it to
+/// perform a bounded, best-effort final drain.
 /// </remarks>
-public interface ILangfuseSession : IDisposable
+public interface ILangfuseSession : ILangfuseClient, IDisposable
 {
     /// <summary>
-    /// Gets a value indicating whether this session is exporting telemetry. <see langword="false"/>
-    /// when the supplied <see cref="LangfuseOptions"/> were not configured (for example, missing
-    /// credentials), in which case the session is an inert no-op.
-    /// </summary>
-    bool IsEnabled { get; }
-
-    /// <summary>
-    /// Gets the cumulative number of evaluation-score uploads that have failed across all scenarios
-    /// created from this session. Always <c>0</c> under
-    /// <see cref="LangfuseScoreFailureMode.Strict"/> (failures throw instead) and for a disabled
-    /// session. Useful as an assertion target or a health indicator.
-    /// </summary>
-    int ScoresFailed { get; }
-
-    /// <summary>
-    /// Flushes any buffered telemetry to Langfuse. Useful before reading results or at the end of
-    /// a test run. No-op when <see cref="IsEnabled"/> is <see langword="false"/>.
+    /// Flushes buffered telemetry to Langfuse.
     /// </summary>
     /// <param name="timeout">
-    /// Maximum time to wait for the flush to complete, or <see cref="System.Threading.Timeout.InfiniteTimeSpan"/>
-    /// to wait indefinitely. When <see langword="null"/>, a provider default is used.
+    /// Maximum time to wait, or <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> to wait
+    /// indefinitely. A provider default is used when <see langword="null"/>.
     /// </param>
     /// <returns><see langword="true"/> if the flush succeeded; otherwise <see langword="false"/>.</returns>
     bool Flush(TimeSpan? timeout = null);
@@ -46,119 +30,15 @@ public interface ILangfuseSession : IDisposable
     /// <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> to explicitly wait indefinitely.
     /// </param>
     /// <returns>
-    /// An outcome describing whether local trace and metric provider shutdown completed. This does
-    /// not guarantee durable ingestion by Langfuse.
+    /// An outcome describing whether local trace and metric provider shutdown completed.
     /// </returns>
     /// <remarks>
-    /// <para>
-    /// Exactly one caller performs final shutdown. Concurrent callers return immediately with
-    /// <see cref="LangfuseShutdownOutcome.IsFinal"/> equal to <see langword="false"/>. Calls made
-    /// after shutdown completes return the same cached final outcome.
-    /// </para>
-    /// <para>
-    /// Once shutdown begins, an enabled session rejects new operations with
-    /// <see cref="ObjectDisposedException"/>.
-    /// </para>
+    /// Exactly one caller performs final shutdown. Concurrent callers return a non-final outcome,
+    /// and calls made after completion return the cached final outcome.
     /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">
     /// <paramref name="timeout"/> is negative and is not
     /// <see cref="System.Threading.Timeout.InfiniteTimeSpan"/>.
     /// </exception>
-    /// <exception cref="NotSupportedException">
-    /// The session implementation predates explicit shutdown and does not override this member.
-    /// </exception>
-    LangfuseShutdownOutcome Shutdown(TimeSpan timeout) =>
-        throw new NotSupportedException(
-            "This ILangfuseSession implementation does not support explicit final shutdown.");
-
-    /// <summary>
-    /// Begins a Langfuse trace scoped to a single eval scenario or agent run. Agent telemetry
-    /// produced while the returned scenario is active nests under its trace, and evaluation scores
-    /// can be attached to it.
-    /// </summary>
-    /// <param name="name">The trace name shown in Langfuse (for example the eval scenario name).</param>
-    /// <param name="sessionId">
-    /// An optional Langfuse session id used to group related traces (for example multiple
-    /// iterations of one scenario).
-    /// </param>
-    /// <param name="userId">An optional end-user identifier associated with the trace.</param>
-    /// <param name="tags">Optional tags used to categorize the trace in Langfuse.</param>
-    /// <param name="metadata">Optional filterable key/value metadata attached to the trace.</param>
-    /// <returns>
-    /// An <see cref="ILangfuseScenario"/> to dispose when the scenario completes. When this session
-    /// is disabled the returned scenario is an inert no-op.
-    /// </returns>
-    /// <exception cref="ArgumentException"><paramref name="name"/> is <see langword="null"/> or whitespace.</exception>
-    ILangfuseScenario BeginScenario(
-        string name,
-        string? sessionId = null,
-        string? userId = null,
-        IEnumerable<string>? tags = null,
-        IReadOnlyDictionary<string, string>? metadata = null);
-
-    /// <summary>
-    /// Gets the client for creating and populating Langfuse datasets (the eval cases experiment
-    /// runs are scored against). Inert when this session is disabled.
-    /// </summary>
-    ILangfuseDatasetClient Datasets { get; }
-
-    /// <summary>
-    /// Gets the client for idempotently registering Langfuse score configs so eval scores render
-    /// with defined data types, ranges, and category sets. Inert when this session is disabled.
-    /// </summary>
-    ILangfuseScoreConfigClient ScoreConfigs { get; }
-
-    /// <summary>
-    /// Gets the client for reading aggregates back from Langfuse via the Metrics API — for example
-    /// to drive a CI quality gate from recorded eval scores. Inert when this session is disabled.
-    /// </summary>
-    ILangfuseMetricsClient Metrics { get; }
-
-    /// <summary>
-    /// Gets the client for registering model price definitions so Langfuse can compute cost for
-    /// generations whose model it does not price by default. Inert when this session is disabled.
-    /// </summary>
-    ILangfuseModelClient Models { get; }
-
-    /// <summary>
-    /// Gets the client for fetching and creating prompts in Langfuse prompt management, so an eval's
-    /// prompt lives in Langfuse and generations link to the version used. Inert when this session is
-    /// disabled.
-    /// </summary>
-    ILangfusePromptClient Prompts { get; }
-
-    /// <summary>
-    /// Begins a Langfuse experiment (dataset run). Each item begun on the returned run links its
-    /// trace to the run so the recorded scores aggregate into the experiment-comparison view.
-    /// </summary>
-    /// <param name="datasetName">
-    /// The dataset to score against. The dataset and its items must already exist — see
-    /// <see cref="Datasets"/>.
-    /// </param>
-    /// <param name="runName">
-    /// A caller-supplied run name (for example a git SHA or CI run id) so runs are comparable.
-    /// </param>
-    /// <param name="runDescription">An optional description applied to the run.</param>
-    /// <returns>
-    /// An <see cref="ILangfuseExperimentRun"/>. When this session is disabled the run is inert.
-    /// </returns>
-    /// <exception cref="ArgumentException">
-    /// <paramref name="datasetName"/> or <paramref name="runName"/> is <see langword="null"/> or whitespace.
-    /// </exception>
-    ILangfuseExperimentRun BeginExperimentRun(string datasetName, string runName, string? runDescription = null);
-
-    /// <summary>
-    /// Attaches a comment to an existing trace — for example a CI run URL, git commit, or a failing
-    /// assertion message. No-op when this session is disabled.
-    /// </summary>
-    /// <remarks>
-    /// Call this <strong>after</strong> <see cref="Flush"/> and after the trace has been ingested:
-    /// unlike scores, Langfuse rejects a comment whose target trace does not yet exist. Comment
-    /// failures are non-fatal and are reported through <c>DiagnosticsCallback</c>.
-    /// </remarks>
-    /// <param name="traceId">The id of an existing Langfuse trace.</param>
-    /// <param name="content">The comment content (Langfuse limits this to 5000 characters).</param>
-    /// <param name="cancellationToken">A cancellation token.</param>
-    /// <returns>A task that completes once Langfuse has accepted the comment or the failure has been reported.</returns>
-    Task AddTraceCommentAsync(string traceId, string content, CancellationToken cancellationToken = default);
+    LangfuseShutdownOutcome Shutdown(TimeSpan timeout);
 }

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseClient.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseClient.cs
@@ -1,0 +1,116 @@
+namespace NexusLabs.Needlr.AgentFramework.Langfuse;
+
+/// <summary>
+/// Shared enabled Langfuse client composition used by both hosted and standalone integrations.
+/// </summary>
+internal sealed class LangfuseClient : ILangfuseClient
+{
+    private readonly LangfuseClientComposition _composition;
+
+    public LangfuseClient(
+        LangfuseHttpTransport transport,
+        LangfuseEndpoints endpoints,
+        LangfuseOptions options)
+        : this(new LangfuseClientComposition(transport, endpoints, options))
+    {
+    }
+
+    public LangfuseClient(
+        LangfuseClientComposition composition,
+        ILangfuseScoreClient scores,
+        ILangfuseDatasetClient datasets,
+        ILangfuseScoreConfigClient scoreConfigs,
+        ILangfuseMetricsClient metrics,
+        ILangfuseModelClient models,
+        ILangfusePromptClient prompts)
+    {
+        ArgumentNullException.ThrowIfNull(composition);
+        ArgumentNullException.ThrowIfNull(scores);
+        ArgumentNullException.ThrowIfNull(datasets);
+        ArgumentNullException.ThrowIfNull(scoreConfigs);
+        ArgumentNullException.ThrowIfNull(metrics);
+        ArgumentNullException.ThrowIfNull(models);
+        ArgumentNullException.ThrowIfNull(prompts);
+
+        _composition = composition;
+        Scores = scores;
+        Datasets = datasets;
+        ScoreConfigs = scoreConfigs;
+        Metrics = metrics;
+        Models = models;
+        Prompts = prompts;
+    }
+
+    /// <inheritdoc />
+    public bool IsEnabled => true;
+
+    /// <inheritdoc />
+    public int ScoresFailed => Scores.ScoresFailed;
+
+    /// <inheritdoc />
+    public ILangfuseScoreClient Scores { get; }
+
+    /// <inheritdoc />
+    public ILangfuseDatasetClient Datasets { get; }
+
+    /// <inheritdoc />
+    public ILangfuseScoreConfigClient ScoreConfigs { get; }
+
+    /// <inheritdoc />
+    public ILangfuseMetricsClient Metrics { get; }
+
+    /// <inheritdoc />
+    public ILangfuseModelClient Models { get; }
+
+    /// <inheritdoc />
+    public ILangfusePromptClient Prompts { get; }
+
+    /// <inheritdoc />
+    public ILangfuseScenario BeginScenario(
+        string name,
+        string? sessionId = null,
+        string? userId = null,
+        IEnumerable<string>? tags = null,
+        IReadOnlyDictionary<string, string>? metadata = null) =>
+        new LangfuseScenario(
+            Scores,
+            _composition.Recorder,
+            name,
+            sessionId,
+            userId,
+            tags,
+            metadata);
+
+    /// <inheritdoc />
+    public ILangfuseExperimentRun BeginExperimentRun(
+        string datasetName,
+        string runName,
+        string? runDescription = null) =>
+        new LangfuseExperimentRun(
+            _composition.ApiClient,
+            Scores,
+            _composition.Recorder,
+            datasetName,
+            runName,
+            runDescription,
+            _composition.Diagnostics);
+
+    /// <inheritdoc />
+    public Task AddTraceCommentAsync(
+        string traceId,
+        string content,
+        CancellationToken cancellationToken = default) =>
+        _composition.CommentRecorder.AddTraceCommentAsync(traceId, content, cancellationToken);
+
+    private LangfuseClient(LangfuseClientComposition composition)
+        : this(
+            composition,
+            composition.Scores,
+            composition.Datasets,
+            composition.ScoreConfigs,
+            composition.Metrics,
+            composition.Models,
+            composition.Prompts)
+    {
+    }
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseClientComposition.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseClientComposition.cs
@@ -1,0 +1,67 @@
+namespace NexusLabs.Needlr.AgentFramework.Langfuse;
+
+/// <summary>
+/// Owns the shared REST API, score recording, failure handling, and default specialized clients
+/// used to compose hosted and standalone Langfuse facades.
+/// </summary>
+internal sealed class LangfuseClientComposition
+{
+    public LangfuseClientComposition(
+        LangfuseHttpTransport transport,
+        LangfuseEndpoints endpoints,
+        LangfuseOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(transport);
+        ArgumentNullException.ThrowIfNull(endpoints);
+        ArgumentNullException.ThrowIfNull(options);
+
+        var scoreApiClient = new LangfuseScoreApiClient(
+            transport.HttpClient,
+            endpoints.ScoresEndpoint,
+            endpoints.AuthorizationHeaderValue);
+        ApiClient = new LangfuseApiClient(
+            transport.HttpClient,
+            endpoints.BaseUrl,
+            endpoints.AuthorizationHeaderValue);
+        FailureSink = new LangfuseScoreFailureSink(
+            options.ScoreFailureMode,
+            options.ScoreErrorCallback);
+        Recorder = new LangfuseScoreRecorder(
+            scoreApiClient,
+            FailureSink,
+            options.NormalizeScoreNames);
+        CommentRecorder = new LangfuseCommentRecorder(
+            ApiClient,
+            options.DiagnosticsCallback);
+        Diagnostics = options.DiagnosticsCallback;
+
+        Scores = new LangfuseScoreClient(Recorder, FailureSink);
+        Datasets = new LangfuseDatasetClient(ApiClient);
+        ScoreConfigs = new LangfuseScoreConfigClient(ApiClient);
+        Metrics = new LangfuseMetricsClient(ApiClient);
+        Models = new LangfuseModelClient(ApiClient);
+        Prompts = new LangfusePromptClient(ApiClient);
+    }
+
+    public LangfuseApiClient ApiClient { get; }
+
+    public LangfuseScoreFailureSink FailureSink { get; }
+
+    public LangfuseScoreRecorder Recorder { get; }
+
+    public LangfuseCommentRecorder CommentRecorder { get; }
+
+    public Action<string>? Diagnostics { get; }
+
+    public ILangfuseScoreClient Scores { get; }
+
+    public ILangfuseDatasetClient Datasets { get; }
+
+    public ILangfuseScoreConfigClient ScoreConfigs { get; }
+
+    public ILangfuseMetricsClient Metrics { get; }
+
+    public ILangfuseModelClient Models { get; }
+
+    public ILangfusePromptClient Prompts { get; }
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseExperimentRun.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseExperimentRun.cs
@@ -10,6 +10,7 @@ internal sealed class LangfuseExperimentRun : ILangfuseExperimentRun
 {
     private readonly LangfuseApiClient _apiClient;
     private readonly LangfuseScoreRecorder _recorder;
+    private readonly ILangfuseScoreClient _scores;
     private readonly string? _runDescription;
     private readonly Action<string>? _diagnostics;
 
@@ -20,18 +21,45 @@ internal sealed class LangfuseExperimentRun : ILangfuseExperimentRun
         string runName,
         string? runDescription,
         Action<string>? diagnostics)
+        : this(
+            apiClient,
+            CreateScoreClient(recorder),
+            recorder,
+            datasetName,
+            runName,
+            runDescription,
+            diagnostics)
+    {
+    }
+
+    public LangfuseExperimentRun(
+        LangfuseApiClient apiClient,
+        ILangfuseScoreClient scores,
+        LangfuseScoreRecorder recorder,
+        string datasetName,
+        string runName,
+        string? runDescription,
+        Action<string>? diagnostics)
     {
         ArgumentNullException.ThrowIfNull(apiClient);
+        ArgumentNullException.ThrowIfNull(scores);
         ArgumentNullException.ThrowIfNull(recorder);
         ArgumentException.ThrowIfNullOrWhiteSpace(datasetName);
         ArgumentException.ThrowIfNullOrWhiteSpace(runName);
 
         _apiClient = apiClient;
+        _scores = scores;
         _recorder = recorder;
         _runDescription = runDescription;
         _diagnostics = diagnostics;
         DatasetName = datasetName;
         RunName = runName;
+    }
+
+    private static ILangfuseScoreClient CreateScoreClient(LangfuseScoreRecorder recorder)
+    {
+        ArgumentNullException.ThrowIfNull(recorder);
+        return new LangfuseScoreClient(recorder, recorder.FailureSink);
     }
 
     /// <inheritdoc />
@@ -56,6 +84,7 @@ internal sealed class LangfuseExperimentRun : ILangfuseExperimentRun
             : scenarioName;
 
         var scenario = new LangfuseScenario(
+            _scores,
             _recorder,
             name,
             sessionId: null,

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseHttpTransport.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseHttpTransport.cs
@@ -1,0 +1,24 @@
+namespace NexusLabs.Needlr.AgentFramework.Langfuse;
+
+/// <summary>
+/// Owns the HTTP transport shared by all Langfuse REST API clients in one client composition.
+/// </summary>
+internal sealed class LangfuseHttpTransport : IDisposable
+{
+    private readonly HttpClient _httpClient;
+
+    public LangfuseHttpTransport()
+        : this(new HttpClient())
+    {
+    }
+
+    public LangfuseHttpTransport(HttpClient httpClient)
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
+        _httpClient = httpClient;
+    }
+
+    public HttpClient HttpClient => _httpClient;
+
+    public void Dispose() => _httpClient.Dispose();
+}

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseScenario.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseScenario.cs
@@ -14,6 +14,7 @@ internal sealed class LangfuseScenario : ILangfuseScenario
     private readonly Activity? _activity;
     private readonly Activity? _previousActivity;
     private readonly LangfuseScoreRecorder _recorder;
+    private readonly ILangfuseScoreClient _scores;
     private readonly string? _sessionId;
     private LangfuseTraceContext _traceContext;
     private int _disposed;
@@ -25,10 +26,31 @@ internal sealed class LangfuseScenario : ILangfuseScenario
         string? userId,
         IEnumerable<string>? tags,
         IReadOnlyDictionary<string, string>? metadata)
+        : this(
+            CreateScoreClient(recorder),
+            recorder,
+            name,
+            sessionId,
+            userId,
+            tags,
+            metadata)
     {
+    }
+
+    public LangfuseScenario(
+        ILangfuseScoreClient scores,
+        LangfuseScoreRecorder recorder,
+        string name,
+        string? sessionId,
+        string? userId,
+        IEnumerable<string>? tags,
+        IReadOnlyDictionary<string, string>? metadata)
+    {
+        ArgumentNullException.ThrowIfNull(scores);
         ArgumentNullException.ThrowIfNull(recorder);
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
 
+        _scores = scores;
         _recorder = recorder;
         _sessionId = sessionId;
         _traceContext = CreateTraceContext(name, sessionId, userId, tags, metadata);
@@ -52,6 +74,12 @@ internal sealed class LangfuseScenario : ILangfuseScenario
         LangfuseTraceContext.Attach(_activity, _traceContext);
     }
 
+    private static ILangfuseScoreClient CreateScoreClient(LangfuseScoreRecorder recorder)
+    {
+        ArgumentNullException.ThrowIfNull(recorder);
+        return new LangfuseScoreClient(recorder, recorder.FailureSink);
+    }
+
     /// <inheritdoc />
     public string? TraceId => _activity?.TraceId.ToString();
 
@@ -61,19 +89,19 @@ internal sealed class LangfuseScenario : ILangfuseScenario
     /// <inheritdoc />
     public Task RecordScoreAsync(string name, double value, string? comment = null, CancellationToken cancellationToken = default) =>
         TraceId is { Length: > 0 } id
-            ? _recorder.RecordNumericAsync(id, name, value, comment, cancellationToken)
+            ? _scores.RecordScoreAsync(id, name, value, comment, cancellationToken)
             : _recorder.RecordSkippedAsync(name, cancellationToken);
 
     /// <inheritdoc />
     public Task RecordScoreAsync(string name, bool value, string? comment = null, CancellationToken cancellationToken = default) =>
         TraceId is { Length: > 0 } id
-            ? _recorder.RecordBooleanAsync(id, name, value, comment, cancellationToken)
+            ? _scores.RecordScoreAsync(id, name, value, comment, cancellationToken)
             : _recorder.RecordSkippedAsync(name, cancellationToken);
 
     /// <inheritdoc />
     public Task RecordScoreAsync(string name, string value, string? comment = null, CancellationToken cancellationToken = default) =>
         TraceId is { Length: > 0 } id
-            ? _recorder.RecordCategoricalAsync(id, name, value, comment, cancellationToken)
+            ? _scores.RecordScoreAsync(id, name, value, comment, cancellationToken)
             : _recorder.RecordSkippedAsync(name, cancellationToken);
 
     /// <inheritdoc />
@@ -82,7 +110,7 @@ internal sealed class LangfuseScenario : ILangfuseScenario
         ArgumentNullException.ThrowIfNull(result);
 
         return TraceId is { Length: > 0 } id
-            ? _recorder.RecordEvaluationAsync(id, result, cancellationToken)
+            ? _scores.RecordEvaluationAsync(id, result, cancellationToken)
             : _recorder.RecordSkippedAsync("evaluation", cancellationToken);
     }
 
@@ -150,19 +178,19 @@ internal sealed class LangfuseScenario : ILangfuseScenario
     /// <inheritdoc />
     public Task RecordSessionScoreAsync(string name, double value, string? comment = null, CancellationToken cancellationToken = default) =>
         _sessionId is { Length: > 0 } sid
-            ? _recorder.RecordNumericAsync(LangfuseScoreTarget.Session(sid), name, value, comment, cancellationToken)
+            ? _scores.RecordSessionScoreAsync(sid, name, value, comment, cancellationToken)
             : SkipSessionScore(name, cancellationToken);
 
     /// <inheritdoc />
     public Task RecordSessionScoreAsync(string name, bool value, string? comment = null, CancellationToken cancellationToken = default) =>
         _sessionId is { Length: > 0 } sid
-            ? _recorder.RecordBooleanAsync(LangfuseScoreTarget.Session(sid), name, value, comment, cancellationToken)
+            ? _scores.RecordSessionScoreAsync(sid, name, value, comment, cancellationToken)
             : SkipSessionScore(name, cancellationToken);
 
     /// <inheritdoc />
     public Task RecordSessionScoreAsync(string name, string value, string? comment = null, CancellationToken cancellationToken = default) =>
         _sessionId is { Length: > 0 } sid
-            ? _recorder.RecordCategoricalAsync(LangfuseScoreTarget.Session(sid), name, value, comment, cancellationToken)
+            ? _scores.RecordSessionScoreAsync(sid, name, value, comment, cancellationToken)
             : SkipSessionScore(name, cancellationToken);
 
     private Task SkipSessionScore(string name, CancellationToken cancellationToken) =>

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseScoreRecorder.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseScoreRecorder.cs
@@ -33,6 +33,8 @@ internal sealed class LangfuseScoreRecorder
         _normalizeNames = normalizeNames;
     }
 
+    public LangfuseScoreFailureSink FailureSink => _failureSink;
+
     public Task RecordNumericAsync(string traceId, string name, double value, string? comment, CancellationToken cancellationToken) =>
         RecordNumericAsync(LangfuseScoreTarget.Trace(traceId), name, value, comment, cancellationToken);
 

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseServiceCollectionExtensions.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseServiceCollectionExtensions.cs
@@ -9,21 +9,22 @@ using OpenTelemetry.Trace;
 namespace NexusLabs.Needlr.AgentFramework.Langfuse;
 
 /// <summary>
-/// Registers Langfuse OTLP export on an <see cref="IServiceCollection"/> for ASP.NET Core and
-/// generic-host applications.
+/// Registers Langfuse OTLP export and a complete non-owning <see cref="ILangfuseClient"/> facade
+/// on an <see cref="IServiceCollection"/> for dependency-injection-based applications.
 /// </summary>
 /// <remarks>
 /// Unlike <see cref="LangfuseTelemetry.Start(LangfuseOptions)"/> — which builds standalone
 /// providers for evals and console apps — this integrates with the host's
 /// <c>AddOpenTelemetry()</c> pipeline so the tracer and meter providers share the application
-/// lifecycle. When the supplied options are not configured (for example, missing credentials),
-/// registration is skipped and the application starts normally without exporting.
+/// lifecycle. The registered facade can create scenarios and experiment runs without constructing
+/// a standalone <see cref="ILangfuseSession"/>. When options are not configured, the same facade
+/// and specialized interfaces are registered as coherent no-ops.
 /// </remarks>
 public static class LangfuseServiceCollectionExtensions
 {
     /// <summary>
-    /// Adds Langfuse OTLP/HTTP export of Needlr agent telemetry to the host's OpenTelemetry
-    /// pipeline.
+    /// Adds Langfuse OTLP/HTTP export to the host's OpenTelemetry pipeline and registers the
+    /// non-owning <see cref="ILangfuseClient"/> facade plus all specialized client interfaces.
     /// </summary>
     /// <param name="services">The service collection to configure.</param>
     /// <param name="configure">
@@ -44,16 +45,52 @@ public static class LangfuseServiceCollectionExtensions
         if (!options.IsConfigured)
         {
             LangfuseExportGuard.WarnIfCredentialsWithoutTarget(options);
-            services.TryAddSingleton<ILangfuseScoreClient>(new DisabledLangfuseScoreClient());
-            services.TryAddSingleton<ILangfuseDatasetClient>(new DisabledLangfuseDatasetClient());
-            services.TryAddSingleton<ILangfuseScoreConfigClient>(new DisabledLangfuseScoreConfigClient());
-            services.TryAddSingleton<ILangfuseMetricsClient>(new DisabledLangfuseMetricsClient());
-            services.TryAddSingleton<ILangfuseModelClient>(new DisabledLangfuseModelClient());
-            services.TryAddSingleton<ILangfusePromptClient>(new DisabledLangfusePromptClient());
+            var client = new DisabledLangfuseClient();
+            RegisterDisabledClient(services, client);
             return services;
         }
 
         var endpoints = LangfuseEndpoints.Resolve(options);
+        var existingClient = services.LastOrDefault(
+            descriptor =>
+                descriptor.ServiceType == typeof(ILangfuseClient)
+                && descriptor.ServiceKey is null);
+        var usesBuiltInClient = existingClient is null;
+        if (usesBuiltInClient)
+        {
+            ValidateSpecializedClientLifetimes(services);
+            services.TryAddSingleton(_ => new LangfuseHttpTransport());
+            services.TryAddSingleton(sp => new LangfuseClientComposition(
+                sp.GetRequiredService<LangfuseHttpTransport>(),
+                endpoints,
+                options));
+            RegisterSpecializedClients(services);
+            services.TryAddSingleton(sp =>
+            {
+                _ = sp.GetRequiredService<TracerProvider>();
+                return new LangfuseClient(
+                    sp.GetRequiredService<LangfuseClientComposition>(),
+                    sp.GetRequiredService<ILangfuseScoreClient>(),
+                    sp.GetRequiredService<ILangfuseDatasetClient>(),
+                    sp.GetRequiredService<ILangfuseScoreConfigClient>(),
+                    sp.GetRequiredService<ILangfuseMetricsClient>(),
+                    sp.GetRequiredService<ILangfuseModelClient>(),
+                    sp.GetRequiredService<ILangfusePromptClient>());
+            });
+            services.TryAddSingleton<ILangfuseClient>(
+                sp => sp.GetRequiredService<LangfuseClient>());
+        }
+        else
+        {
+            ValidateSingleton(existingClient!, typeof(ILangfuseClient));
+            if (existingClient!.ImplementationInstance is not ILangfuseClient client)
+            {
+                throw new InvalidOperationException(
+                    $"{nameof(ILangfuseClient)} overrides must be registered as singleton instances.");
+            }
+
+            RegisterSpecializedClientsFromFacade(services, client);
+        }
 
         var otelBuilder = services
             .AddOpenTelemetry()
@@ -75,6 +112,14 @@ public static class LangfuseServiceCollectionExtensions
                 .AddProcessor(new LangfuseTraceAttributeProcessor(options.Environment, options.Release))
                 .AddOtlpExporter(otlp => ConfigureOtlp(otlp, endpoints.TracesEndpoint, endpoints.Headers)));
 
+        if (usesBuiltInClient)
+        {
+            services.ConfigureOpenTelemetryTracerProvider((serviceProvider, tracing) =>
+            {
+                _ = serviceProvider.GetRequiredService<LangfuseHttpTransport>();
+            });
+        }
+
         if (options.IncludeMetrics)
         {
             otelBuilder.WithMetrics(metrics => metrics
@@ -82,28 +127,103 @@ public static class LangfuseServiceCollectionExtensions
                 .AddMeter(options.GenAiMeterName)
                 .AddMeter([.. options.AdditionalMeters])
                 .AddOtlpExporter(otlp => ConfigureOtlp(otlp, endpoints.MetricsEndpoint, endpoints.Headers)));
+            if (usesBuiltInClient)
+            {
+                services.ConfigureOpenTelemetryMeterProvider((serviceProvider, metrics) =>
+                {
+                    _ = serviceProvider.GetRequiredService<LangfuseHttpTransport>();
+                });
+            }
         }
 
-        var httpClient = new HttpClient();
-        var scoreApiClient = new LangfuseScoreApiClient(
-            httpClient,
-            endpoints.ScoresEndpoint,
-            endpoints.AuthorizationHeaderValue);
-        var apiClient = new LangfuseApiClient(
-            httpClient,
-            endpoints.BaseUrl,
-            endpoints.AuthorizationHeaderValue);
-        var failureSink = new LangfuseScoreFailureSink(options.ScoreFailureMode, options.ScoreErrorCallback);
-        var recorder = new LangfuseScoreRecorder(scoreApiClient, failureSink, options.NormalizeScoreNames);
-
-        services.TryAddSingleton<ILangfuseScoreClient>(new LangfuseScoreClient(recorder, failureSink));
-        services.TryAddSingleton<ILangfuseDatasetClient>(new LangfuseDatasetClient(apiClient));
-        services.TryAddSingleton<ILangfuseScoreConfigClient>(new LangfuseScoreConfigClient(apiClient));
-        services.TryAddSingleton<ILangfuseMetricsClient>(new LangfuseMetricsClient(apiClient));
-        services.TryAddSingleton<ILangfuseModelClient>(new LangfuseModelClient(apiClient));
-        services.TryAddSingleton<ILangfusePromptClient>(new LangfusePromptClient(apiClient));
-
         return services;
+    }
+
+    private static void RegisterDisabledClient(
+        IServiceCollection services,
+        DisabledLangfuseClient client)
+    {
+        services.RemoveAll<ILangfuseClient>();
+        services.RemoveAll<ILangfuseScoreClient>();
+        services.RemoveAll<ILangfuseDatasetClient>();
+        services.RemoveAll<ILangfuseScoreConfigClient>();
+        services.RemoveAll<ILangfuseMetricsClient>();
+        services.RemoveAll<ILangfuseModelClient>();
+        services.RemoveAll<ILangfusePromptClient>();
+
+        services.AddSingleton<ILangfuseClient>(client);
+        services.AddSingleton<ILangfuseScoreClient>(client.Scores);
+        services.AddSingleton<ILangfuseDatasetClient>(client.Datasets);
+        services.AddSingleton<ILangfuseScoreConfigClient>(client.ScoreConfigs);
+        services.AddSingleton<ILangfuseMetricsClient>(client.Metrics);
+        services.AddSingleton<ILangfuseModelClient>(client.Models);
+        services.AddSingleton<ILangfusePromptClient>(client.Prompts);
+    }
+
+    private static void RegisterSpecializedClientsFromFacade(
+        IServiceCollection services,
+        ILangfuseClient client)
+    {
+        services.RemoveAll<ILangfuseScoreClient>();
+        services.RemoveAll<ILangfuseDatasetClient>();
+        services.RemoveAll<ILangfuseScoreConfigClient>();
+        services.RemoveAll<ILangfuseMetricsClient>();
+        services.RemoveAll<ILangfuseModelClient>();
+        services.RemoveAll<ILangfusePromptClient>();
+
+        services.AddSingleton(client.Scores);
+        services.AddSingleton(client.Datasets);
+        services.AddSingleton(client.ScoreConfigs);
+        services.AddSingleton(client.Metrics);
+        services.AddSingleton(client.Models);
+        services.AddSingleton(client.Prompts);
+    }
+
+    private static void RegisterSpecializedClients(IServiceCollection services)
+    {
+        services.TryAddSingleton<ILangfuseScoreClient>(
+            sp => sp.GetRequiredService<LangfuseClientComposition>().Scores);
+        services.TryAddSingleton<ILangfuseDatasetClient>(
+            sp => sp.GetRequiredService<LangfuseClientComposition>().Datasets);
+        services.TryAddSingleton<ILangfuseScoreConfigClient>(
+            sp => sp.GetRequiredService<LangfuseClientComposition>().ScoreConfigs);
+        services.TryAddSingleton<ILangfuseMetricsClient>(
+            sp => sp.GetRequiredService<LangfuseClientComposition>().Metrics);
+        services.TryAddSingleton<ILangfuseModelClient>(
+            sp => sp.GetRequiredService<LangfuseClientComposition>().Models);
+        services.TryAddSingleton<ILangfusePromptClient>(
+            sp => sp.GetRequiredService<LangfuseClientComposition>().Prompts);
+    }
+
+    private static void ValidateSpecializedClientLifetimes(IServiceCollection services)
+    {
+        ValidateSingletonOverride<ILangfuseScoreClient>(services);
+        ValidateSingletonOverride<ILangfuseDatasetClient>(services);
+        ValidateSingletonOverride<ILangfuseScoreConfigClient>(services);
+        ValidateSingletonOverride<ILangfuseMetricsClient>(services);
+        ValidateSingletonOverride<ILangfuseModelClient>(services);
+        ValidateSingletonOverride<ILangfusePromptClient>(services);
+    }
+
+    private static void ValidateSingletonOverride<TService>(IServiceCollection services)
+    {
+        var descriptor = services.LastOrDefault(
+            candidate =>
+                candidate.ServiceType == typeof(TService)
+                && candidate.ServiceKey is null);
+        if (descriptor is not null)
+        {
+            ValidateSingleton(descriptor, typeof(TService));
+        }
+    }
+
+    private static void ValidateSingleton(ServiceDescriptor descriptor, Type serviceType)
+    {
+        if (descriptor.Lifetime != ServiceLifetime.Singleton)
+        {
+            throw new InvalidOperationException(
+                $"{serviceType.Name} must be registered as a singleton before AddNeedlrLangfuse.");
+        }
     }
 
     private static void ConfigureOtlp(OtlpExporterOptions otlp, Uri endpoint, string headers)

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseSession.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseSession.cs
@@ -15,12 +15,8 @@ internal sealed class LangfuseSession : ILangfuseSession
 {
     private readonly TracerProvider _tracerProvider;
     private readonly MeterProvider? _meterProvider;
-    private readonly HttpClient _httpClient;
-    private readonly LangfuseScoreRecorder _recorder;
-    private readonly LangfuseScoreFailureSink _failureSink;
-    private readonly LangfuseCommentRecorder _commentRecorder;
-    private readonly LangfuseApiClient _apiClient;
-    private readonly Action<string>? _diagnostics;
+    private readonly ILangfuseClient _client;
+    private readonly LangfuseHttpTransport _transport;
     private readonly int _defaultShutdownTimeoutMilliseconds;
     private LangfuseShutdownOutcome? _shutdownOutcome;
     private int _shutdownState;
@@ -33,58 +29,44 @@ internal sealed class LangfuseSession : ILangfuseSession
     public LangfuseSession(
         TracerProvider tracerProvider,
         MeterProvider? meterProvider,
-        HttpClient httpClient,
-        LangfuseScoreRecorder recorder,
-        LangfuseScoreFailureSink failureSink,
-        LangfuseCommentRecorder commentRecorder,
-        LangfuseApiClient apiClient,
-        Action<string>? diagnostics,
+        LangfuseHttpTransport transport,
+        ILangfuseClient client,
         TimeSpan defaultShutdownTimeout)
     {
         ArgumentNullException.ThrowIfNull(tracerProvider);
-        ArgumentNullException.ThrowIfNull(httpClient);
-        ArgumentNullException.ThrowIfNull(recorder);
-        ArgumentNullException.ThrowIfNull(failureSink);
-        ArgumentNullException.ThrowIfNull(commentRecorder);
-        ArgumentNullException.ThrowIfNull(apiClient);
+        ArgumentNullException.ThrowIfNull(transport);
+        ArgumentNullException.ThrowIfNull(client);
 
         _tracerProvider = tracerProvider;
         _meterProvider = meterProvider;
-        _httpClient = httpClient;
-        _recorder = recorder;
-        _failureSink = failureSink;
-        _commentRecorder = commentRecorder;
-        _apiClient = apiClient;
-        _diagnostics = diagnostics;
+        _transport = transport;
+        _client = client;
         _defaultShutdownTimeoutMilliseconds = LangfuseTimeout.ToShutdownMilliseconds(defaultShutdownTimeout);
-
-        Datasets = new LangfuseDatasetClient(apiClient);
-        ScoreConfigs = new LangfuseScoreConfigClient(apiClient);
-        Metrics = new LangfuseMetricsClient(apiClient);
-        Models = new LangfuseModelClient(apiClient);
-        Prompts = new LangfusePromptClient(apiClient);
     }
 
     /// <inheritdoc />
-    public bool IsEnabled => true;
+    public bool IsEnabled => _client.IsEnabled;
 
     /// <inheritdoc />
-    public int ScoresFailed => _failureSink.FailedCount;
+    public int ScoresFailed => _client.ScoresFailed;
 
     /// <inheritdoc />
-    public ILangfuseDatasetClient Datasets { get; }
+    public ILangfuseScoreClient Scores => _client.Scores;
 
     /// <inheritdoc />
-    public ILangfuseScoreConfigClient ScoreConfigs { get; }
+    public ILangfuseDatasetClient Datasets => _client.Datasets;
 
     /// <inheritdoc />
-    public ILangfuseMetricsClient Metrics { get; }
+    public ILangfuseScoreConfigClient ScoreConfigs => _client.ScoreConfigs;
 
     /// <inheritdoc />
-    public ILangfuseModelClient Models { get; }
+    public ILangfuseMetricsClient Metrics => _client.Metrics;
 
     /// <inheritdoc />
-    public ILangfusePromptClient Prompts { get; }
+    public ILangfuseModelClient Models => _client.Models;
+
+    /// <inheritdoc />
+    public ILangfusePromptClient Prompts => _client.Prompts;
 
     /// <inheritdoc />
     public bool Flush(TimeSpan? timeout = null)
@@ -110,30 +92,21 @@ internal sealed class LangfuseSession : ILangfuseSession
         IReadOnlyDictionary<string, string>? metadata = null)
     {
         ThrowIfShutdownStarted();
-        return new LangfuseScenario(_recorder, name, sessionId, userId, tags, metadata);
+        return _client.BeginScenario(name, sessionId, userId, tags, metadata);
     }
 
     /// <inheritdoc />
     public ILangfuseExperimentRun BeginExperimentRun(string datasetName, string runName, string? runDescription = null)
     {
         ThrowIfShutdownStarted();
-        ArgumentException.ThrowIfNullOrWhiteSpace(datasetName);
-        ArgumentException.ThrowIfNullOrWhiteSpace(runName);
-
-        return new LangfuseExperimentRun(
-            _apiClient,
-            _recorder,
-            datasetName,
-            runName,
-            runDescription,
-            _diagnostics);
+        return _client.BeginExperimentRun(datasetName, runName, runDescription);
     }
 
     /// <inheritdoc />
     public Task AddTraceCommentAsync(string traceId, string content, CancellationToken cancellationToken = default)
     {
         ThrowIfShutdownStarted();
-        return _commentRecorder.AddTraceCommentAsync(traceId, content, cancellationToken);
+        return _client.AddTraceCommentAsync(traceId, content, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -228,7 +201,7 @@ internal sealed class LangfuseSession : ILangfuseSession
             }
             finally
             {
-                _httpClient.Dispose();
+                _transport.Dispose();
             }
         }
     }

--- a/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseTelemetry.cs
+++ b/src/NexusLabs.Needlr.AgentFramework.Langfuse/LangfuseTelemetry.cs
@@ -25,7 +25,7 @@ namespace NexusLabs.Needlr.AgentFramework.Langfuse;
 /// <example>
 /// <code>
 /// using var langfuse = LangfuseTelemetry.Start(LangfuseOptions.FromEnvironment());
-/// using (LangfuseTrace.BeginScenario("trip-planner: NYC -> Tokyo", sessionId: runId))
+/// using (langfuse.BeginScenario("trip-planner: NYC -> Tokyo", sessionId: runId))
 /// {
 ///     var run = await runner.RunAsync(...);
 ///     // ... evaluate and record scores ...
@@ -84,29 +84,14 @@ public static class LangfuseTelemetry
                 .Build();
         }
 
-        var httpClient = new HttpClient();
-        var scoreApiClient = new LangfuseScoreApiClient(
-            httpClient,
-            endpoints.ScoresEndpoint,
-            endpoints.AuthorizationHeaderValue);
-        var apiClient = new LangfuseApiClient(
-            httpClient,
-            endpoints.BaseUrl,
-            endpoints.AuthorizationHeaderValue);
-
-        var failureSink = new LangfuseScoreFailureSink(options.ScoreFailureMode, options.ScoreErrorCallback);
-        var recorder = new LangfuseScoreRecorder(scoreApiClient, failureSink, options.NormalizeScoreNames);
-        var commentRecorder = new LangfuseCommentRecorder(apiClient, options.DiagnosticsCallback);
+        var transport = new LangfuseHttpTransport();
+        var client = new LangfuseClient(transport, endpoints, options);
 
         return new LangfuseSession(
             tracerProvider,
             meterProvider,
-            httpClient,
-            recorder,
-            failureSink,
-            commentRecorder,
-            apiClient,
-            options.DiagnosticsCallback,
+            transport,
+            client,
             options.ShutdownTimeout);
     }
 


### PR DESCRIPTION
## Summary

- add a complete non-owning `ILangfuseClient` facade to dependency injection
- share one internal client composition between hosted and standalone integrations
- expose scenarios, experiment runs, known-trace scoring, datasets, score configs, metrics, models, prompts, comments, and publication health through the facade
- keep the host as the sole owner of its OpenTelemetry providers and DI-owned REST transport; no `ILangfuseSession` is registered
- guarantee exact identity between facade properties and individually resolved specialized interfaces
- support coherent enabled, disabled, custom-facade, custom-specialized-client, and keyed registration behavior
- add a no-server `LangfuseConformanceApp -- dependency-injection` ownership check

Closes #32

## Breaking change

This intentionally breaks custom alpha `ILangfuseSession` implementations. They must now implement the inherited `ILangfuseClient` contract, including the `Scores` property. We deliberately removed the default-interface compatibility forwarding rather than carrying permanent dispatch and documentation duplication into the stable API.

## DI ownership and override rules

- `ILangfuseClient` is non-disposable and exposes no flush/shutdown methods
- the host owns the single `TracerProvider`, optional `MeterProvider`, and REST transport
- a custom unkeyed facade override must be registered as a singleton instance
- individual specialized overrides must be singletons
- keyed registrations remain independent and untouched
- disabled registration replaces unkeyed facade/specialized overrides with one coherent no-op composition

## Validation

- Langfuse tests: **117 passed, 0 failed, 0 skipped**
- full repository matrix: **4,276 passed, 0 failed, 0 skipped** across 34 test projects
- full Release build: **0 errors**; 4 existing generated-code `CS0162` warnings
- `python -m mkdocs build --strict`: passed
- solution pack + package-content validation: passed
- package validation built all **65 example projects** and passed 5 example test projects
- `LangfuseConformanceApp -- dependency-injection`: passed against an unreachable endpoint
- final read-only review: no high-confidence findings

## Remaining boundary

No live Langfuse server is required or exercised by this PR; live ingestion remains covered by the existing manual conformance modes.