### PR TITLE
docs: restore ADR authoring discipline

### DIFF
--- a/.claude/rules/generated/genesis/adr.md
+++ b/.claude/rules/generated/genesis/adr.md
@@ -1,0 +1,136 @@
+---
+# AUTO-GENERATED from .github/instructions/genesis/adr.instructions.md — do not edit
+paths:
+  - "**/adr-*.md"
+  - "**/ADR-*.md"
+  - "**/*-adr-*.md"
+  - "**/*-ADR-*.md"
+  - "**/*-adr.md"
+  - "**/*-ADR.md"
+---
+# Architecture Decision Record Authoring
+
+Use these rules for every ADR, regardless of where the repository stores it.
+
+## Purpose
+
+An ADR records one architecturally significant decision for future readers who were
+not part of the original discussion. It must explain the problem, decision, rationale,
+scope, alternatives, and accepted consequences without requiring access to source code,
+an issue, a pull request, or conversation history.
+
+Record why the decision was made, not the chronology of how it was implemented.
+
+## Metadata and naming
+
+The default location is `docs/adr/`. Use `adr-NNNN-title-slug.md` with sequential
+4-digit numbering, a lowercase hyphenated slug, and this front matter:
+
+```yaml
+---
+title: "ADR-NNNN: Decision title"
+status: "Proposed"
+date: "YYYY-MM-DD"
+authors: []
+tags: ["architecture", "decision"]
+supersedes: ""
+superseded_by: ""
+---
+```
+
+## Status lifecycle
+
+| Status | Meaning |
+|--------|---------|
+| Proposed | Decision documented, awaiting review or acceptance |
+| Accepted | Decision approved and in effect |
+| Rejected | Decision was considered but not adopted |
+| Superseded | Replaced by a newer ADR (set `superseded_by` field) |
+| Deprecated | No longer relevant due to changed circumstances |
+
+## Decision history, not work history
+
+An ADR preserves how a decision evolved, not the activity used to implement it.
+
+- A Proposed ADR may change while the decision is under review.
+- Once Accepted, keep its context, decision, rationale, and consequences unchanged.
+- A short dated outcome note may record observed consequences or confirmation results.
+- A material change requires a new ADR linked through `supersedes` and `superseded_by`.
+- Issues and PRs track tasks, owners, progress, commits, and rollout activity. They may
+  be supplemental references, but the ADR must not depend on them for its meaning.
+
+## Required content
+
+Every ADR must make the following reasoning explicit.
+
+### Context and scope
+
+Describe the facts, forces, constraints, and problem that require a decision. State
+which systems, components, interfaces, or quality attributes the decision governs and
+what is explicitly out of scope. Distinguish verified facts from assumptions.
+
+### Decision drivers
+
+List the criteria that determine a good outcome, such as reliability, reversibility,
+operational cost, delivery constraints, security, or maintainability. Use these drivers
+to explain why the selected option won.
+
+### Decision
+
+State the chosen direction as a clear commitment. Explain how it satisfies the decision
+drivers and where the decision applies. Do not leave the decision implicit in a list of
+implementation details.
+
+### Alternatives considered
+
+Record the serious alternatives, including the status quo when it was viable. For each,
+explain the relevant benefits, drawbacks, and why it lost against the decision drivers.
+Do not invent filler alternatives or enforce an arbitrary count.
+
+### Consequences
+
+Document positive, negative, and neutral consequences. Be explicit about tradeoffs,
+risks, follow-on constraints, and what becomes harder. Do not hide drawbacks to make the
+decision appear stronger.
+
+### Confirmation
+
+When the decision can be checked, explain how compliance or continued validity will be
+confirmed through tests, architecture rules, configuration, operational evidence, or a
+manual review. State any evidence that cannot be verified from the repository.
+
+### References
+
+List related ADRs and supplemental source material when useful. Give each reference
+enough description for the reader to understand why it is relevant.
+
+## Evidence must be understandable
+
+The ADR must contain the meaning of its evidence. A file path, symbol, package, issue,
+or link is a locator, not an explanation.
+
+- Do not use a bare citation such as `src/App/Startup.cs:42-71` as rationale.
+- Explain what the referenced artifact demonstrates and why that fact matters to the
+  decision.
+- Prefer stable identifiers such as a named type, method, module, package, configuration
+  key, or architectural boundary over mutable line ranges.
+- When an exact historical snapshot matters, use an immutable commit permalink and label
+  it as evidence from that point in time. Still summarize the evidence in the ADR.
+- Keep essential reasoning in the ADR. References are supplemental and must not be
+  required to understand the decision.
+
+Instead of writing only `Evidence: src/App/Startup.cs:42-71`, explain the fact and its
+significance: `StartupPlugin constructs every adapter directly, so adding an adapter
+changes the application composition root. StartupPlugin.ConfigureServices contains the
+current implementation.`
+
+## Write as a permanent record
+
+- Keep one decision per ADR and default to roughly one or two pages.
+- Use complete, factual sentences. Bullets may organize reasoning but must not replace it
+  with fragments.
+- Do not turn the ADR into an implementation plan or design guide.
+- Do not mention planning phases, sprints, conversation history, or what "the user" said.
+- If an event motivated the decision, identify it by date and substance.
+- Check existing ADRs before creating a new one; update supersession links instead of
+  silently contradicting or rewriting accepted decisions.

--- a/.github/instructions/genesis/adr.instructions.md
+++ b/.github/instructions/genesis/adr.instructions.md
@@ -1,0 +1,130 @@
+---
+applyTo: "**/adr-*.md,**/ADR-*.md,**/*-adr-*.md,**/*-ADR-*.md,**/*-adr.md,**/*-ADR.md"
+---
+
+# Architecture Decision Record Authoring
+
+Use these rules for every ADR, regardless of where the repository stores it.
+
+## Purpose
+
+An ADR records one architecturally significant decision for future readers who were
+not part of the original discussion. It must explain the problem, decision, rationale,
+scope, alternatives, and accepted consequences without requiring access to source code,
+an issue, a pull request, or conversation history.
+
+Record why the decision was made, not the chronology of how it was implemented.
+
+## Metadata and naming
+
+The default location is `docs/adr/`. Use `adr-NNNN-title-slug.md` with sequential
+4-digit numbering, a lowercase hyphenated slug, and this front matter:
+
+```yaml
+---
+title: "ADR-NNNN: Decision title"
+status: "Proposed"
+date: "YYYY-MM-DD"
+authors: []
+tags: ["architecture", "decision"]
+supersedes: ""
+superseded_by: ""
+---
+```
+
+## Status lifecycle
+
+| Status | Meaning |
+|--------|---------|
+| Proposed | Decision documented, awaiting review or acceptance |
+| Accepted | Decision approved and in effect |
+| Rejected | Decision was considered but not adopted |
+| Superseded | Replaced by a newer ADR (set `superseded_by` field) |
+| Deprecated | No longer relevant due to changed circumstances |
+
+## Decision history, not work history
+
+An ADR preserves how a decision evolved, not the activity used to implement it.
+
+- A Proposed ADR may change while the decision is under review.
+- Once Accepted, keep its context, decision, rationale, and consequences unchanged.
+- A short dated outcome note may record observed consequences or confirmation results.
+- A material change requires a new ADR linked through `supersedes` and `superseded_by`.
+- Issues and PRs track tasks, owners, progress, commits, and rollout activity. They may
+  be supplemental references, but the ADR must not depend on them for its meaning.
+
+## Required content
+
+Every ADR must make the following reasoning explicit.
+
+### Context and scope
+
+Describe the facts, forces, constraints, and problem that require a decision. State
+which systems, components, interfaces, or quality attributes the decision governs and
+what is explicitly out of scope. Distinguish verified facts from assumptions.
+
+### Decision drivers
+
+List the criteria that determine a good outcome, such as reliability, reversibility,
+operational cost, delivery constraints, security, or maintainability. Use these drivers
+to explain why the selected option won.
+
+### Decision
+
+State the chosen direction as a clear commitment. Explain how it satisfies the decision
+drivers and where the decision applies. Do not leave the decision implicit in a list of
+implementation details.
+
+### Alternatives considered
+
+Record the serious alternatives, including the status quo when it was viable. For each,
+explain the relevant benefits, drawbacks, and why it lost against the decision drivers.
+Do not invent filler alternatives or enforce an arbitrary count.
+
+### Consequences
+
+Document positive, negative, and neutral consequences. Be explicit about tradeoffs,
+risks, follow-on constraints, and what becomes harder. Do not hide drawbacks to make the
+decision appear stronger.
+
+### Confirmation
+
+When the decision can be checked, explain how compliance or continued validity will be
+confirmed through tests, architecture rules, configuration, operational evidence, or a
+manual review. State any evidence that cannot be verified from the repository.
+
+### References
+
+List related ADRs and supplemental source material when useful. Give each reference
+enough description for the reader to understand why it is relevant.
+
+## Evidence must be understandable
+
+The ADR must contain the meaning of its evidence. A file path, symbol, package, issue,
+or link is a locator, not an explanation.
+
+- Do not use a bare citation such as `src/App/Startup.cs:42-71` as rationale.
+- Explain what the referenced artifact demonstrates and why that fact matters to the
+  decision.
+- Prefer stable identifiers such as a named type, method, module, package, configuration
+  key, or architectural boundary over mutable line ranges.
+- When an exact historical snapshot matters, use an immutable commit permalink and label
+  it as evidence from that point in time. Still summarize the evidence in the ADR.
+- Keep essential reasoning in the ADR. References are supplemental and must not be
+  required to understand the decision.
+
+Instead of writing only `Evidence: src/App/Startup.cs:42-71`, explain the fact and its
+significance: `StartupPlugin constructs every adapter directly, so adding an adapter
+changes the application composition root. StartupPlugin.ConfigureServices contains the
+current implementation.`
+
+## Write as a permanent record
+
+- Keep one decision per ADR and default to roughly one or two pages.
+- Use complete, factual sentences. Bullets may organize reasoning but must not replace it
+  with fragments.
+- Do not turn the ADR into an implementation plan or design guide.
+- Do not mention planning phases, sprints, conversation history, or what "the user" said.
+- If an event motivated the decision, identify it by date and substance.
+- Check existing ADRs before creating a new one; update supersession links instead of
+  silently contradicting or rewriting accepted decisions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,20 @@ All NuGet package versions are declared in `src/Directory.Packages.props` (`Mana
 - **Interfaces over static classes.** Static classes are acceptable only for trivial value calculations or extension method containers. Anything with behavior, state, or dependencies must be an interface registered via DI.
 - **No static singleton holders.** Never use `static Instance` properties, `static Holder` classes, or any pattern that stores a singleton in a static field to share state between components. This destroys testability, breaks multi-threaded scenarios, and is antithetical to dependency injection. Pass dependencies through constructors, method parameters, or DI — never through static state. We are a dependency injection library; use dependency injection.
 
+## Architecture Decision Records
+
+When a task involves a significant architectural or technical decision:
+
+- Check existing ADRs before implementation. Flag contradictions with accepted decisions
+  instead of silently diverging.
+- Propose an ADR when the choice changes system structure, technology, integration
+  boundaries, important quality attributes, or another convention that is costly to
+  reverse.
+- Do not create an ADR for a routine implementation choice, straightforward bug fix, or
+  decision already covered by an accepted record.
+- Use the repository's established ADR location and format; default to `docs/adr/` only
+  when no convention exists.
+
 ## Architecture
 
 The codebase follows a consistent per-feature pattern:

--- a/docs/adr/adr-0001-dag-graph-workflow-support.md
+++ b/docs/adr/adr-0001-dag-graph-workflow-support.md
@@ -8,281 +8,172 @@ supersedes: ""
 superseded_by: ""
 ---
 
-## Status
+## Context and scope
 
-Accepted — Phases 1–4 implemented. Expert-validated via 5-agent fleet review, rubber duck critique, and expert consultation.
+Needlr's Agent Framework originally supported handoff, group-chat, and sequential
+workflows through a consistent model: attributes declare topology, source generation
+emits registration and factory code, and analyzers reject invalid declarations before
+runtime.
 
-### Implementation Status
+Microsoft Agent Framework (MAF) also supports graph execution for conditional routing,
+fan-out, and fan-in. Without a Needlr graph abstraction, consumers that need non-linear
+workflows must use raw MAF APIs and give up Needlr's source-generated discovery,
+compile-time validation, dependency-injection integration, and common diagnostics.
 
-| Phase | Status | Notes |
-|---|---|---|
-| 1 | ✅ Complete | Attributes, enums, `IWorkflowFactory.CreateGraphWorkflow`, reflection-based factory |
-| 2 | ✅ Complete | Source generator discovers graph attributes, emits `Create{Name}GraphWorkflow()` extensions, Mermaid subgraph. `AgentGraphReducerAttribute` defined. |
-| 3 | ✅ Complete | 12 diagnostics (NDLRMAF016–022, NDLRMAF024–025, NDLRMAF027–029) across 9 analyzer classes. 137 analyzer tests. Release tracking entries. |
-| 4 | ✅ Complete | `IDagRunResult`, `IDagNodeResult`, `NodeKind`, `DagRunResult`, `DagNodeResult`, `ReducerNodeInvokedEvent`. Docs updated. Runtime wiring for RoutingMode, JoinMode, reducers. End-to-end example app (`GraphWorkflowApp`). Per-node `NodeRoutingMode` override on `AgentGraphEdgeAttribute`. 12 analyzer doc pages. `GraphTopologyRegistration` DTO + `AgentGraphTopologyRegistry` source-gen emission + bootstrap registration for AOT-safe topology discovery. `Run{Name}GraphWorkflowAsync` generated extension method on `IGraphWorkflowRunner`. `GraphNames` constants class. |
+This decision governs finite directed acyclic workflows composed of Needlr agents and
+deterministic reducer nodes. It does not make Needlr a general-purpose distributed
+workflow engine, add cyclic execution, or guarantee that every graph can run through the
+same MAF execution primitive.
 
-### Known Limitations
+## Decision drivers
 
-- **WaitAny requires `RunGraphAsync`**: `GraphJoinMode.WaitAny` is fully implemented via the `RunGraphAsync` extension method in `NexusLabs.Needlr.AgentFramework.Workflows`. However, it is **not compatible** with `CreateGraphWorkflow` (which returns a MAF `Workflow` using BSP execution). `CreateGraphWorkflow` throws `NotSupportedException` when WaitAny nodes are detected, directing users to `RunGraphAsync`. Analyzer **NDLRMAF025** catches this at compile time — users see an error in their IDE before they ever run the code.
-- **LlmChoice requires `RunGraphAsync`**: `GraphRoutingMode.LlmChoice` uses the Needlr-native executor (`RunGraphAsync`) because MAF's BSP engine cannot handle LLM-driven edge selection. `CreateGraphWorkflow` does not support LlmChoice. When the graph-wide or any per-node routing mode is `LlmChoice`, `RunGraphAsync` automatically selects the Needlr-native executor.
-
-### Runtime Feature Coverage
-
-All attribute properties are wired at runtime in the Needlr-native executor (`RunGraphAsync`) with test coverage:
-
-| Feature | Status | Tests |
-|---|---|---|
-| Condition-based routing | ✅ Implemented | Conditional edge skips branch, unconditional always fires, mixed behavior |
-| IsRequired failure propagation | ✅ Implemented | Required failure kills graph, optional failure continues, mixed scenario |
-| Reducer invocation | ✅ Implemented | Reducer called with branch outputs, return value passed downstream |
-| WaitAny join mode | ✅ Implemented | Proceeds on first-to-complete, verified by timing |
-| RoutingMode enforcement | ✅ Implemented | FirstMatching fires only first, ExclusiveChoice rejects zero/multiple matches |
-| NodeRoutingMode override | ✅ Implemented | Per-node override takes precedence over graph-wide mode |
-| Progress events | ✅ Implemented | AgentInvokedEvent, WorkflowStarted/CompletedEvent emitted during execution |
-| LlmChoice routing | ✅ Implemented | LLM picks route from condition strings, unchosen branch skipped, no-match fallback |
-
-## Context
-
-Needlr's agent framework wraps [Microsoft Agent Framework (MAF)](https://github.com/microsoft/agent-framework) with an attribute-driven, source-generated workflow model. Three workflow types exist today:
-
-| Workflow Type | Attribute | Factory Method Pattern |
-|---|---|---|
-| Handoff | `[AgentHandoffsTo]` | `Create{Agent}HandoffWorkflow()` |
-| Group Chat | `[AgentGroupChatMember]` | `Create{GroupName}GroupChatWorkflow()` |
-| Sequential | `[AgentSequenceMember]` | `Create{PipelineName}SequentialWorkflow()` |
-
-Each follows a consistent pattern: attributes on agent classes declare topology, a source generator (`AgentFrameworkFunctionRegistryGenerator`) emits `IWorkflowFactory` extension methods, and Roslyn analyzers (`NDLRMAF001`–`NDLRMAF015`) provide compile-time validation.
-
-MAF 1.1.0 introduced a graph-based execution model (`WorkflowBuilder`, `Edge`, `Executor`, `FunctionExecutor<T>`, `DirectEdgeData`, `FanOutEdgeData`, `FanInEdgeData`, `SwitchBuilder`) using superstep-based Bulk Synchronous Parallel (BSP) execution. This model enables directed acyclic graph (DAG) orchestration: conditional routing, fan-out/fan-in parallelism, and non-linear agent coordination. Needlr does not yet wrap this API.
-
-Without DAG support, users who need branching, parallel, or conditional workflows must drop down to raw MAF APIs, losing Needlr's compile-time validation, diagnostics integration, and attribute-driven developer experience.
-
-Existing infrastructure that this decision builds on:
-
-- **Progress reporting**: `IProgressReporter` with events for workflow lifecycle, agent invocation, LLM calls, tool calls, budget tracking, and superstep progression (`SuperStepStartedProgressEvent`, `SuperStepCompletedProgressEvent`).
-- **Diagnostics**: `IPipelineRunResult` with per-stage `IAgentStageResult` entries, token usage tracking via `IAgentMetrics`, and hierarchical scoping via `BeginChildScope`.
-- **Source generator**: Incremental generator with `Models/` (metadata types like `HandoffEntry`, `GroupChatEntry`, `SequenceEntry`) and `CodeGen/` (emitters like `RegistryCodeGenerator`, `ExtensionsCodeGenerator`, `BootstrapCodeGenerator`, `TopologyGraphCodeGenerator`).
-- **Analyzer infrastructure**: `MafDiagnosticIds` and `MafDiagnosticDescriptors` centralize diagnostic metadata. Existing analyzers cover cyclic handoffs, orphan detection, group chat validation, sequence ordering, and topology correctness.
-
-### Forces
-
-- **Consistency**: A 4th workflow type should follow the established attribute → generator → analyzer → factory pattern.
-- **Determinism**: Orchestration edges encode control flow. Nondeterministic routing by default undermines testability, replayability, and debuggability.
-- **Expressiveness**: DAGs introduce topological ambiguity that linear and group-chat workflows do not have. Three outgoing conditional edges could mean fan-out, switch-case, or priority routing — the topology alone does not disambiguate.
-- **Progressive disclosure**: Simple DAGs (linear chains, basic fan-out) should be simple to declare. Complex DAGs (conditional routing, LLM-driven choice, mixed fan-out/fan-in) should be possible without escaping to raw MAF.
-- **MAF stability**: MAF's graph API is relatively new (v1.1.0). The attribute model should insulate users from breaking changes in the underlying API.
+- Graph workflows should follow the same attribute, generator, analyzer, and runtime
+  composition model as existing Needlr workflows.
+- Deterministic and replayable control flow should be the default.
+- Routing, joining, and failure semantics must be explicit where topology alone is
+  ambiguous.
+- Invalid topology and callback signatures should fail at compile time where possible.
+- The public model should insulate consumers from changes in MAF's graph API.
+- Graph support should reuse existing Agent Framework packages, diagnostics, and progress
+  infrastructure rather than create a parallel subsystem.
 
 ## Decision
 
-Add a 4th workflow type — DAG/graph workflows — via `[AgentGraphEdge]` and `[AgentGraphEntry]` attributes, a `[AgentGraphReducer]` attribute for fan-in aggregation, source-generated `Create{Name}GraphWorkflow()` factory methods, and Roslyn analyzers (`NDLRMAF016`–`NDLRMAF022`, `NDLRMAF024`–`NDLRMAF025`, `NDLRMAF027`).
+Needlr will support graph workflows as a first-class Agent Framework workflow type.
 
-### Core Attribute Design
+Graph topology is declared through:
 
-Edges are declared on the source node (edge-on-source), consistent with `[AgentHandoffsTo]`:
+- `AgentGraphEntryAttribute` for an explicit named entry point;
+- `AgentGraphEdgeAttribute` for source-to-target edges and per-edge failure requirements;
+- `AgentGraphNodeAttribute` for target-side join behavior;
+- `AgentGraphReducerAttribute` for deterministic fan-in aggregation.
 
-```csharp
-[AgentGraphEntry("ResearchPipeline")]
-[AgentGraphEdge("ResearchPipeline", typeof(WebResearchAgent), Condition = "needs-web")]
-[AgentGraphEdge("ResearchPipeline", typeof(SummarizerAgent))]
-public class AnalyzerAgent { }
-```
+The source generator emits topology metadata, registration, and execution extensions
+through the same surfaces used by other workflow types. Generated topology metadata is the
+intended discovery source for trimmed and AOT execution; reflection may exist only as an
+explicit fallback. Roslyn analyzers validate cycles, entry points, reachability, edge
+targets, terminal nodes, routing callbacks, reducer callbacks, and executor
+incompatibilities.
 
-- `[AgentGraphEntry]` marks an agent as the entry point for a named graph. It is required and must be explicit — entry points are not inferred from topology.
-- `[AgentGraphEdge]` declares a directed edge from the decorated class to the specified target agent type, within a named graph.
-- The source generator emits `Create{Name}GraphWorkflow()` as an extension method on `IWorkflowFactory`.
+Routing is deterministic by default. `GraphRoutingMode` supports predicate-based
+`Deterministic` routing, parallel `AllMatching`, ordered `FirstMatching`,
+single-selection `ExclusiveChoice`, and explicit LLM-selected `LlmChoice`. The entry
+attribute supplies the graph-wide default, and an edge may declare the effective mode for
+its source node. Fan-out routing behavior and fan-in join behavior are declared
+independently because multiple outgoing or incoming edges do not fully describe execution
+semantics.
 
-### Routing: Deterministic Default, LLM Opt-In
+`IGraphWorkflowRunner.RunGraphAsync` is the canonical execution entry point. It may use
+MAF's native bulk-synchronous execution for compatible `WaitAll` graphs and a
+Needlr-owned executor for semantics that MAF does not provide, including `WaitAny` and
+LLM-selected routing. Raw MAF workflow creation remains available for compatible graphs
+and direct MAF integration.
 
-Deterministic routing is the default. Condition strings on `[AgentGraphEdge]` reference a named predicate method on the agent class by convention. The Roslyn analyzer (`NDLRMAF028`) validates the method exists with the correct signature at compile time. At runtime, the `GraphEdgeRouter` binds the method via reflection and evaluates it as a `Func<object?, bool>` predicate.
+Failure requirements are declared per edge. Required branch failure fails the graph;
+optional branch failure degrades that branch while preserving completed work. Graph
+results extend the existing pipeline result model with node and branch diagnostics rather
+than introducing an unrelated result hierarchy.
 
-LLM-driven routing is an explicit opt-in via `RoutingMode = GraphRoutingMode.LlmChoice` on the entry point attribute. When active, condition strings become handoff-style tool descriptions — the agent's LLM selects which edge to follow. The routing decision is recorded in diagnostics for auditability.
+User-facing content comes from terminal graph output. Intermediate node execution is
+reported through diagnostics and progress events rather than being treated as an
+independent user-facing content stream.
 
-Routing mode enum (`GraphRoutingMode`):
+Graph support remains in the existing Agent Framework, Workflows, Generators, and
+Analyzers packages. It will not be split into a separate graph package.
 
-| Mode | Behavior | MAF Mapping |
-|---|---|---|
-| `Deterministic` (default) | Condition methods evaluated as boolean predicates | Individual `AddEdge` with `Func<object?, bool>` |
-| `LlmChoice` | Condition strings as tool descriptions; model selects | Handoff-style tool mapping |
-| `AllMatching` | All edges whose condition is true are followed (parallel fan-out) | MAF's default behavior when multiple edge conditions pass |
-| `FirstMatching` | First edge whose condition is true is followed (priority order) | **Needlr abstraction** — MAF has no ordered-priority routing; generator emits a composite condition wrapper |
-| `ExclusiveChoice` | Exactly one edge must match | **Needlr abstraction** — composite condition validates exactly one match at runtime |
+## Alternatives considered
 
-`RoutingMode` is a property on `[AgentGraphEntry]` as the graph-wide default. Per-node routing overrides (via `NodeRoutingMode` on `[AgentGraphEdge]`) are enabled by the source generator's edge-grouping logic and the runtime's per-node effective routing mode computation.
+### Require consumers to use raw MAF graph APIs
 
-**Rationale**: DAG edges encode orchestration rules. Making control flow nondeterministic by default undermines testability, replayability, and determinism. LLM routing is powerful but should be a conscious architectural choice.
+This has the lowest Needlr maintenance cost and exposes every MAF capability immediately.
+It was rejected because graph users would lose the compile-time discovery, analyzers,
+DI composition, diagnostics, and stable abstraction that justify Needlr's other workflow
+types.
 
-### Fan-Out/Fan-In: Inferred Shape, Explicit Semantics
+### Infer entry, routing, and join semantics from topology
 
-Fan-out and fan-in **shapes** are inferred from topology (multiple outgoing edges = fan-out, multiple incoming edges = fan-in). However, the **semantics** are explicitly declared because topology alone is ambiguous.
+Inference makes simple graphs terse, but multiple roots, multiple outgoing edges, and
+multiple incoming edges have several valid meanings. It was rejected because hidden
+inference would make behavior difficult to review and could change when topology changes.
 
-Source-side routing (on `[AgentGraphEntry]` or per-node):
+### Make LLM-selected routing the default
 
-- `AllMatching` — run all edges whose condition passes
-- `FirstMatching` — run the first edge whose condition passes
-- `ExclusiveChoice` — exactly one edge must match (analyzer error if ambiguous at compile time)
-- `LlmChoice` — LLM selects
+LLM routing is expressive and avoids writing predicates. It was rejected as the default
+because orchestration control flow would become nondeterministic, harder to test, and
+harder to audit. It remains available as an explicit mode.
 
-Target-side join is declared via `[AgentGraphNode]` on the target agent:
+### Use one graph-wide failure mode
 
-```csharp
-[NeedlrAiAgent(Instructions = "Synthesize all findings.")]
-[AgentGraphNode("ResearchPipeline", JoinMode = GraphJoinMode.WaitAll)]
-public class SummarizerAgent { }
-```
+A single fail-fast or continue-on-error setting is simpler than per-edge requirements.
+It was rejected because real graphs commonly contain both required and optional branches;
+one global setting either discards useful completed work or hides failures on required
+paths.
 
-- `WaitAll` (default) — barrier; wait for all incoming edges before proceeding
-- `WaitAny` — proceed when any incoming edge completes
+### Create a separate graph-workflow package
 
-`[AgentGraphNode]` is a lightweight per-node attribute separate from `[AgentGraphEdge]` to avoid overloading edge attributes with target-side semantics.
-
-**Rationale**: Three conditional outgoing edges could mean fan-out, switch-case, or priority routing. The topology says "3 edges" but not what they mean. Explicit semantics prevent runtime ambiguity without requiring users to understand MAF's `FanOutEdgeData` vs `DirectEdgeData` distinction.
-
-### Non-Agent Nodes: Minimal Phase-1 Reducer
-
-Full `FunctionExecutor<T>` support is deferred to phase 2. However, phase 1 includes a minimal deterministic reducer node for fan-in convergence, because fan-in without a reducer forces users to wrap pure aggregation logic in agent classes (paying LLM cost and latency for what should be a deterministic function).
-
-```csharp
-[AgentGraphReducer("ResearchPipeline", ReducerMethod = nameof(MergeResults))]
-public static class ResearchReducer
-{
-    public static string MergeResults(IReadOnlyList<string> branchOutputs)
-        => string.Join("\n---\n", branchOutputs);
-}
-```
-
-The reducer covers the most common fan-in pattern (aggregation of branch outputs) without requiring a full function-executor attribute model. If `ReducerMethod` is not specified, the convention default `"Reduce"` is used — the source generator and runtime will look for a `public static string Reduce(IReadOnlyList<string>)` method on the decorated class.
-
-**Diagnostics**: Reducer nodes do NOT go through `IChatClient` pipelines (no LLM calls, no token usage). `IDagNodeResult` carries a `NodeKind` discriminator (`Agent` vs `Reducer`) so downstream tooling can distinguish agent nodes from pure-function nodes. A dedicated `ReducerNodeInvokedEvent` progress event carries `NodeId`, `InputBranchCount`, and `Duration` without the LLM-specific metadata of `AgentInvokedEvent`.
-
-### Streaming: Terminal Content, Full Progress
-
-Content streaming is terminal-node only by default. Intermediate node output is internal processing — not user-facing.
-
-Progress and observability use the existing `IProgressReporter` infrastructure, which already supports `AgentInvokedEvent`, `LlmCallStartedEvent`, `ToolCallCompletedEvent`, and `SuperStepStartedProgressEvent`. DAG-specific metadata is added as nullable properties to existing event types for backward compatibility:
-
-| Field | Type | Added To | Purpose |
-|---|---|---|---|
-| `GraphName` | `string?` | All DAG progress events | Identifies which named graph is executing |
-| `NodeId` | `string?` | `AgentInvokedEvent`, `ReducerNodeInvokedEvent` | Identifies the node within the graph |
-| `BranchId` | `string?` | `AgentInvokedEvent`, `ReducerNodeInvokedEvent` | Identifies the parallel branch |
-| `IncomingEdgeLabel` | `string?` | `AgentInvokedEvent` | The condition label of the activating edge |
-| `ParallelBranchCount` | `int?` | `SuperStepStartedProgressEvent` | Active parallel branches in this superstep |
-
-One new event type: `ReducerNodeInvokedEvent` for non-LLM reducer nodes (carries `NodeId`, `BranchId`, `InputBranchCount`, `Duration` without LLM-specific fields).
-
-**Rationale**: Users need progress visibility for long-running DAGs, but that is a progress concern, not a streaming concern. The existing `IProgressReporter` and `IProgressSink` pipeline is extensible and already consumed by downstream tooling.
-
-### Failure Propagation: Per-Edge Required/Optional
-
-Graph-wide failure modes (fail-fast vs continue-parallel) are too coarse for DAGs with heterogeneous branches. Instead, failure semantics are declared per-edge:
-
-- `IsRequired = true` (default): if this edge's target node fails, the entire graph fails.
-- `IsRequired = false`: if this edge's target node fails, the branch is marked degraded but parallel branches continue.
-
-Completed branch outputs are always preserved in `IDagRunResult.NodeResults` — even when the graph fails, work already done is accessible. This avoids discarding expensive computation (e.g., a completed research branch) when an optional enrichment branch fails.
-
-### Diagnostics: `IDagRunResult`
-
-`IDagRunResult` extends `IPipelineRunResult` with:
-
-- `NodeResults` — per-node diagnostics with edge metadata and timing offsets
-- `BranchResults` — parallel branch grouping with degraded/failed status
-- Flat `Stages` preserved for backward compatibility with existing `IPipelineRunResult` consumers
-- Token budget tracking via existing hierarchical scoping (`BeginChildScope`)
-
-### Analyzers
-
-Twelve new diagnostics across nine analyzer classes, extending the existing `NDLRMAF` series:
-
-| ID | Title | Severity |
-|---|---|---|
-| NDLRMAF016 | Cycle detected in agent graph | Error |
-| NDLRMAF017 | Graph has no entry point | Error |
-| NDLRMAF018 | Graph has multiple entry points | Error |
-| NDLRMAF019 | Graph edge target is not a declared agent | Error |
-| NDLRMAF020 | Graph edge source is not a declared agent | Warning |
-| NDLRMAF021 | Graph entry point is not a declared agent | Warning |
-| NDLRMAF022 | Graph contains unreachable agents | Warning |
-| ~~NDLRMAF023~~ | ~~MaxSupersteps value is invalid~~ | Retired — property removed |
-| NDLRMAF024 | All edges from fan-out node are optional | Warning |
-| NDLRMAF025 | CreateGraphWorkflow incompatible with WaitAny | Error |
-| ~~NDLRMAF026~~ | *(reserved — do not reuse)* | Reserved |
-| NDLRMAF027 | Terminal node has outgoing edges | Error |
-| NDLRMAF028 | Condition method has invalid signature | Error |
-| NDLRMAF029 | Reducer method has invalid signature | Error |
-
-NDLRMAF024 catches the pattern where all outgoing edges from a fan-out node have `IsRequired = false` — the graph could produce empty results if all optional branches fail. NDLRMAF025 catches calls to `CreateGraphWorkflow` on graphs that contain `WaitAny` nodes — `CreateGraphWorkflow` returns a MAF `Workflow` using BSP execution which only supports `WaitAll`; the fix is to use `RunGraphAsync` instead. NDLRMAF027 catches topology errors where a terminal node still has outgoing edges. NDLRMAF028 validates that `Condition` references on `[AgentGraphEdge]` point to a `public static bool Method(object?)` method. NDLRMAF029 validates that `ReducerMethod` references on `[AgentGraphReducer]` point to a `public static string Method(IReadOnlyList<string>)` method.
-
-These follow the existing pattern in `MafDiagnosticIds` and `MafDiagnosticDescriptors`, extending the ID range from the current ceiling of `NDLRMAF015`.
-
-### Implementation Phases
-
-| Phase | Scope | Deliverables |
-|---|---|---|
-| 1 | Attributes + Runtime Factory | `AgentGraphEdgeAttribute`, `AgentGraphEntryAttribute`, `AgentGraphNodeAttribute`, `GraphRoutingMode`/`GraphJoinMode` enums, `IWorkflowFactory.CreateGraphWorkflow`, `WorkflowFactory` graph support |
-| 2 | Source Generator + Reducer + Mermaid Diagrams | `AgentGraphReducerAttribute`, per-node `RoutingMode` override, `GraphEdgeEntry`/`GraphEntryPointEntry`/`GraphNodeEntry`/`GraphReducerEntry` models, `TopologyGraphCodeGenerator` Mermaid output, `RegistryCodeGenerator.GenerateGraphTopologyRegistrySource`, `BootstrapCodeGenerator` graph registration, `GraphTopologyRegistration` DTO, `Run{Name}GraphWorkflowAsync` extension, `GraphNames` constants |
-| 3 | Analyzers + Release Tracking + Docs | `NDLRMAF016`–`NDLRMAF025`, `NDLRMAF027`–`NDLRMAF029`, analyzer tests, XML doc comments, README updates |
-| 4 | Diagnostics + Progress Events + Example App | `IDagRunResult`, `NodeKind` discriminator, DAG-specific progress metadata, `ReducerNodeInvokedEvent`, `RunGraphAsync` extension (WaitAny via Needlr-native executor), `Examples/` project demonstrating a research pipeline |
+Package separation could isolate graph-specific dependencies. It was rejected because the
+feature shares the same public agents, factory, generator, analyzer IDs, diagnostics, and
+composition root as the existing workflow types. A new package would fragment that model.
 
 ## Consequences
 
 ### Positive
 
-- **POS-001**: Needlr covers all four MAF workflow patterns (Handoff, Group Chat, Sequential, DAG), eliminating the need for users to drop to raw MAF APIs for non-linear orchestration.
-- **POS-002**: Deterministic-first routing gives users testable, replayable, and debuggable orchestration by default. LLM-driven routing is available when intelligence-based decisions are genuinely needed.
-- **POS-003**: Compile-time validation via 9 new analyzer classes (12 diagnostics) catches topology errors (cycles, missing entry points, unreachable nodes) and method signature errors (condition/reducer methods) before runtime, consistent with the existing analyzer experience for other workflow types.
-- **POS-004**: Per-edge failure semantics (`IsRequired`) preserve expensive parallel work when optional branches fail, avoiding the all-or-nothing tradeoff of graph-wide failure modes.
-- **POS-005**: The attribute model insulates users from MAF's graph API surface (`WorkflowBuilder`, `Edge`, `DirectEdgeData`, `FanOutEdgeData`, etc.), providing a stable abstraction layer if MAF's API evolves.
+- Consumers can express non-linear workflows without leaving Needlr's source-generated
+  and analyzer-backed model.
+- Deterministic routing remains the normal path, while LLM routing is available when its
+  nondeterminism is intentional.
+- Compile-time topology validation catches many graph defects before execution.
+- Per-edge failure requirements preserve completed optional work without weakening
+  required paths.
+- Needlr can adapt its runtime integration when MAF changes without replacing the
+  consumer-facing topology model.
 
 ### Negative
 
-- **NEG-001**: Significant implementation surface across 4 phases: 4 new attributes, 2 enums, factory method updates, 9 analyzer classes (12 diagnostics), generator updates, a new diagnostics interface, progress event extensions, and a compile-time topology registry.
-- **NEG-002**: Routing mode (`Deterministic`, `LlmChoice`, `AllMatching`, `FirstMatching`) and join mode (`WaitAll`, `WaitAny`) add cognitive overhead compared to the simpler "just declare edges" model. Users must understand when each mode applies.
-- **NEG-003**: The phase-1 reducer (`[AgentGraphReducer]`) is a narrow solution covering only the aggregation pattern. Full `FunctionExecutor<T>` support is still needed for arbitrary non-agent computation nodes.
-- **NEG-004**: MAF's graph execution model uses superstep-based BSP, which may surprise users expecting event-driven or streaming DAG execution. Documentation must set clear expectations.
+- Needlr owns a larger public surface for routing, joining, reducers, graph diagnostics,
+  and analyzer behavior.
+- Two execution strategies must remain behaviorally coherent even though MAF does not
+  support every Needlr graph semantic.
+- Users must understand the difference between source-side routing and target-side join
+  behavior.
+- The abstraction is intentionally narrower than a general workflow engine and will not
+  represent every arbitrary computation graph.
 
-## Alternatives Considered
+### Neutral
 
-### Infer Entry Points from Topology
+- Raw MAF workflows remain available for callers that need direct framework control.
+- Existing handoff, group-chat, and sequential workflow contracts remain separate and
+  unchanged.
 
-- **Description**: Automatically identify the entry point as the node with zero incoming edges, rather than requiring an explicit `[AgentGraphEntry]` attribute.
-- **Rejection Reason**: Topological inference is fragile — a graph with multiple roots (e.g., parallel starting branches) would require disambiguation logic in the generator. Explicit declaration is consistent with the existing pattern where `[AgentHandoffsTo]` requires the user to mark the initial agent via the generic type parameter on `CreateHandoffWorkflow<TInitialAgent>()`. Explicit entry points also serve as documentation.
+## Confirmation
 
-### LLM Routing as the Default
+The repository confirms this decision through the following durable boundaries:
 
-- **Description**: Default to LLM-driven routing where the agent's model decides which edge to follow based on condition strings as tool descriptions.
-- **Rejection Reason**: DAG edges encode orchestration control flow. Nondeterministic routing by default undermines testability, replayability, and determinism. Teams that need deterministic pipelines (compliance, financial, safety-critical) would be forced to opt out of the default. Deterministic-default with LLM opt-in respects both camps.
+- The Agent Framework exposes graph entry, edge, node, reducer, routing, and join types.
+- `AgentFrameworkFunctionRegistryGenerator` emits graph topology and execution extensions,
+  demonstrating that graph discovery participates in the source-generated model.
+- The Agent Framework analyzers include graph topology and callback validation rules.
+- `GraphWorkflowRunner` selects between MAF and Needlr execution based on the declared
+  topology, while `IGraphWorkflowRunner` exposes one public execution contract.
+- Graph runtime, generator, and analyzer tests exercise valid and invalid topologies.
+- `GraphWorkflowApp` and the graph section of `docs/ai-integrations.md` demonstrate the
+  supported public workflow.
 
-### Graph-Wide Failure Mode Instead of Per-Edge
+The runtime topology provider currently reconstructs graph metadata through assembly
+reflection instead of consuming the generated topology registration. The public graph
+workflow is implemented, but the intended AOT-safe discovery path is therefore not fully
+confirmed and remains architecture drift against this decision.
 
-- **Description**: Provide a single `FailureMode` property on `[AgentGraphEntry]` with `FailFast` and `ContinueParallel` options, rather than per-edge `IsRequired` semantics.
-- **Rejection Reason**: Graph-wide modes are too coarse. A research pipeline may have a required web-research branch and an optional sentiment-enrichment branch. `FailFast` would discard completed research if sentiment fails. `ContinueParallel` would silently ignore failures in the required branch. Per-edge semantics let users express "this branch is optional" without sacrificing safety for required paths.
-
-### Defer Entirely Until MAF Stabilizes
-
-- **Description**: Wait for MAF's graph API to mature beyond v1.1.0 before adding Needlr support, avoiding rework if the API changes.
-- **Rejection Reason**: Users need DAG support now for multi-agent research pipelines, content generation workflows, and conditional processing. The attribute model provides an insulation layer — if MAF's underlying API changes, only the factory/generator internals need updating, not the user-facing attribute surface. The risk of rework is contained.
-
-### Separate Package for Graph Workflows
-
-- **Description**: Create a new `NexusLabs.Needlr.AgentFramework.Graph` package rather than adding graph support to the existing `AgentFramework`, `Generators`, and `Analyzers` projects.
-- **Rejection Reason**: The three existing workflow types live in the core `AgentFramework` package with shared infrastructure (`IWorkflowFactory`, `WorkflowFactory`, generator, analyzers). A separate package would duplicate shared types, require cross-package analyzer coordination, and fragment the developer experience. Graph workflows should be a first-class citizen alongside the other three types.
-
-## Implementation Notes
-
-- **IMP-001**: New attributes (`AgentGraphEdgeAttribute`, `AgentGraphEntryAttribute`, `AgentGraphReducerAttribute`) should follow the established pattern: `[AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]`, placed in `src/NexusLabs.Needlr.AgentFramework/`.
-- **IMP-002**: The source generator requires new model types (`GraphEdgeEntry`, `GraphEntryPointEntry`, `GraphNodeEntry`, `GraphReducerEntry`) in `Generators/Models/` and Mermaid emission in `TopologyGraphCodeGenerator` in `Generators/CodeGen/`, following the existing `HandoffEntry`/`GroupChatEntry`/`SequenceEntry` pattern. The registry emitter (`RegistryCodeGenerator.GenerateGraphTopologyRegistrySource`) produces `AgentGraphTopologyRegistry` which is registered in the bootstrap `ModuleInitializer`.
-- **IMP-003**: Analyzer IDs `NDLRMAF016`–`NDLRMAF029` (with `023` retired and `026` reserved) must be registered in `MafDiagnosticIds.cs` and `MafDiagnosticDescriptors.cs`. Cycle detection (`NDLRMAF016`) requires a topological sort or DFS-based algorithm operating on the Roslyn syntax/semantic model. Condition method validation (`NDLRMAF028`) and reducer method validation (`NDLRMAF029`) walk the type hierarchy for inherited method resolution.
-- **IMP-004**: The `WorkflowFactory` needs a new code path for graph construction that maps `[AgentGraphEdge]` topology to MAF's `WorkflowBuilder` API, translating routing modes to the appropriate edge data types (`DirectEdgeData`, `FanOutEdgeData`, `FanInEdgeData`).
-- **IMP-005**: Success criteria — the feature is correct when: (a) a DAG declared entirely via attributes compiles, runs, and produces the expected output; (b) all 9 analyzer classes (12 diagnostics) fire on invalid topologies with no false positives on valid ones; (c) `IDagRunResult` captures per-node diagnostics with timing and token usage; (d) existing workflow types are unaffected (no regressions in handoff, group chat, or sequential tests).
+Static repository inspection cannot establish production latency, model-routing quality,
+or suitability for a particular workload. Those remain operational concerns.
 
 ## References
 
-- **REF-001**: [MAF graph API source (v1.1.0)](https://github.com/microsoft/agent-framework/tree/main/dotnet/src/Microsoft.Agents.AI.Workflows) — `WorkflowBuilder`, `Edge`, `Executor`, `FunctionExecutor<T>`, `DirectEdgeData`, `FanOutEdgeData`, `FanInEdgeData`
-- **REF-002**: Existing workflow attributes — `src/NexusLabs.Needlr.AgentFramework/AgentHandoffsToAttribute.cs`, `AgentGroupChatMemberAttribute.cs`, `AgentSequenceMemberAttribute.cs`
-- **REF-003**: Existing workflow factory — `src/NexusLabs.Needlr.AgentFramework/IWorkflowFactory.cs`, `WorkflowFactory.cs`
-- **REF-004**: Existing source generator — `src/NexusLabs.Needlr.AgentFramework.Generators/AgentFrameworkFunctionRegistryGenerator.cs`, `CodeGen/`, `Models/`
-- **REF-005**: Existing analyzers — `src/NexusLabs.Needlr.AgentFramework.Analyzers/MafDiagnosticIds.cs` (IDs `NDLRMAF001`–`NDLRMAF015`)
-- **REF-006**: Progress infrastructure — `src/NexusLabs.Needlr.AgentFramework/Progress/IProgressReporter.cs`, `IProgressEvent.cs`
-- **REF-007**: Diagnostics infrastructure — `src/NexusLabs.Needlr.AgentFramework/Diagnostics/IPipelineRunResult.cs`, `IAgentStageResult.cs`
-- **REF-008**: MAF package version — `src/Directory.Packages.props` pins `Microsoft.Agents.AI.Workflows` at `1.1.0`
+- [`docs/ai-integrations.md`](../ai-integrations.md) documents the public graph attributes,
+  execution modes, diagnostics, and runnable example that implement this decision.
+- [`IGraphWorkflowRunner` at the confirmation snapshot](https://github.com/ncosentino/needlr/blob/78b27a1c5eddd5b8fa3e0c07dce629159b39e436/src/NexusLabs.Needlr.AgentFramework/IGraphWorkflowRunner.cs)
+  is the stable public execution boundary selected by this decision.
+- [Microsoft Agent Framework workflows](https://learn.microsoft.com/en-us/agent-framework/workflows/)
+  describe the underlying framework capability that Needlr adapts rather than exposes as
+  its public topology model.

--- a/docs/adr/adr-0002-build-scriptedchatclient-locally.md
+++ b/docs/adr/adr-0002-build-scriptedchatclient-locally.md
@@ -8,86 +8,127 @@ supersedes: ""
 superseded_by: ""
 ---
 
-## Status
+## Context and scope
 
-Accepted — gates the V1.5 follow-up to ship a paved path for end-to-end agent-loop tool tests.
+`NexusLabs.Needlr.AgentFramework.Testing` provides runners for deterministic agent and
+pipeline scenarios, but callers must supply an `IChatClient`. Needlr's tests and examples
+therefore contain multiple one-off chat-client implementations for scripted responses,
+multi-turn tool calls, failure injection, and call recording. Consumers face the same
+duplication when testing agents without a live model.
 
-## Context
+At the time of this decision, the shipped Microsoft.Extensions.AI packages did not
+include a public testing package or reusable scripted `IChatClient`. The dotnet/extensions
+test suite had a callback-based `TestChatClient` in a test assembly, but that type was not
+part of a package consumers could reference.
 
-The `NexusLabs.Needlr.AgentFramework.Testing` package ships `AgentScenarioRunner` and `PipelineScenarioRunner`, both of which expect callers to wire a fake `IChatClient` through `AgentFrameworkSyringeExtensions.UsingChatClient(...)` to deterministically test agent behavior without a real LLM. The package itself does not provide an `IChatClient` fake, so the Needlr codebase contains 8 ad-hoc, copy-pasted implementations:
+This decision covers a deterministic scripted test client for agent-loop tests. It does
+not attempt to emulate a model provider, network transport, token accounting, streaming
+timing, or every possible `IChatClient` implementation detail.
 
-- `Examples/AgentFramework/IterativeLoopDiagnosticsApp/Program.cs:200` — `ToolCallingMockChatClient`
-- `Examples/AgentFramework/DiagnosticAttributionApp/Program.cs:197` — `MockChatClient`
-- `Examples/AgentFramework/AotAgentFrameworkApp/Program.cs:68` — `NoOpChatClient`
-- `NexusLabs.Needlr.AgentFramework.Evaluation.Tests/RecordingChatClient.cs`
-- `NexusLabs.Needlr.AgentFramework.Evaluation.Tests/ThrowingChatClient.cs`
-- `NexusLabs.Needlr.AgentFramework.Tests/DiagnosticsRecordingChatClientTestsHelpers.cs:5` — `FakeInnerChatClient`
-- `NexusLabs.Needlr.AgentFramework.Tests/DiagnosticsFunctionInvokingChatClientTestsHelpers.cs:9` — `TestChatClient`
-- `NexusLabs.Needlr.AgentFramework.Tests/GraphWorkflowRuntimeTests.cs:1399` — `FailingChatClient`
+## Decision drivers
 
-Downstream consumers writing `[AgentFunction]`-decorated tools hit the same gap and write their own.
-
-The candidate alternative was to depend on a Microsoft testing package and wrap it with a Needlr extension method. This ADR records the investigation outcome and the build-vs-buy decision.
+- Agent-loop tests must run deterministically without credentials or network access.
+- Needlr and its consumers should not repeatedly implement the same multi-turn fake.
+- The public testing surface should remain small and depend only on existing MEAI
+  abstractions.
+- The client should support both response scripting and request inspection.
+- Needlr should prefer an official Microsoft test primitive if one becomes available and
+  satisfies the same contract.
 
 ## Decision
 
-Build a first-party `ScriptedChatClient` (and supporting `ChatScriptBuilder`) inside `NexusLabs.Needlr.AgentFramework.Testing`. Do not take a dependency on a Microsoft testing package — none exists, none is on the public roadmap, and the dotnet/extensions team's own tests use an `internal` copy-paste pattern that consumers cannot reuse.
+Needlr will build a first-party `ScriptedChatClient` in
+`NexusLabs.Needlr.AgentFramework.Testing`, with a small `ChatScriptBuilder` for readable
+multi-turn scripts.
 
-## Investigation
+The client will:
 
-Verified via direct nuget.org and dotnet/extensions repository inspection (May 6, 2026):
+- implement `IChatClient` directly;
+- return ordered scripted responses and fail clearly when the script is exhausted;
+- record received messages and call count for assertions;
+- support streaming by projecting scripted responses through MEAI's response-update
+  model;
+- remain sealed and intentionally narrow so it can be deprecated or adapted if Microsoft
+  later ships an equivalent public testing primitive.
 
-| Search | Result |
-|---|---|
-| `https://www.nuget.org/packages/Microsoft.Extensions.AI.Testing` | HTTP 404 |
-| NuGet search `Microsoft.Extensions.AI.Testing` (incl. prerelease) | 0 results |
-| NuGet search `Microsoft.Extensions.AI.Fakes` / `Microsoft.Extensions.AI.TestUtilities` | 0 results |
-| dotnet/extensions GitHub issues + discussions for testing package | 0 results — no public proposal or roadmap entry |
-| dotnet/extensions `src/` libraries scanned for any public scripted/fake `IChatClient` | None found |
+The Testing package will not take a dependency on a speculative Microsoft testing package
+or copy an internal test-only type from dotnet/extensions.
 
-What does exist:
+## Alternatives considered
 
-1. **`TestChatClient`** at `dotnet/extensions:test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/TestChatClient.cs` (SHA `95f89a79141e34f8f8defddb60821800cc3bffad`) — an internal callback wrapper used only inside the dotnet/extensions test suite. Not referenced from any `src/` library, not packaged into any NuGet output. Public API surface is two settable `Func<>` callbacks; no turn scheduling or call recording.
-2. **`AnonymousDelegatingChatClient`** at `dotnet/extensions:src/Libraries/Microsoft.Extensions.AI/ChatCompletion/AnonymousDelegatingChatClient.cs:18` is `internal sealed`, so consumers cannot instantiate it.
-3. **The dotnet team's own multi-turn tests** at `dotnet/extensions:test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/FunctionInvokingChatClientTests.cs:2198-2252` use the `TestChatClient` callback with `messages.Count()` as the turn index — every test re-implements the turn counter via closure. There is no reusable type.
-4. **Shipped MEAI packages** (Abstractions / Core / OpenAI / Evaluation, all 10.5.2 as of May 5, 2026, MIT-licensed) provide no `IChatClient` test fakes.
+### Depend on an official Microsoft.Extensions.AI testing package
+
+An official package would minimize Needlr-owned surface and align consumers with upstream
+MEAI conventions. It was not available when this decision was made, so it could not
+provide a usable dependency. This remains the preferred future replacement if Microsoft
+ships an equivalent public contract.
+
+### Continue using local fakes in each test project
+
+Local fakes avoid adding a public Needlr type and let each test implement only what it
+needs. This was rejected because multi-turn sequencing, exhaustion behavior, streaming,
+and request recording were already being duplicated across the repository and by
+consumers.
+
+### Keep a shared fake internal to Needlr's test assemblies
+
+An internal helper would improve Needlr's own tests without committing to public API. It
+was rejected because the same gap exists for every consumer of `AgentScenarioRunner`; an
+internal helper would leave the public testing workflow incomplete.
+
+### Use mocks directly for `IChatClient`
+
+Mocking is appropriate for a single boundary call, but multi-turn agent behavior requires
+ordered responses and captured conversation state. Rebuilding that state machine in each
+mock setup is less readable and no less coupled than a purpose-built scripted client.
 
 ## Consequences
 
 ### Positive
 
-- Removes 8 copy-paste fakes once V1.5 ships.
-- The `AgentScenarioRunner` doc comment at `src/NexusLabs.Needlr.AgentFramework.Testing/AgentScenarioRunner.cs:24-37` already directs consumers to wire a fake `IChatClient` — `ScriptedChatClient` becomes the canonical answer.
-- ~60 lines of code with zero dependencies beyond `Microsoft.Extensions.AI.Abstractions` (already in the chain).
-- `ScriptedChatClient` lives next to `AgentScenarioRunner` in the same package — discoverable in IDE.
-- Streaming support is free via `ChatResponse.ToChatResponseUpdates()` (stable public MEAI API).
+- Agent-loop tests gain one credential-free, deterministic client for multi-turn scripts.
+- Consumers can assert the messages sent to the model without writing another fake.
+- The type lives beside `AgentScenarioRunner`, making the supported test path discoverable.
+- No new package dependency is required beyond the MEAI abstractions already used by the
+  Agent Framework.
 
 ### Negative
 
-- One more shipped public type to maintain forever in Needlr's public API surface.
-- If Microsoft ever ships an official testing package, we'd have a competing primitive. Mitigation: design `ScriptedChatClient` as a thin sealed type so it can be marked `[Obsolete]` and forwarded later without breaking consumers.
+- Needlr assumes maintenance responsibility for another public testing type.
+- The client cannot model every provider-specific behavior without losing its intentionally
+  small scope.
+- If Microsoft ships an equivalent package, Needlr will temporarily have a competing
+  abstraction and will need a deliberate migration.
 
 ### Neutral
 
-- The decision does not affect V1 — the `ToolInvocationRunner` does not need a chat client because it invokes the source-generated `AIFunction` wrapper directly, bypassing the LLM.
+- Tests that need provider-specific transport or streaming behavior may continue to use
+  specialized boundary fakes.
+- This decision does not change production chat-client composition.
 
-## Implementation outline (V1.5)
+## Confirmation
 
-Target file: `src/NexusLabs.Needlr.AgentFramework.Testing/ScriptedChatClient.cs`. One type per file. File-scoped namespace. Full XML docs. Per `AGENTS.md`.
+This accepted decision is not yet fully implemented. The current Testing package still
+exposes scenario runners without a public `ScriptedChatClient`, and
+`docs/testing-tools.md` identifies the scripted client as planned work.
 
-Required surface:
-- Sealed class implementing `IChatClient`.
-- Constructor accepting an ordered list of `ChatResponse` (the script).
-- `ReceivedMessages` — `IReadOnlyList<IReadOnlyList<ChatMessage>>` for assertions.
-- `CallCount` — `int`.
-- `GetResponseAsync` returns the next scripted response; throws clear `InvalidOperationException` on overflow ("script exhausted").
-- `GetStreamingResponseAsync` shells through `GetResponseAsync` + `ToChatResponseUpdates()`.
-- A separate `ChatScriptBuilder` (also one type per file) for fluent script assembly with `OnTurn(n, t => t.RequestTool(...))` / `OnTurn(n, t => t.RespondText(...))` shorthand.
+Implementation will confirm the decision when:
 
-Replaces (post-ship migration):
-- All 8 ad-hoc fakes listed above. Forcing-function migration done as part of V1.5 to keep the abstraction honest.
+- the Testing package exposes the scripted client and builder;
+- tests verify ordered responses, exhaustion, request recording, cancellation, and
+  streaming projection;
+- at least one end-to-end agent scenario uses the public client; and
+- representative one-off chat-client fakes can be removed without losing coverage.
+
+If Microsoft publishes a supported equivalent before those conditions are met, this ADR
+must be reconsidered rather than implemented by default.
 
 ## References
 
-- Spike research: `meai-testing-spike` background agent, May 6, 2026.
-- Needlr issue: build-vs-buy gate for V1.5 follow-up todo `meai-testing-spike` (was satisfied by this ADR; new V1.5 todo `scripted-chat-client-build` will track implementation).
+- [`docs/testing-tools.md`](../testing-tools.md) explains why full agent scenarios require
+  a deterministic `IChatClient` and records the current absence of the shared client.
+- [`AgentScenarioRunner` at the confirmation snapshot](https://github.com/ncosentino/needlr/blob/78b27a1c5eddd5b8fa3e0c07dce629159b39e436/src/NexusLabs.Needlr.AgentFramework.Testing/AgentScenarioRunner.cs)
+  is the public test harness that needs the scripted boundary.
+- [dotnet/extensions `TestChatClient` at an immutable commit](https://github.com/dotnet/extensions/blob/c221abef4b4f1bf3fcf0bda27490e8b26bb479f4/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/TestChatClient.cs)
+  demonstrates that Microsoft used a test-assembly helper but did not expose it as a
+  consumer package.

--- a/docs/adr/adr-0003-provider-neutral-experiment-runner.md
+++ b/docs/adr/adr-0003-provider-neutral-experiment-runner.md
@@ -8,1105 +8,219 @@ supersedes: ""
 superseded_by: ""
 ---
 
-## Status
+## Context and scope
 
-Accepted - proceed through the separately reviewed implementation phases below.
+Needlr already supported individual MEAI evaluations, deterministic and LLM-judged
+evaluators, response capture, quality thresholds, and Langfuse tracing and scoring.
+It did not provide one reusable way to run a finite collection of cases with bounded
+concurrency, repeated statistical trials, operational retries, failure isolation,
+run-level evaluation, acceptance policy, and independent publication.
 
-This ADR was the design deliverable for [issue #36](https://github.com/ncosentino/needlr/issues/36).
-Phase 1 was delivered by [issue #43](https://github.com/ncosentino/needlr/issues/43).
-Phase 2 was delivered by [issue #45](https://github.com/ncosentino/needlr/issues/45).
-Phase 3A was delivered by [issue #49](https://github.com/ncosentino/needlr/issues/49).
-Phase 3B was delivered by [issue #50](https://github.com/ncosentino/needlr/issues/50).
-Phase 4A was delivered by [issue #51](https://github.com/ncosentino/needlr/issues/51).
-Phase 4B was delivered by [issue #52](https://github.com/ncosentino/needlr/issues/52).
-Phase 4C was delivered by [issue #53](https://github.com/ncosentino/needlr/issues/53).
-Phase 5 was delivered by [issue #54](https://github.com/ncosentino/needlr/issues/54).
+That gap affected at least two materially different workloads:
 
-The post-Phase-2 convergence audit found that the provider-neutral scheduler and the existing
-Langfuse primitives are complementary, but the item-lifecycle and result-sink seams proposed by this
-ADR were still missing. That left Langfuse documentation relying on a caller-owned item loop instead
-of the generic runner.
+- deterministic regression suites, where each case usually runs once and every failure
+  must remain visible; and
+- stochastic evaluations, where one logical case has multiple independent trials and
+  acceptance must report sample counts and uncertainty.
 
-The separately reviewed implementation sequence is complete. Further scheduler, retry, evaluator,
-statistical-policy, or provider expansion requires a separate design and issue.
+Microsoft.Extensions.AI.Evaluation.Reporting provides evaluator composition, response
+caching, result storage, and report generation around a `ScenarioRun`. It is not a
+collection scheduler or retry and policy engine. Langfuse's SDK experiment runners prove
+that collection orchestration is useful, but their provider-specific data model and
+failure semantics are not suitable as Needlr's canonical contract.
+
+This decision governs finite in-process experiment orchestration and provider adapter
+boundaries. It does not cover streaming or unbounded case sources, distributed workers,
+checkpoint and resume, a universal statistical-method catalog, provider-specific
+idempotency, or test-framework fixtures.
+
+## Decision drivers
+
+- Deterministic and stochastic workloads should share one execution and failure model.
+- Trials must remain distinct from operational retry attempts.
+- Bounded resource use, caller cancellation, and deterministic result ordering must be
+  explicit.
+- Failed, timed-out, canceled, and unevaluable items must remain visible to run-level
+  analysis.
+- Evaluation quality must remain independent from telemetry and persistence health.
+- Dataset hosts, observability providers, and report stores must integrate without
+  controlling scheduling or canonical results.
+- Needlr should reuse MEAI's evaluator and metric abstractions rather than create a second
+  evaluation ecosystem.
+- The core API must remain independent of xUnit, NUnit, MSTest, and a particular agent
+  loop.
 
 ## Decision
 
-Needlr should add a provider-neutral experiment runner that owns:
+Needlr will own a provider-neutral experiment runner in
+`NexusLabs.Needlr.AgentFramework.Evaluation.Experiments`.
+
+The core runner owns:
 
 - finite case materialization and validation;
-- expansion of cases into statistically meaningful trials;
-- bounded item scheduling;
-- execution attempts, timeouts, and retries;
+- expansion of cases into statistically independent trials;
+- bounded scheduling and deterministic result ordering;
+- attempt history, timeout, cancellation, and explicit retry policy;
 - whole-item failure isolation;
-- deterministic result ordering;
-- run-level evaluation and policy decisions;
-- structured publication outcomes across independent sinks.
-
-Needlr should not own:
-
-- MEAI evaluator composition;
-- MEAI response caches;
-- MEAI evaluation-result stores;
-- MEAI report generation;
-- Langfuse dataset, trace, score, or comparison semantics;
-- test-framework fixtures or process-global coordination.
-
-`Microsoft.Extensions.AI.Evaluation.EvaluationResult` remains the item- and run-metric payload because Needlr's evaluation package already uses the MEAI core abstractions directly. MEAI Reporting types such as `ReportingConfiguration`, `ScenarioRun`, and `ScenarioRunResult` do not become Needlr's experiment data model.
-
-In this ADR, provider-neutral means neutral across execution engines, dataset hosts, observability platforms, and publication targets. It does not mean evaluation-abstraction neutral: MEAI core is the deliberate metric lingua franca for Needlr's evaluation package.
-
-The runner belongs in the existing `NexusLabs.Needlr.AgentFramework.Evaluation` package under an
-`Experiments` namespace. Langfuse-specific adapters remain in
-`NexusLabs.Needlr.AgentFramework.Langfuse`; MEAI Reporting-specific dependencies remain in
-`NexusLabs.Needlr.AgentFramework.Evaluation.Reporting`.
-
-## Context
-
-Needlr already provides:
-
-- native MEAI evaluation inputs and evaluators;
-- deterministic and LLM-judged agent evaluators;
-- a single-result `EvaluationQualityGate`;
-- response capture and replay;
-- agent and pipeline scenario runners;
-- Langfuse scenario, dataset-run, and score primitives;
-- bounded Langfuse shutdown, caller-cancellation preservation, isolated trace context, and a complete non-owning `ILangfuseClient`.
-
-It does not provide collection-level experiment orchestration. Consumers still have to independently implement:
-
-- bounded concurrency across cases;
-- failure isolation between cases;
-- retries that remain distinct from statistical trials;
-- run-level aggregates and acceptance policies;
-- one structured result that retains failures;
-- publication to multiple reporting or observability systems.
-
-The existing `AgentScenarioRunner` and `PipelineScenarioRunner` are not the missing abstraction. They each execute one Needlr-specific scenario shape and combine execution with verification. An experiment runner must remain independent of a particular agent loop, pipeline, test framework, or verification style.
-
-### Verified external boundaries
-
-The repository currently pins MEAI Evaluation and Reporting `10.5.0`. The latest stable Reporting package reviewed during this spike was `10.7.0`; its documented responsibility remains response caching, result storage, and reporting rather than collection scheduling.
-
-At the pinned version:
-
-- `ReportingConfiguration` configures evaluators, judge chat configuration, response caching, result storage, execution identity, interpretation, and tags.
-- `ScenarioRun` represents one scenario iteration, invokes a `CompositeEvaluator`, and persists its result when disposed.
-- `CompositeEvaluator` runs item evaluators concurrently and converts evaluator exceptions into metric diagnostics.
-- MEAI does not schedule a collection of scenarios, bound item concurrency, model execution attempts, apply retries, or run aggregate evaluators.
-
-Langfuse's current Python and JavaScript/TypeScript experiment runners provide concurrent item execution, item and run evaluators, tracing, error isolation, and hosted-dataset integration. They are useful validation that the orchestration problem is real, but they are not a suitable canonical model for Needlr:
-
-- both SDKs currently default to a concurrency of 50;
-- their scheduling implementations differ;
-- failed task items are logged and omitted from the `itemResults` supplied to run evaluators;
-- they do not expose a first-class retry/attempt model;
-- local datasets and hosted datasets have different publication behavior.
-
-Needlr should not clone those provider-specific semantics, especially the omission of failed items from aggregate inputs.
-
-### Decision constraints
-
-- Needlr is alpha. Prefer intentional API correction over compatibility shims.
-- Public results must be structured and machine-actionable.
-- A human-readable formatter is an adapter, not the canonical result.
-- No static singleton holders or process-global mutable coordination.
-- No xUnit, NUnit, MSTest, or test-runner types in the core API.
-- No universal concurrency default derived from one provider or workload.
-- Provider publication failure must not redefine evaluation quality.
-- Implementation must use strict TDD and include runnable, credential-free examples.
-
-## Independent evaluation shapes
-
-The runner is justified only if one model supports materially different evaluation shapes.
-
-### Shape 1: finite deterministic regression suite
-
-Example:
-
-- 200 fixed agent scenarios;
-- one trial per case;
-- no retry unless a case explicitly opts into a transient-failure policy;
-- deterministic trajectory, termination, and token-budget evaluators;
-- acceptance requires every required metric and no failed execution.
-
-This shape needs:
-
-- stable source ordering;
-- bounded concurrency;
-- exact failure accounting;
-- deterministic pass/fail policy;
-- a CI adapter that can translate the structured decision to a process exit code.
-
-### Shape 2: repeated stochastic trials
-
-Example:
-
-- 40 logical scenarios;
-- 10 independent trials per scenario;
-- an LLM or agent execution whose output can vary;
-- run evaluators that calculate success rate, execution-failure rate, latency, cost, and a confidence interval;
-- acceptance that can return passed, failed, or inconclusive.
-
-This shape needs:
-
-- a strict distinction between a trial and an operational retry;
-- sample and exclusion counts;
-- all failed and timed-out items retained in aggregate inputs;
-- an explicit response-cache policy so repeated trials are not accidentally replayed from one cached response;
-- statistical policies that report uncertainty rather than only a mean.
-
-These shapes share scheduling, attempts, result ordering, failure isolation, and publication. They differ at the run-evaluation and policy layers, which supports a common runner with composable policies.
-
-## Terminology
-
-| Term | Meaning |
-|---|---|
-| Case | One logical input and its caller-defined data. |
-| Trial | One statistically independent scheduled execution of a case. |
-| Item | The runner's work unit for one case and one trial index. |
-| Attempt | One operational execution try for an item. Retries add attempts, not trials. |
-| Item evaluation | Metrics calculated from one terminal successful item output. |
-| Run evaluation | Metrics calculated across every item result, including failures. |
-| Policy | A structured acceptance decision derived from item and run metrics. |
-| Sink | An independent publisher or artifact writer that receives a completed run result. |
-
-The identity of an item is `(CaseId, TrialIndex)`. The identity of an attempt is `(CaseId, TrialIndex, AttemptNumber)`.
-
-## Options considered
-
-| Path | Benefits | Costs and risks | Migration and future compatibility |
-|---|---|---|---|
-| A. Provider-neutral Needlr runner | Solves scheduling, attempts, failures, aggregation, and publication once; supports local and hosted data; retains a single structured result; test-framework independent. | Medium public API cost; Needlr must maintain concurrency, cancellation, and failure semantics. | Best isolation from MEAI Reporting and provider changes. Adapters can evolve without changing experiment definitions. |
-| B. Thin MEAI Reporting extensions | Lowest immediate implementation and API cost; directly follows Microsoft types. | Does not solve collection scheduling, retries, aggregate policy, or sink fan-out; every consumer still builds a runner. | Low library maintenance but high consumer fragmentation. A later canonical runner becomes harder to adopt. |
-| C. Langfuse-specific runner | Fastest path to familiarity for Langfuse Python/JS users; direct hosted-dataset integration. | Provider lock-in; duplicates changing SDK behavior; failed-item semantics are unsuitable; creates a second Needlr evaluation model. | Highest migration risk if Langfuse changes or MEAI later adds orchestration. Non-Langfuse users still need another solution. |
-
-### Option A: provider-neutral Needlr runner
-
-**Pros**
-
-- The missing behavior is general across deterministic and stochastic workloads.
-- Failure, timeout, retry, and ordering semantics become consistent.
-- Providers cannot silently change the quality verdict.
-- Local data remains first-class.
-- MEAI and Langfuse each retain ownership of their established capabilities.
-
-**Cons**
-
-- The scheduler and result model become long-lived Needlr API.
-- Statistical policy design must avoid false universality.
-- Adapter lifecycle hooks require careful async-context testing.
-
-### Option B: thin MEAI Reporting extensions
-
-**Pros**
-
-- Minimal code and dependency risk.
-- MEAI remains the visible user model.
-
-**Cons**
-
-- `ReportingConfiguration` and `ScenarioRun` are not collection schedulers.
-- Consumers still duplicate concurrency, retries, partial-failure handling, and aggregate decisions.
-- Provider publication and evaluation quality remain easy to conflate.
-
-This path may produce small convenience adapters, but it is rejected as the end state for issue #36.
-
-### Option C: Langfuse-specific runner
-
-**Pros**
-
-- Direct parity with Langfuse terminology and hosted comparison views.
-- Less adapter work for Langfuse-only consumers.
-
-**Cons**
-
-- Concurrency and failure semantics would inherit provider behavior.
-- Local-only and alternate-provider consumers would receive a second-class API.
-- Current Langfuse SDKs omit failed tasks from aggregate inputs.
-- Retries, statistical trials, and MEAI Reporting would remain awkward additions.
-
-This path is avoided.
-
-## Proposed architecture
-
-```text
-Experiment definition
-  |
-  +-- finite case source
-  +-- item task
-  +-- optional item evaluator
-  +-- run evaluators
-  +-- run policies
-  +-- item lifecycle adapters
-  +-- result sinks
-  |
-Experiment runner
-  |
-  +-- materialize and validate cases
-  +-- expand cases into ordered trials
-  +-- schedule bounded attempts
-  +-- isolate item failures
-  +-- evaluate successful items
-  +-- evaluate the full run
-  +-- calculate the quality decision
-  +-- publish through independent sinks
-  |
-Experiment run outcome
-  +-- canonical run result
-  +-- independent publication results
-```
-
-### Proposed definition and execution surface
-
-The following is the intended shape, not a finalized signature:
-
-```csharp
-public interface IExperimentRunner
-{
-    ValueTask<ExperimentRunOutcome<TOutput>> RunAsync<TCase, TOutput>(
-        ExperimentDefinition<TCase, TOutput> definition,
-        ExperimentRunOptions options,
-        CancellationToken cancellationToken = default);
-}
-
-public sealed record ExperimentDefinition<TCase, TOutput>
-{
-    public required string Name { get; init; }
-    public required IExperimentCaseSource<TCase> CaseSource { get; init; }
-    public required ExperimentTask<TCase, TOutput> Task { get; init; }
-    public IExperimentItemEvaluator<TCase, TOutput>? ItemEvaluator { get; init; }
-    public IReadOnlyList<IExperimentRunEvaluator<TCase, TOutput>> RunEvaluators { get; init; }
-    public IReadOnlyList<IExperimentRunPolicy<TCase, TOutput>> Policies { get; init; }
-    public IReadOnlyList<IExperimentItemScopeProvider<TCase, TOutput>> ItemScopes { get; init; }
-    public IReadOnlyList<IExperimentResultSink<TOutput>> Sinks { get; init; }
-}
-
-public sealed record ExperimentRunOptions
-{
-    public required string RunId { get; init; }
-    public required int MaxConcurrency { get; init; }
-    public TimeSpan? AttemptTimeout { get; init; }
-    public IExperimentRetryPolicy RetryPolicy { get; init; }
-    public IExperimentConcurrencyLimiter? SharedLimiter { get; init; }
-}
-```
-
-The implementation may refine names or generic placement, but it must preserve these boundaries:
-
-- one runner service with injected dependencies;
-- a finite case source;
-- an attempt-level task callback;
-- item evaluation after terminal execution success;
-- full-run evaluators and policies;
-- item-lifecycle scopes for provider context;
-- independent final-result sinks.
-
-Interfaces are limited to genuine extension points. Result types are sealed data types rather than inheritance hierarchies.
-
-There is at most one item-evaluation producer. A caller that needs multiple evaluators composes them behind that one interface. A MEAI Reporting adapter supplies the item evaluator and uses its paired item scope to reach the same `ScenarioRun`; it does not add a second hidden evaluation stage.
-
-### Case and source model
-
-The minimum case model is:
-
-```text
-ExperimentCase<TCase>
-  Id                 required, unique within the materialized source
-  Value              caller-defined input, expected output, and metadata
-  TrialCount         positive; defaults to one
-  Tags               optional string tags
-
-ExperimentCaseSourceResult<TCase>
-  Source             provider-neutral name/id/version reference
-  Cases              finite ordered case list
-```
-
-The core does not define separate generic input, expected-output, and metadata types. Callers model those together in `TCase`, which avoids a growing generic arity and lets hosted adapters preserve provider references in an adapter-owned case type.
-
-The source is fully materialized before execution. The runner validates:
-
-- non-empty run and case identifiers;
-- unique case identifiers;
-- positive trial counts;
-- positive `MaxConcurrency`;
-- representable total item count.
-
-Source or validation failures occur before any item starts and are thrown to the caller.
-
-### Attempt and item result model
-
-```text
-ExperimentAttemptResult
-  AttemptNumber       one-based
-  Status              Succeeded | Failed | TimedOut | Canceled
-  StartedAt
-  Duration
-  Failure             structured failure when not successful
-
-ExperimentItemResult<TOutput>
-  Sequence            stable source-order/trial-order index
-  CaseId
-  TrialIndex          one-based statistical sample index
-  Status              Succeeded | ExecutionFailed | TimedOut |
-                      Canceled | EvaluationFailed | PrerequisiteFailed
-  Attempts            every operational attempt in order
-  Output              terminal successful output, when available
-  Evaluation          MEAI EvaluationResult, when available
-  Failure             terminal structured failure, when present
-  Correlations        optional namespaced string identifiers for adapters
-  Publications        item-scope publication results
-```
-
-`ExperimentFailure` is machine-actionable:
-
-```text
-ExperimentFailure
-  Code
-  Stage               Execution | ItemEvaluation | RunEvaluation |
-                      Policy | Publication
-  ExceptionType
-  Message
-  IsRetryable
-```
-
-The canonical result does not serialize a raw `Exception` or stack trace by default. Isolated
-failures retain stable machine-actionable fields without making provider-specific exception types
-part of the result contract.
-
-An item-scope publication result is separate from item quality:
-
-```text
-ExperimentItemPublicationResult
-  Name
-  IsRequired
-  Status              Succeeded | Failed | NotAttempted
-  Correlations
-  Failure
-```
-
-### Run evaluation and policy model
-
-```text
-ExperimentRunEvaluationResult
-  Name
-  Status              Succeeded | Failed
-  Metrics             MEAI EvaluationResult when successful
-  Failure             structured failure when failed
-
-ExperimentPolicyResult
-  Name
-  Kind                Deterministic | Statistical
-  IsRequired
-  Decision            Passed | Failed | Inconclusive
-  Evidence            structured policy evidence containing MEAI metrics,
-                      status counts, thresholds, bounds, and exclusions
-  Failure             structured failure when policy execution failed
-
-ExperimentRunResult<TOutput>
-  SchemaVersion
-  RunId
-  ExperimentName
-  Source
-  StartedAt
-  Duration
-  Items
-  RunEvaluations
-  PolicyResults
-  Decision            Passed | Failed | Inconclusive | NotEvaluated
-```
-
-The overall decision is reduced deterministically:
-
-1. Any required failed policy makes the run `Failed`.
-2. Otherwise, any required inconclusive policy makes the run `Inconclusive`.
-3. Otherwise, all required policies passing makes the run `Passed`.
-4. No required policies makes the run `NotEvaluated`.
-
-A policy exception does not become a fabricated quality failure. It produces an inconclusive policy result with a structured failure.
-
-### Publication model
-
-Sinks receive a read-only snapshot of `ExperimentRunResult<TOutput>` and return structured sink results. The runner then returns:
-
-```text
-ExperimentSinkResult
-  Name
-  IsRequired
-  Status              ExperimentPublicationOperationStatus:
-                      Succeeded | Failed | NotAttempted
-  Failure
-
-ExperimentRunOutcome<TOutput>
-  SchemaVersion       4
-  Result              canonical ExperimentRunResult<TOutput>
-  PublicationStatus   ExperimentPublicationStatus:
-                      NotRequested | Succeeded | PartiallyFailed | Failed
-  SinkResults
-```
-
-This two-stage model prevents publication outcomes from being folded back into the quality decision. Sinks receive a read-only snapshot contract. The implementation copies all Needlr-owned collections and normalizes MEAI metrics before fan-out; arbitrary caller-owned `TOutput` values cannot be deeply frozen and are read-only by contract.
-
-Required sink failure changes `PublicationStatus`, not `Result.Decision`. A CI adapter may independently require both a passing quality decision and successful required publication.
-
-`PublicationStatus` aggregates both item-scope publication results and final sink results:
-
-- `NotRequested` when no scope or sink attempted publication;
-- `Succeeded` when every attempted publication succeeded;
-- `PartiallyFailed` when only optional publications failed;
-- `Failed` when any required publication failed.
-
-### Item lifecycle adapters
-
-Some providers need a scope around the entire item rather than only a final sink:
-
-- MEAI Reporting creates a `ScenarioRun` before model execution when response caching is used.
-- Langfuse creates and activates one scenario trace for the trial and links it to a hosted dataset run.
-
-The runner therefore needs an item-scope extension point with these constraints:
-
-- scopes wrap one trial, not each retry attempt;
-- the runner still owns admission, attempts, timeout, retry, and decision semantics;
-- scopes can expose adapter-specific execution context to the task;
-- the runner invokes exactly one configured item evaluator after terminal execution success;
-- scopes can provide state to that evaluator but do not independently produce a second evaluation;
-- the runner builds the execution/evaluation portion, notifies scopes, disposes them, and then finalizes the item result with their publication results;
-- scopes receive an explicit abort path for caller cancellation before disposal;
-- provider failures are publication failures unless the caller explicitly makes them execution prerequisites;
-- multiple scopes enter in registration order and exit in reverse order;
-- no scope may rely on static or process-global mutable state.
-
-The finalized Phase 3A contract separates the provider factory from its per-trial scope:
-
-```text
-IExperimentItemScopeProvider<TCase,TOutput>
-  Name
-  IsRequired
-  FailureMode         BestEffort | ExecutionPrerequisite
-  EnterAsync          once per statistical trial
-
-IExperimentItemScope<TCase,TOutput>
-  Features            exact-Type adapter feature map
-  Activate            context-restoration handle per attempt/evaluator
-  CompleteAsync       terminal quality notification and publication result
-  AbortAsync          caller-cancellation notification
-  DisposeAsync        final cleanup
-```
-
-Entry runs under caller cancellation and shared admission but outside the per-attempt timeout.
-Activation handles nest in registration order and unwind in reverse order. Completion, abort, and scope disposal run without ambient activation and use scope-owned state.
-Caller cancellation aborts only scopes whose completion has not started; a started completion owns
-cancellation-safe termination and is never followed by abort. `ItemScopeCleanupTimeout` bounds
-cancellation cleanup and terminal disposal.
-
-`BestEffort` scope failure never changes item quality. `ExecutionPrerequisite` applies only before a
-task attempt starts; a failed prerequisite produces `PrerequisiteFailed` without inventing an
-attempt. Completion or disposal failures remain publication failures after quality is known.
-
-The item lifecycle is:
-
-1. Enter item scopes and collect their scoped features.
-2. Execute attempts under runner-owned timeout and retry rules.
-3. On terminal execution success, invoke the one item evaluator.
-4. Build the execution/evaluation portion, including `EvaluationFailed` when the evaluator throws.
-5. Notify scopes of that read-only quality outcome and collect structured publication results.
-6. Dispose scopes in reverse order; disposal failure updates only publication status.
-7. Finalize the item result with correlations and publication results.
-
-The MEAI Reporting adapter implements a coordinated scope/evaluator pair: the scope owns `ScenarioRun`, and the evaluator is the only component that calls `ScenarioRun.EvaluateAsync(...)`.
-
-Issues #33 and #34 established the context-safe Langfuse callback and structured link result used
-to finalize this provider-neutral contract. Langfuse types remain outside the core package.
-
-## Execution semantics
-
-### Materialization and ordering
-
-- Materialize the finite source before scheduling.
-- Expand cases in source order, then ascending `TrialIndex`.
-- Assign a stable `Sequence` before execution.
-- Return item results in `Sequence` order regardless of completion order.
-- Invoke run evaluators, policies, scopes, and sinks in their registration order unless an API explicitly states otherwise.
-
-### Bounded concurrency
-
-- `MaxConcurrency` is required and must be positive.
-- It bounds active execution attempts, not total cases and not queued retry delays.
-- Do not create one task per dataset item and place all tasks behind a semaphore.
-- Use a bounded worker/scheduler design whose pending work is data, not an unbounded task collection.
-- A retry delay holds neither a local execution permit nor a shared permit.
-- A retry is re-enqueued with a scheduled ready time; a worker does not sleep in place while holding a worker slot.
-
-An optional caller-owned `IExperimentConcurrencyLimiter` provides a second admission boundary shared by simultaneous runs. The runner:
-
-- awaits it with the caller token;
-- acquires it per attempt;
-- releases it before retry delay;
-- never disposes it;
-- does not create a default process-global limiter.
-
-The built-in limiter can be registered and shared through DI. Alternate implementations may adapt `System.Threading.RateLimiting`, provider quotas, or resource-aware admission policies.
-
-### Cancellation
-
-- Caller cancellation stops new admission immediately.
-- Limiter waits, active attempts, evaluator calls, and retry delays receive cancellation.
-- If the caller token is requested, caller cancellation wins over a simultaneous timeout.
-- `RunAsync` rethrows `OperationCanceledException`; it does not convert cancellation into an item failure or a completed run result.
-- Final run evaluators, policies, and sinks do not run after caller cancellation.
-- Entered item scopes receive an abort notification and are disposed through bounded cleanup.
-- An aborted scope must not publish a completed evaluation record for an incomplete item.
-
-Completed provider side effects may already exist when cancellation occurs. A resumable partial-run artifact is deferred rather than hidden behind a success-shaped result.
-
-### Timeouts
-
-- Timeout is per attempt.
-- The task receives a linked token combining caller cancellation and attempt deadline.
-- Caller-token cancellation is rethrown.
-- Deadline cancellation while the caller token remains active produces `TimedOut`.
-- A task-originated cancellation with neither token requested produces `Canceled`.
-- Timeout is retryable only when the configured retry policy says so.
-
-### Retries
-
-- Default is one attempt and no retry.
-- Retries apply only to execution failure, timeout, or task-originated cancellation selected by policy.
-- Caller cancellation is never retried.
-- Item evaluation, run evaluation, policy, scope, and sink failures never rerun the agent task.
-- Every attempt and retry delay is recorded.
-- Retry attempts do not increase the statistical sample count.
-- Hidden random jitter is prohibited. Any jitter policy must be explicit and reproducibly seeded.
-
-### Item evaluation
-
-- Item evaluation runs once after terminal execution success.
-- It receives the case, trial identity, output, and attempt history.
-- It returns a MEAI `EvaluationResult`.
-- Evaluator failure preserves the successful task output and marks the item `EvaluationFailed`.
-- The definition has at most one item evaluator. Multiple evaluator implementations must be explicitly composed behind it.
-- A MEAI Reporting adapter occupies that one evaluator slot and delegates to `ScenarioRun` and its `CompositeEvaluator`.
-- The runner never invokes both a direct item evaluator and a hidden MEAI evaluator for the same item.
-
-### Whole-item failure isolation
-
-- One item failure does not cancel siblings.
-- Failed, timed-out, canceled, and evaluation-failed items remain in the run result.
-- Run evaluators receive every item, not only successes.
-- Any exclusion must be explicit and reported with an exclusion count.
-- Execution failures count in denominators by default.
-
-### Run evaluators and policies
-
-Run evaluators measure. Policies decide.
-
-- Run evaluators receive the complete ordered item list.
-- Run evaluator failures are isolated and represented structurally.
-- Run evaluators execute sequentially in registration order initially; no hidden second concurrency policy is introduced.
-- Policies consume item results and successful run-evaluation metrics.
-- Policies cannot mutate measurements.
-- Human-readable report rendering remains outside the policy result.
-
-The existing `EvaluationQualityGate` is not duplicated. Phase 2 refactors its threshold checks into a shared structured result and keeps `Assert(...)` as a throwing adapter over that same evaluation.
-
-Missing required metrics produce `Inconclusive` by default, or `Failed` when the policy explicitly selects pessimistic treatment. `Optional*` thresholds preserve conditionally emitted metric support. Updating `Assert(...)` to use required-metric semantics is an intentional alpha correction rather than a compatibility shim.
-
-### Statistical policies
-
-The runner does not claim one universal statistical method.
-
-A statistical run evaluation must report at least:
-
-- total trial count;
-- successful sample count;
-- execution-failure count;
-- exclusion count;
-- estimate;
-- uncertainty measure or confidence interval;
-- confidence level;
-- baseline and paired delta when applicable.
-
-The initial statistical vertical slice should support a binary success proportion with a documented confidence interval and a policy such as:
-
-```text
-Passed         lower confidence bound >= required threshold
-Failed         upper confidence bound < required threshold
-Inconclusive   otherwise, or minimum sample requirements are unmet
-```
-
-The default binary-policy status mapping is:
-
-| Item state | Statistical treatment |
-|---|---|
-| `Succeeded` with a valid required boolean metric | Denominator success or failure according to the metric value. |
-| `ExecutionFailed` | Denominator failure. |
-| `TimedOut` | Denominator failure. |
-| Task-originated `Canceled` | Denominator failure. |
-| `EvaluationFailed`, `PrerequisiteFailed`, missing metric, or metric with failed diagnostics | Unknown sample; counted as an exclusion and forces `Inconclusive` unless the policy explicitly selects pessimistic failure treatment. |
-| Explicit policy exclusion | Excluded with a structured reason and counted by status. |
-
-Every statistical result reports counts by item status in addition to total success, failure, and exclusion counts. A policy cannot silently remove an item from its denominator.
-
-Paired candidate/baseline comparisons, clustered bootstrap methods, continuous-metric policies, adaptive sampling, and power-analysis helpers are deferred extension points.
-
-## MEAI Reporting adapter boundary
-
-The MEAI Reporting adapter is responsible for:
-
-1. Creating or receiving a run-specific `ReportingConfiguration`.
-2. Mapping the Needlr run ID to MEAI `ExecutionName`.
-3. Mapping case ID to `ScenarioName`.
-4. Mapping trial index to `IterationName`.
-5. Creating one `ScenarioRun` per statistical trial, not per retry attempt.
-6. Exposing the scenario's wrapped `ChatConfiguration` to the task when response caching is desired.
-7. Supplying the definition's single item evaluator, which calls `ScenarioRun.EvaluateAsync(...)` once after successful execution.
-8. Mapping an evaluator exception to the runner's `EvaluationFailed` item status.
-9. Disposing the `ScenarioRun` after the item result is built so the configured MEAI result store persists it.
-10. Returning the `EvaluationResult` as the item's canonical metrics.
-
-MEAI continues to own:
-
-- `CompositeEvaluator`;
-- judge chat configuration;
-- response-cache providers and keys;
-- evaluation-result stores;
-- report writers and the `dotnet aieval` report workflow.
-
-The adapter must make response reuse explicit for repeated trials:
-
-| Mode | Behavior |
-|---|---|
-| `CaseAndTrialReplay` | Preserve MEAI's normal scenario/iteration cache identity across runs. Useful for deterministic replay when the complete request and model cache key also matches. |
-| `FreshPerRun` | Add the Needlr run ID to cache identity so a new run produces new stochastic samples. |
-| `Disabled` | Require a `ReportingConfiguration` without a response-cache provider. |
-
-One `ScenarioRun` and cache identity spans all retry attempts for an item. A response cached before a downstream execution failure may therefore be replayed by the retry. This is intentional because a retry is not a new statistical sample. A caller that requires a fresh model response on every attempt must disable MEAI response caching for that experiment; finer per-attempt cache policy is deferred.
-
-The runner does not generate MEAI reports and does not create fake `ScenarioRun` entries for aggregate metrics. Run-level metrics remain in the Needlr result and may be published by sinks.
-
-A MEAI result-store write failure is publication failure. Normal scope disposal invokes
-`ScenarioRun.DisposeAsync`; the provider-neutral scope manager converts a thrown store exception into
-the final failed `ExperimentItemPublicationResult`. It does not trigger another model execution,
-disappear into logging, or change the item's quality status. `ScenarioRun.DisposeAsync` accepts no
-cancellation token, so a cleanup timeout can be reported while the provider store operation finishes
-later.
-
-## Langfuse adapter boundary
-
-Langfuse integrates through three independent adapters.
-
-### Hosted case source
-
-The source:
-
-- loads a finite hosted dataset selection;
-- records dataset identity and selected version in the source reference;
-- maps each hosted item to a Needlr case while preserving dataset-item identity;
-- performs all remote loading before item execution starts.
-
-Local case sources remain first-class and require no Langfuse dataset.
-
-### Item scope
-
-The scope:
-
-- creates one context-safe scenario trace per trial;
-- links that trace to a hosted dataset item at most once;
-- keeps every retry attempt beneath the same trial trace;
-- exposes trace correlation to the item result;
-- restores the prior ambient activity for nested and parallel items;
-- records link or trace-publication failure independently from item quality.
-
-This adapter depends on issue #33 for context-safe item execution and issue #34 for structured run identity and link status.
-
-### Result sink
-
-The sink:
-
-- projects item MEAI metrics to trace or observation scores;
-- projects run-evaluation metrics to dataset-run scores when a dataset-run ID exists;
-- records item-link, score, and run-score outcomes;
-- treats disabled Langfuse mode as a structurally valid no-op publication result;
-- does not choose concurrency, retry, timeout, or the quality verdict.
-
-High-volume retry, idempotency, batching, and export-health behavior remains owned by issue #35.
-
-Local experiments may publish traces and scores without a Langfuse dataset run. The Needlr run result remains complete even when the provider cannot create a comparison view.
-
-## Sink fan-out
-
-- Sinks receive the same read-only run snapshot, including item-scope publication results.
-- Sinks execute in deterministic registration order.
-- One sink failure does not suppress later sinks.
-- Sinks declare whether publication is required.
-- Generic automatic sink retry is not provided because publication operations may not be idempotent.
-- Provider adapters own bounded retry only after they establish provider-specific idempotency.
-- Evaluation decision and publication status remain separate at every layer.
-
-Expected initial sinks:
-
-- canonical JSON artifact;
-- MEAI Reporting persistence adapter;
-- Langfuse publication adapter.
-
-Human-readable console, Markdown, HTML, and CI-comment rendering consume the canonical outcome rather than changing it.
-
-## Compatibility and versioning
-
-The API is new and alpha:
-
-- no compatibility shim is required;
-- breaking corrections should be made before stabilization;
-- result types should be sealed, non-positional types so fields can be added without constructor churn;
-- interfaces should exist only at extension points;
-- the canonical result and canonical JSON projection include `SchemaVersion` from the first release;
-- serialized enum values and required fields become versioned contracts;
-- the JSON sink normalizes MEAI metrics into a Needlr-owned metric snapshot rather than blindly serializing the mutable `EvaluationResult` object graph;
-- `SchemaVersion` governs the Needlr envelope and normalized metric projection, not arbitrary caller-owned `TCase` or `TOutput` payloads;
-- Langfuse types do not appear in the core package;
-- MEAI Reporting types appear only in its adapter surface;
-- no raw exception object is part of the serialized contract;
-- caller-defined `TCase` and `TOutput` serialization remains caller responsibility.
-
-The implementation must revalidate against the then-current stable MEAI packages before coding. This ADR was verified against the repository's pinned `10.5.0` surface and the current stable `10.7.0` responsibility boundary.
-
-## Phased implementation plan
-
-No phase begins from this ADR alone. Each phase requires its own issue and reviewed pull request.
-
-### Phase 1: core scheduler and canonical result — delivered by #43
-
-Deliver:
-
-- finite case source and validation;
-- case-to-trial expansion;
-- required bounded concurrency;
-- caller cancellation and per-attempt timeout;
-- one-attempt default;
-- whole-item failure isolation;
-- deterministic result ordering;
-- canonical JSON sink with normalized metric snapshots;
-- no provider adapter.
-
-Required TDD:
-
-- exact maximum active attempts;
-- no unbounded task creation;
-- deterministic ordering under out-of-order completion;
-- duplicate-ID and invalid-option rejection before execution;
-- failure isolation;
-- caller cancellation precedence over timeout;
-- task-originated cancellation classification;
-- failed and timed-out items retained.
-- JSON schema version and normalized metric shape.
-
-Runnable example:
-
-- credential-free deterministic fake agent;
-- finite local cases;
-- mixed success and failure;
-- canonical JSON output;
-- no test-framework dependency.
-
-### Phase 2: retries, run evaluation, and policy — delivered by #45
-
-Deliver:
-
-- explicit retry policy and attempt history;
-- run evaluators;
-- deterministic and statistical policy results;
-- structured quality decision;
-- shared concurrency limiter;
-- `EvaluationQualityGate` refactored to reuse structured threshold evaluation.
-
-Required TDD:
-
-- retry selection and exhaustion;
-- cancellation during retry delay;
-- retry delays holding no permits;
-- delayed retries re-entering the scheduler without occupying workers;
-- retries not counted as trials;
-- evaluator failure not rerunning execution;
-- all item statuses reaching run evaluators;
-- run-evaluator failure isolation;
-- deterministic passed/failed decisions;
-- statistical passed/failed/inconclusive decisions;
-- two concurrent runs sharing one limiter.
-
-Runnable example:
-
-- seeded stochastic binary outcomes;
-- repeated trials;
-- estimate, confidence interval, sample count, attempts, and decision;
-- no credentials.
-
-### Phase 3A: per-trial provider lifecycle scopes — #49
-
-Deliver:
-
-- provider-neutral item scopes configured on the experiment definition;
-- one scope entry per statistical trial, not per retry attempt;
-- scope reactivation around every attempt and item evaluation after delayed re-enqueue;
-- typed adapter features available to task and evaluator contexts;
-- namespaced item correlations and structured item publication outcomes;
-- terminal completion notification, caller-cancellation abort, and reverse-order disposal.
-
-Required TDD:
-
-- one scope per trial across multiple attempts;
-- scope reactivation after retry delay and worker changes;
-- nested scope ordering and reverse disposal;
-- the single item evaluator runs inside the same scope;
-- all terminal item statuses reach scope completion;
-- cancellation invokes abort and does not publish a completed item.
-
-### Phase 3B: result sinks and publication outcomes — #50
-
-Delivered by issue #50.
-
-Deliver:
-
-- deterministic result-sink fan-out;
-- required and optional sink semantics;
-- `ExperimentRunOutcome<TCase,TOutput>` containing the canonical result and publication outcomes;
-- aggregate `NotRequested`, `Succeeded`, `PartiallyFailed`, or `Failed` publication status;
-- item-scope and final-sink publication aggregation;
-- an intentional alpha return-type correction for `IExperimentRunner.RunAsync`;
-- schema-versioned outcome serialization.
-
-Required TDD:
-
-- deterministic sink order;
-- required versus optional failure aggregation;
-- one failing sink does not suppress another;
-- publication status never changes the quality decision;
-- caller cancellation skips final sinks;
-- runs without scopes or sinks remain `NotRequested`.
-
-### Phase 4A: Langfuse hosted case source — #51
-
-Deliver:
-
-- paginated read-side dataset and dataset-item APIs;
-- latest and explicit version-timestamp selection;
-- finite hosted-case materialization before execution;
-- caller-defined mapping from hosted item data to `ExperimentCase<TCase>`;
-- dataset identity and version in `ExperimentSourceReference`;
-- coherent disabled behavior that cannot silently produce a passing empty run.
-
-The hosted binding keeps the Langfuse dataset item id as `ExperimentCase<TCase>.Id`. Caller mapping
-owns the case value, trial count, and tags, but cannot replace that provider identity. This lets the
-next-phase item scope link a trial using only the provider-neutral case id while input, expected
-output, metadata, and source trace/observation references remain available in the adapter-owned
-hosted item passed to the mapper.
-
-An explicit selection timestamp is normalized to UTC in `ExperimentSourceReference.Version`. A
-latest selection leaves the version unset because Langfuse's public dataset metadata and item-list
-responses do not expose a resolved latest-version identifier.
-
-Required TDD:
-
-- pagination and stable source ordering;
-- version selection and source identity;
-- input, expected-output, and metadata mapping;
-- cancellation and malformed-response handling before execution;
-- duplicate case-id validation;
-- disabled mode does not silently pass.
-
-### Phase 4B: Langfuse per-trial trace scope — #52
-
-Prerequisites:
-
-- #33 context-safe item execution;
-- #34 dataset-run identity and link status;
-- #35 idempotency and publication health;
-- #49 provider lifecycle scopes.
-
-Deliver:
-
-- one scenario trace per statistical trial;
-- every retry attempt beneath the same trial trace;
-- one hosted dataset-run-item link per trial;
-- trace-only local experiments when no hosted item is bound;
-- namespaced trace, dataset-run-item, and dataset-run correlations;
-- structured link/trace publication outcomes;
-- strict and best-effort prerequisite behavior;
-- one shared internal lifecycle implementation used by both the adapter and
-  `ILangfuseExperimentRun.RunItemAsync`;
-- coherent disabled mode.
-
-The built-in client/session extension creates either a hosted provider bound to an existing
-`ILangfuseExperimentRun` or a local trace-only provider. The hosted provider uses the case id as the
-dataset item id, forwards the run's optional dataset-version timestamp, and leaves the same run
-instance available to the Phase 4C result sink. Task and evaluator contexts receive the active
-`ILangfuseScenario` as an exact-type feature.
-
-Item publications use the `langfuse` namespace with `trace.id`, `dataset.run.item.id`, and
-`dataset.run.id` correlations. Linked and local recorded traces complete their requested local
-lifecycle work; failed or inconsistent links remain publication failures; not-sampled and disabled
-scopes are not attempted. None of these states claims durable OpenTelemetry ingestion.
-
-Required TDD:
-
-- nested and parallel ambient-context restoration;
-- delayed retry reactivation on another worker;
-- no trace-per-attempt behavior;
-- local trace-only mode;
-- linked, failed, inconsistent, not-sampled, and disabled outcomes;
-- strict failure stops execution while best effort preserves it;
-- item evaluation can publish scores before scenario disposal;
-- caller cancellation aborts and restores prior context.
-
-### Phase 4C: Langfuse result sink and canonical guidance — #53
-
-Deliver:
-
-- item metric projection to trace scores;
-- successful run-evaluation metric projection to dataset-run scores;
-- explicit projection of the already-computed run decision without recalculating policy;
-- generic publication status backed by the existing Langfuse publication snapshot;
-- required and optional Langfuse publication behavior;
-- the same experiment definition running locally, with disabled Langfuse, and with hosted Langfuse;
-- the generic runner documented as the canonical bulk-experiment path;
-- `ILangfuseExperimentRun` retained as the low-level/manual escape hatch.
-
-The result sink uses the Langfuse item-scope publication to resolve each trace correlation, then
-projects the existing mutable `EvaluationResult` rather than rebuilding metrics from normalized
-snapshots. Successful run evaluators publish through the bound run's authoritative dataset-run
-identity. Decision publication is explicit and categorical, using the already-reduced
-`ExperimentRunDecision` without invoking policy again.
-
-Provider details remain on `LangfuseExperimentResultSink.GetPublicationSnapshot()`: ordered item and
-run-evaluation score outcomes, optional decision publication, and the hosted run's link/run-score
-snapshot. Generic publication reduction observes only the sink's score work; item-link failures are
-already represented by item-scope publication and are not counted again.
-
-Required TDD:
-
-- item and run score projection;
-- decision projection without duplicate policy computation;
-- unresolved and inconsistent dataset-run identity;
-- one failing sink does not suppress another;
-- disabled mode;
-- publication status remains independent from quality decision;
-- the same definition works with and without credentials.
-
-Runnable example:
-
-- one public experiment definition;
-- local credential-free execution;
-- disabled Langfuse execution with identical quality results;
-- optional hosted source, trace links, and score publication when configured;
-- no standalone telemetry ownership in a DI host.
-
-### Phase 5: MEAI Reporting adapter as the second-provider proof — #54
-
-Delivered in the dedicated `NexusLabs.Needlr.AgentFramework.Evaluation.Reporting` package.
-
-Deliver:
-
-- one `ScenarioRun` per trial;
-- execution/scenario/iteration mapping;
-- explicit case/trial replay, fresh-per-run, and disabled response-reuse modes;
-- coordinated item scope and single item-evaluator integration;
-- MEAI result-store persistence as item publication outcome;
-- report generation left to MEAI tooling;
-- Reporting-specific dependencies isolated from the provider-neutral core.
-
-Required TDD:
-
-- real `ReportingConfiguration` and test store/cache implementations;
-- `CompositeEvaluator` behavior preserved;
-- one evaluation per successful item;
-- no execution retry on evaluator or store failure;
-- cache isolation across trial and run modes;
-- response-cache replay across retries documented and verified;
-- disposal persists completed results;
-- result-store failure appears as item publication failure;
-- cancellation abort does not persist an incomplete `ScenarioRun`;
-- caller cancellation preserved.
-
-Runnable example:
-
-- credential-free deterministic `IChatClient`;
-- cached deterministic replay and fresh stochastic mode;
-- generated MEAI report from the configured store.
-
-## Rejected alternatives
-
-- Use Langfuse item and result types as Needlr's canonical model.
-- Treat a retry as another statistical sample.
-- Drop failed items before run evaluation.
-- Make telemetry or result-store availability redefine model quality.
-- Reimplement MEAI `CompositeEvaluator`, response caches, stores, or reports.
-- Reuse `AgentScenarioRunner` or `PipelineScenarioRunner` as the collection contract.
-- Put xUnit fixtures, theory data, collection attributes, or assembly-global gates in core.
-- Create a process-global semaphore or static coordination registry.
-- Copy Langfuse's concurrency default or its failed-item omission.
-- Create one task for every source item and rely only on a semaphore.
-- Add hidden random retry jitter.
-- Automatically retry non-idempotent sinks.
-- Return a success-shaped partial result after caller cancellation.
-- Ship a universal statistical policy for binary, continuous, paired, and clustered data.
-
-## Deferred concerns
-
-- streaming or unbounded case sources;
-- checkpoint/resume;
-- distributed workers;
-- adaptive sampling and early stopping;
-- cross-run baseline storage;
-- paired and clustered statistical helpers;
-- durable partial artifacts after cancellation;
-- a broad built-in statistical policy catalog.
-
-These concerns may be added after the finite runner and its result contract are exercised by runnable examples.
+- one item-evaluation stage after terminal execution success;
+- run-level evaluators and structured acceptance policies;
+- per-trial lifecycle scopes for provider context;
+- final result-sink fan-out;
+- a canonical result and schema-versioned artifact model.
+
+A bounded worker scheduler keeps pending work as data rather than creating one task per
+item behind a semaphore. Delayed retries hold neither worker capacity nor shared admission
+permits.
+
+A trial is the statistical sample. A retry is another operational attempt for the same
+trial and never increases the sample count. Run evaluators receive the complete ordered
+item set, including failures, unless an explicit policy records an exclusion.
+
+Caller cancellation stops admission, active work, retry delays, evaluation, policy, and
+publication. It aborts entered incomplete scopes and propagates
+`OperationCanceledException`; the runner does not return a partial success-shaped outcome
+or continue into run evaluation, policies, or sinks.
+
+`Microsoft.Extensions.AI.Evaluation.EvaluationResult` is the metric payload for item and
+run evaluation. Needlr owns the surrounding experiment, failure, policy, publication, and
+serialization contracts; it does not replace MEAI evaluator composition.
+
+Provider integrations remain adapters:
+
+- case sources may materialize local or hosted datasets before execution;
+- item scopes may establish one provider lifecycle per trial and reactivate it around
+  attempts and item evaluation;
+- result sinks may publish the completed result;
+- case-source loading and validation fail before execution and propagate to the caller;
+- best-effort scope entry and activation failures are publication failures;
+- execution-prerequisite scope failures prevent the next attempt and produce an explicit
+  prerequisite item failure; and
+- scope completion, disposal, and sink failures after quality is known remain publication
+  failures.
+
+Evaluation decision and publication status are separate. A model-quality result is not
+changed by a failed trace export, dataset link, score upload, or result-store write.
+
+Required policies reduce deterministically: any failed required policy makes the run
+`Failed`; otherwise any inconclusive required policy makes it `Inconclusive`; otherwise
+all required policies passing makes it `Passed`; and a run with no required policies is
+`NotEvaluated`.
+
+The initial built-in statistical policy evaluates a binary success proportion with
+confidence bounds. Execution failure, timeout, and task-originated cancellation count as
+failed samples. Evaluation failure, prerequisite failure, missing evidence, and invalid
+metrics are explicit exclusions that make the result inconclusive unless the caller
+selects pessimistic failure treatment. The policy reports item-status, success, failure,
+sample, attempt, and exclusion counts so excluded or unknown evidence cannot disappear
+from the reported accounting.
+
+Langfuse-specific sources, trial scopes, and score sinks remain in
+`NexusLabs.Needlr.AgentFramework.Langfuse`. MEAI Reporting-specific scenario caching and
+persistence remain in `NexusLabs.Needlr.AgentFramework.Evaluation.Reporting`. Neither
+provider's types become the canonical experiment model.
+
+The runner requires explicit local concurrency and may accept a caller-owned shared
+limiter. It will not create process-global mutable coordination or copy a provider's
+default concurrency.
+
+## Alternatives considered
+
+### Leave orchestration to each consumer
+
+This keeps Needlr's public API small and lets every workload choose its own scheduler.
+It was rejected because consumers would continue to duplicate cancellation, retries,
+failure accounting, result ordering, aggregate policy, and provider publication, producing
+incompatible experiment semantics.
+
+### Build only thin MEAI Reporting extensions
+
+This has low implementation cost and follows Microsoft's public model closely. It was
+rejected as the complete solution because `ReportingConfiguration` and `ScenarioRun` do
+not schedule case collections, distinguish trials from retries, retain all failed items
+for aggregation, or reduce run-level acceptance policy. MEAI Reporting remains an adapter
+for the responsibilities it already owns.
+
+### Build a Langfuse-specific runner
+
+This would provide direct parity with Langfuse datasets and experiment-comparison views.
+It was rejected because it would couple execution semantics to one provider, make local
+and alternate-provider experiments second-class, and create a competing Needlr evaluation
+model. Langfuse remains a hosted source, lifecycle, and publication adapter.
+
+### Reuse `AgentScenarioRunner` or `PipelineScenarioRunner`
+
+Those runners execute one Needlr-specific scenario shape and combine execution with
+verification. They were rejected as the collection contract because experiments must be
+independent of a particular agent loop, pipeline, or test framework.
 
 ## Consequences
 
 ### Positive
 
-- Needlr consumers receive one reusable orchestration model instead of rebuilding schedulers.
-- Deterministic and stochastic evaluations share the same execution semantics.
-- Failures remain visible and statistically honest.
-- MEAI and Langfuse remain replaceable adapters.
-- CI quality and publication health are independently actionable.
-- The design remains independent of test frameworks and agent-loop implementations.
+- Needlr consumers share one bounded and failure-honest experiment model.
+- Deterministic suites and repeated stochastic trials use the same scheduling and result
+  semantics.
+- Retries cannot silently inflate statistical sample counts.
+- Local data, Langfuse, MEAI Reporting, and future providers compose through independent
+  boundaries.
+- Quality policy and publication health remain separately actionable in CI and operations.
+- Failed items remain available to aggregate evaluation instead of disappearing from the
+  denominator.
 
 ### Negative
 
-- Needlr assumes long-term ownership of scheduler and result semantics.
-- The public surface is larger than thin MEAI helpers.
-- Item-scope composition adds async-context and lifecycle complexity.
-- Statistical policy APIs require careful documentation to prevent misuse.
+- Needlr assumes long-term ownership of scheduler, failure, result, and policy contracts.
+- The public surface is larger than a thin wrapper over MEAI Reporting.
+- Per-trial scope composition and cancellation-safe cleanup require careful asynchronous
+  lifecycle testing.
+- Statistical policy APIs can be misused if callers ignore exclusions, sample size, or
+  uncertainty.
+- Provider adapters may expose capability differences that the core cannot normalize
+  without becoming provider-specific.
 
 ### Neutral
 
-- This ADR does not immediately change existing single-scenario evaluators or quality gates.
-- This decision does not add an implementation timeline.
-- Langfuse-specific runner parity is not a goal.
+- Existing single-result evaluators and quality gates remain useful outside experiments.
+- Provider SDKs retain ownership of their storage, scoring, tracing, and report-rendering
+  semantics.
+- Distributed execution and broader statistical methods require separate decisions.
 
-## Outcome
+## Confirmation
 
-Proceed with option A after this ADR is reviewed.
+The repository confirms the decision through these stable boundaries:
 
-Do not proceed with a Langfuse-specific runner. Do not treat thin MEAI Reporting helpers as a complete solution.
+- `ExperimentDefinition<TCase,TOutput>` composes a finite case source, task, one item
+  evaluator, run evaluators, policies, per-trial scopes, and result sinks.
+- `IExperimentRunner` returns a canonical quality result with independent publication
+  outcomes.
+- Experiment-runner tests cover bounded scheduling, retries, cancellation, failure
+  isolation, run evaluation, policy, scope lifecycle, sink fan-out, and deterministic
+  artifacts.
+- `NexusLabs.Needlr.AgentFramework.Langfuse` implements hosted source, trial lifecycle,
+  and result-sink adapters without owning the scheduler.
+- `NexusLabs.Needlr.AgentFramework.Evaluation.Reporting` implements one MEAI
+  `ScenarioRun` per trial without introducing a second scheduler or canonical result.
+- Credential-free examples exercise the core runner and Reporting adapter; the Langfuse
+  conformance example exercises disabled, local, and hosted provider shapes.
+
+Repository tests cannot establish production provider availability, model quality, or the
+statistical validity of a caller's chosen metric and sample design. Those require
+workload-specific evidence.
 
 ## References
 
-- [Needlr issue #36](https://github.com/ncosentino/needlr/issues/36)
-- [Needlr evaluation documentation](../evaluation.md)
-- [MEAI Evaluation libraries](https://learn.microsoft.com/en-us/dotnet/ai/evaluation/libraries)
-- [MEAI evaluation reporting tutorial](https://learn.microsoft.com/en-us/dotnet/ai/evaluation/evaluate-with-reporting)
-- [`ReportingConfiguration` 10.5.0 source](https://github.com/dotnet/extensions/blob/v10.5.0/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/ReportingConfiguration.cs)
-- [`ScenarioRun` 10.5.0 source](https://github.com/dotnet/extensions/blob/v10.5.0/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/ScenarioRun.cs)
-- [`CompositeEvaluator` 10.5.0 source](https://github.com/dotnet/extensions/blob/v10.5.0/src/Libraries/Microsoft.Extensions.AI.Evaluation/CompositeEvaluator.cs)
-- [MEAI Reporting 10.8.0 on NuGet](https://www.nuget.org/packages/Microsoft.Extensions.AI.Evaluation.Reporting/10.8.0)
+- [`docs/experiment-runner.md`](../experiment-runner.md) documents the implemented runner,
+  lifecycle, retry, policy, and adapter semantics selected by this decision.
+- [`docs/evaluation.md`](../evaluation.md) describes the MEAI evaluation primitives reused
+  as the metric language rather than replaced by Needlr.
+- [`docs/langfuse.md`](../langfuse.md) describes the provider-specific source, trace, and
+  score adapters that remain outside the core runner.
+- [MEAI Evaluation libraries](https://learn.microsoft.com/dotnet/ai/evaluation/libraries)
+  define the evaluator, metric, caching, storage, and reporting responsibilities Needlr
+  composes with.
 - [Langfuse experiments via SDK](https://langfuse.com/docs/evaluation/experiments/experiments-via-sdk)
-- [Langfuse experiment data model](https://langfuse.com/docs/evaluation/experiments/data-model)
-- [Langfuse experiments in CI/CD](https://langfuse.com/docs/evaluation/experiments/experiments-ci-cd)
-- [Langfuse Python experiment runner source](https://github.com/langfuse/langfuse-python/blob/a02fc7c2195a81a6f75e084795f86857876b1c90/langfuse/_client/client.py)
-- [Langfuse JavaScript experiment runner source](https://github.com/langfuse/langfuse-js/blob/a7ca64951da54448ff3397f21cf0ca378023be28/packages/client/src/experiment/ExperimentManager.ts)
-- [Adding Error Bars to Evals](https://arxiv.org/abs/2411.00640)
-- [A statistical approach to model evaluations](https://www.anthropic.com/research/statistical-approach-to-model-evals)
-- [AI Agents That Matter](https://arxiv.org/abs/2407.01502)
+  provide the hosted experiment model that motivated adapter support without becoming the
+  Needlr canonical contract.
+- [Needlr issue #36](https://github.com/ncosentino/needlr/issues/36) contains supplemental
+  design-spike and implementation history intentionally excluded from this permanent
+  decision record.


### PR DESCRIPTION
## Summary

Restores Genesis ADR authoring discipline in Needlr and remediates all three accepted ADRs without changing their architectural decisions.

## Guidance sync

- Adds the exact ADR authoring contract from `ncosentino/genesis` at commit `f8026e36614458de2cfdec710dd9958a54c421c0`.
- Adds the ADR trigger guidance to `AGENTS.md`.
- Generates the corresponding Claude path-scoped rule.
- Imports no unrelated Genesis instructions.

The installed `adr-generator` and `adr-drift-detector` skills already match upstream byte-for-byte. Genesis currently has no ADR-specific agent.

## ADR remediation

All three records now use the same durable structure:

- Context and scope
- Decision drivers
- Decision
- Alternatives considered
- Consequences
- Confirmation
- References

### ADR-0001

Preserves the accepted graph-workflow decision while removing implementation phases, status tables, diagnostic inventories, and code-level implementation notes.

It retains the architectural commitments around:

- first-class attribute/source-generator/analyzer graph support;
- deterministic, all-matching, first-matching, exclusive-choice, and explicit LLM routing;
- graph-wide routing with per-source-node overrides;
- explicit join and per-edge failure semantics;
- terminal content versus intermediate progress/diagnostics;
- MAF versus Needlr executor selection.

The confirmation section now records an actual architecture drift: generated topology metadata exists, but runtime topology discovery still scans assemblies through reflection rather than consuming the generated registration.

### ADR-0002

Reframes the ScriptedChatClient build-vs-buy decision without an implementation outline or ephemeral file inventory. It explicitly records that the accepted decision remains unimplemented and lists the evidence required to confirm it.

### ADR-0003

Reduces the provider-neutral experiment-runner ADR from more than 1,100 lines to a permanent decision record. Detailed API specifications, phase plans, issue progress, and test checklists remain in implementation documentation and GitHub history.

It preserves the accepted contracts for:

- finite provider-neutral orchestration;
- trials versus retries;
- bounded data-backed scheduling;
- caller cancellation with no partial success-shaped outcome;
- complete failure accounting;
- source, prerequisite, best-effort scope, and publication failure boundaries;
- deterministic required-policy reduction;
- binary confidence-bound sample and exclusion treatment;
- independent quality and publication status;
- Langfuse and MEAI Reporting adapter package boundaries.

## Verification

- ADR structural contract: **21 checks, 0 errors**
- Local ADR references: **7 checked, 0 missing**
- Genesis contract comparison: exact normalized match
- Generated Claude rule body: exact match to the Copilot instruction
- `python -m mkdocs build --strict`: **passed with 0 warnings and 0 errors**
- Two independent ADR reviews identified substantive decision loss and inaccurate confirmation claims; every blocker was corrected before commit.

No production code or runtime behavior changed.

## Known architecture status

- Graph runtime discovery still uses reflection instead of the generated topology registry; ADR-0001 now records that drift.
- The public `ScriptedChatClient` accepted by ADR-0002 is still planned rather than implemented.
