### PR TITLE
chore: prepare Needlr 0.0.3-alpha.1 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,10 @@ jobs:
   publish:
     # PitCrew default. Set CI_RUNNER=ubuntu-latest for the manual cloud fallback.
     runs-on: ${{ vars.CI_RUNNER || fromJSON('["self-hosted","linux","x64","general-purpose"]') }}
+    environment: release
     permissions:
       contents: write
+      id-token: write
       packages: write
 
     steps:
@@ -36,25 +38,43 @@ jobs:
       run: echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
 
     - name: Install NBGV CLI
-      run: dotnet tool install -g nbgv
+      run: |
+        dotnet tool install \
+          --tool-path "$RUNNER_TEMP/nbgv" \
+          nbgv \
+          --version 3.7.115
+        echo "$RUNNER_TEMP/nbgv" >> "$GITHUB_PATH"
 
-    - name: Validate tag format & prepare version
+    - name: Validate release version
       id: version
       shell: bash
       run: |
-        export NBGV_PublicRelease=true    # force public release behavior
+        if [[ "${GITHUB_REF_TYPE}" != "tag" ]]; then
+          echo "::error::Run the release workflow from a version tag."
+          exit 1
+        fi
 
-        TAG="${GITHUB_REF_NAME}"          # e.g., v0.0.1-alpha.3
-        TAG_CLEAN="${TAG#v}"              # strip leading "v"
+        TAG="${GITHUB_REF_NAME}"
+        if [[ ! "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+          echo "::error::Tag '${TAG}' is not a supported semantic version tag."
+          exit 1
+        fi
 
-        echo "Git tag: ${TAG}"
-        echo "Clean tag: ${TAG_CLEAN}"
+        VERSION="${TAG#v}"
+        NBGV_SEMVER="$(nbgv get-version -v SemVer2)"
+        NUGET_VERSION="$(nbgv get-version -v NuGetPackageVersion)"
+        if [[ "${NBGV_SEMVER}" != "${VERSION}" ]]; then
+          echo "::error::Tag version '${VERSION}' does not match NBGV semantic version '${NBGV_SEMVER}'."
+          exit 1
+        fi
 
-        # We don't hard-fail here if NBGV outputs a height suffix; we trust the tag for publishing
-        NUGETVER="$(nbgv get-version -v NuGetPackageVersion || true)"
-        echo "NBGV NuGetPackageVersion: ${NUGETVER}"
+        if ! grep -Fq "## [${VERSION}]" CHANGELOG.md; then
+          echo "::error::CHANGELOG.md does not contain a '${VERSION}' release section."
+          exit 1
+        fi
 
-        echo "version=${TAG_CLEAN}" >> "$GITHUB_OUTPUT"
+        echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+        echo "package-version=${NUGET_VERSION}" >> "$GITHUB_OUTPUT"
 
     - name: Restore
       run: dotnet restore src/NexusLabs.Needlr.slnx
@@ -137,9 +157,33 @@ jobs:
     - name: List packages
       run: ls -la artifacts/packages
 
+    - name: Validate package versions
+      shell: pwsh
+      run: |
+        $expectedVersion = '${{ steps.version.outputs.package-version }}'
+        $packages = @(
+          Get-ChildItem artifacts/packages -Filter '*.nupkg'
+        )
+        if ($packages.Count -eq 0) {
+          throw 'No NuGet packages were produced.'
+        }
+        foreach ($package in $packages) {
+          if (-not $package.BaseName.EndsWith(
+            ".$expectedVersion",
+            [System.StringComparison]::OrdinalIgnoreCase)) {
+            throw "Package '$($package.Name)' does not use expected version '$expectedVersion'."
+          }
+        }
+
+    - name: Authenticate to NuGet.org
+      id: nuget-login
+      uses: NuGet/login@v1
+      with:
+        user: ncosentino
+
     - name: Push to NuGet.org
       env:
-        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
       run: |
         dotnet nuget push "artifacts/packages/*.nupkg" \
           --api-key "$NUGET_API_KEY" \
@@ -165,8 +209,12 @@ jobs:
         NOTES=$(awk -v ver="$VERSION" '
           /^## \[/ { 
             if (found) exit
-            if (index($0, "[" ver "]")) found=1
+            if (index($0, "[" ver "]")) {
+              found=1
+              next
+            }
           }
+          found && /^\[[^]]+\]: / { exit }
           found { print }
         ' CHANGELOG.md)
         

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+## [0.0.3-alpha.1] - 2026-07-19
+
 ### Changed
 
 - **BREAKING (alpha): AI and agentic packages have moved to [Foundry](https://github.com/ncosentino/foundry).** Foundry now owns Microsoft Agent Framework orchestration, MEAI evaluation and experiments, MEAI Reporting, Langfuse, GitHub Copilot, Semantic Kernel, testing, generators, analyzers, examples, and the optional `NexusLabs.Foundry.Needlr.*` integration packages. Needlr no longer carries AI provider dependencies or releases those capabilities on its version stream.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -16,35 +16,36 @@ git pull
 # 2. Ship analyzers. Move every rule out of
 #    src/**/AnalyzerReleases.Unshipped.md into the matching
 #    AnalyzerReleases.Shipped.md under the EXISTING base-version
-#    release section (e.g. "## Release 0.0.2"). Keep rule IDs in
+#    release section (e.g. "## Release 0.0.3"). Keep rule IDs in
 #    alphanumeric order within the section.
 #
 #    The header uses the base version ONLY — RS2007 rejects
-#    pre-release labels, so "## Release 0.0.2-alpha.26" will not
-#    build. All alpha/beta/rc releases of 0.0.2 share one section.
+#    pre-release labels, so "## Release 0.0.3-alpha.2" will not
+#    build. All alpha/beta/rc releases of 0.0.3 share one section.
 #
-#    Commit as: chore: ship analyzers for 0.0.2-alpha.N
+#    Commit as: chore: ship analyzers for 0.0.3-alpha.N
 #    (scripts/release.ps1 refuses to proceed without this.)
 
 # 3. Add a CHANGELOG.md entry:
-#        ## [0.0.2-alpha.N] - YYYY-MM-DD
+#        ## [0.0.3-alpha.N] - YYYY-MM-DD
 #    with Added / Fixed / Changed sections.
 
 # 4. Dry-run the release script to validate every gate passes.
-./scripts/release.ps1 -Prerelease alpha -Base 0.0.2 -DryRun
+./scripts/release.ps1 -Prerelease alpha -Base 0.0.3 -DryRun
 
 # 5. Run for real. This bumps version.json, commits, tags, and pushes.
-./scripts/release.ps1 -Prerelease alpha -Base 0.0.2
+./scripts/release.ps1 -Prerelease alpha -Base 0.0.3
 ```
 
-Pushing the `v0.0.2-alpha.N` tag to `origin` triggers
+Pushing the `v0.0.3-alpha.N` tag to `origin` triggers
 `.github/workflows/release.yml`, which:
 
 1. Builds the solution with `-p:PublicRelease=true`.
 2. Runs the full test suite with coverage.
 3. Packs every `NexusLabs.Needlr*.csproj` except `*.Tests`, `*.Benchmarks`, `*IntegrationTests`.
-4. Pushes all `.nupkg` + `.snupkg` files to NuGet.org and GitHub Packages.
-5. Creates a GitHub Release (flagged pre-release because the tag contains `-`)
+4. Exchanges the GitHub OIDC identity for a short-lived NuGet.org API key.
+5. Pushes all `.nupkg` + `.snupkg` files to NuGet.org and GitHub Packages.
+6. Creates a GitHub Release (flagged pre-release because the tag contains `-`)
    with release notes extracted from `CHANGELOG.md`.
 
 ## Gates enforced by `scripts/release.ps1`
@@ -68,7 +69,7 @@ If any gate fails, the script throws before touching `version.json` or git.
   reads at compile time. Do not edit by hand; use `nbgv set-version` or
   `release.ps1`.
 - Tag format: lightweight `v<SemVer>` with a dot before the prerelease
-  counter: `v0.0.2-alpha.26`, not `v0.0.2-alpha-0026`.
+  counter: `v0.0.3-alpha.2`, not `v0.0.3-alpha-0002`.
 - The release workflow's public-release regex is in `version.json` under
   `publicReleaseRefSpec`.
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -43,8 +43,9 @@ the release script:
 You also need:
 
 - **Push access to `origin/main`** on `ncosentino/needlr`.
-- **A NuGet.org API key** stored as `NUGET_API_KEY` in the GitHub
-  repository secrets (already set — the workflow reads it).
+- **A NuGet.org trusted publishing policy** for package owner `ncosentino`,
+  repository `ncosentino/needlr`, workflow `release.yml`, and environment
+  `release`.
 - **The GitHub-provided `GITHUB_TOKEN`** (automatic, no setup).
 
 ---
@@ -62,7 +63,7 @@ zero hardcoded versions in individual project files**.
 
 ```json
 {
-  "version": "0.0.2-alpha.25",
+  "version": "0.0.3-alpha.1",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release/v\\d+\\.\\d+",
@@ -82,21 +83,24 @@ Tags are lightweight (not annotated) and follow the pattern:
 v<major>.<minor>.<patch>-<label>.<counter>
 ```
 
-For alpha: `v0.0.2-alpha.25`, `v0.0.2-alpha.26`, ...
+For alpha: `v0.0.3-alpha.1`, `v0.0.3-alpha.2`, ...
 
 **Watch the separator:** it's a **dot** between `alpha` and the
-counter, not a dash. `v0.0.2-alpha-0026` is wrong; `v0.0.2-alpha.26` is
+counter, not a dash. `v0.0.3-alpha-0002` is wrong; `v0.0.3-alpha.2` is
 right. NuGet displays the version with different normalization in its
 UI but the tag and `version.json` use the dotted form.
+
+For example, tag `v0.0.3-alpha.1` publishes NuGet package version
+`0.0.3-alpha-0001`.
 
 ### Finding the next version
 
 ```powershell
-./scripts/release.ps1 -Prerelease alpha -Base 0.0.2 -DryRun
+./scripts/release.ps1 -Prerelease alpha -Base 0.0.3 -DryRun
 ```
 
 The `-Prerelease` flag scans existing tags for the highest
-`v0.0.2-alpha.*` and increments the counter. `-Base` pins the base
+`v0.0.3-alpha.*` and increments the counter. `-Base` pins the base
 version so a stale `version.json` doesn't confuse the calculation. The
 dry run prints what the real run would do.
 
@@ -437,7 +441,7 @@ Review the output, edit for tone, and append to `CHANGELOG.md`.
 ### Dry run first
 
 ```powershell
-./scripts/release.ps1 -Prerelease alpha -Base 0.0.2 -DryRun
+./scripts/release.ps1 -Prerelease alpha -Base 0.0.3 -DryRun
 ```
 
 Dry run:
@@ -454,14 +458,14 @@ analyzers, fix those and re-run.
 ### Real run
 
 ```powershell
-./scripts/release.ps1 -Prerelease alpha -Base 0.0.2
+./scripts/release.ps1 -Prerelease alpha -Base 0.0.3
 ```
 
 The real run, in order:
 
 1. Runs all gates.
 2. Runs `nbgv set-version <new>` to bump `version.json`.
-3. Creates a commit: `chore: bump version to 0.0.2-alpha.26`.
+3. Creates a commit: `chore: bump version to 0.0.3-alpha.2`.
 4. Creates a lightweight tag via `nbgv tag`.
 5. Runs `git push origin HEAD --tags`.
 
@@ -474,12 +478,14 @@ The real run, in order:
 3. Run full test suite with coverage collection.
 4. Pack every `NexusLabs.Needlr*.csproj` except tests, benchmarks,
    integration tests.
-5. `dotnet nuget push` every `.nupkg` to NuGet.org using
-   `${{ secrets.NUGET_API_KEY }}` with `--skip-duplicate`.
-6. `dotnet nuget push` every `.nupkg` to GitHub Packages using
+5. Exchange the GitHub OIDC identity for a short-lived NuGet.org API key
+   through `NuGet/login@v1`.
+6. `dotnet nuget push` every `.nupkg` to NuGet.org with
+   `--skip-duplicate`.
+7. `dotnet nuget push` every `.nupkg` to GitHub Packages using
    `${{ secrets.GITHUB_TOKEN }}` with `--skip-duplicate`.
-7. Extract the matching `## [<version>]` section from `CHANGELOG.md`.
-8. Create a GitHub Release via `softprops/action-gh-release@v2`
+8. Extract the matching `## [<version>]` section from `CHANGELOG.md`.
+9. Create a GitHub Release via `softprops/action-gh-release@v2`
    flagged as pre-release because the tag contains `-`, attaching
    every `.nupkg` and `.snupkg` file.
 
@@ -603,9 +609,10 @@ the bundle packages.
 
 Check the Actions tab for the workflow run. Common causes:
 
-- The `NUGET_API_KEY` secret expired. Renew at
-  [nuget.org/account/apikeys](https://www.nuget.org/account/apikeys)
-  and update the secret in repo settings.
+- The NuGet trusted publishing policy does not match the repository owner,
+  repository, workflow filename, or `release` environment.
+- The publish job is missing `id-token: write`, `environment: release`, or the
+  `NuGet/login@v1` token exchange.
 - A transient NuGet.org outage. Re-run the workflow from the Actions
   tab.
 - A package was already published at that version (`--skip-duplicate`

--- a/scripts/release.ps1
+++ b/scripts/release.ps1
@@ -136,7 +136,7 @@ function Test-UnshippedAnalyzerRules {
     $content = Get-Content -Path $file.FullName
     # A "rule row" is any line starting with "NDLR" — that's the Needlr
     # analyzer prefix used across all diagnostic IDs (NDLRCOR, NDLRGEN,
-    # NDLRMAF, NDLRSIG, NDLRHTTP, etc.). Comment lines begin with ";" and
+    # NDLRLOG, NDLRSIG, NDLRHTTP, etc.). Comment lines begin with ";" and
     # header lines begin with "#" or "-".
     $ruleLines = $content | Where-Object { $_ -match '^NDLR' }
     if ($ruleLines.Count -gt 0) {

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.0.2-alpha.66",
+  "version": "0.0.3-alpha.1",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release/v\\d+\\.\\d+",


### PR DESCRIPTION
## Summary

Prepare Needlr `0.0.3-alpha.1` without tagging or publishing.

## Changes

- bump `version.json` through NBGV to `0.0.3-alpha.1`
- move the Foundry extraction notes into the `0.0.3-alpha.1` changelog section
- configure NuGet trusted publishing through `NuGet/login@v1`
- bind the publish job to the `release` environment with `id-token: write`
- install pinned NBGV 3.7.115 in an isolated runner tool path
- strictly validate tag, NBGV SemVer, NuGet package version, and changelog section
- validate every packed `.nupkg` filename before publication
- harden release-note extraction and update maintainer runbooks for OIDC and the 0.0.3 line
- remove the stale `NDLRMAF` release-script reference

## Validation

- `python -m mkdocs build --strict`
- `release.yml` parses as YAML
- no long-lived `secrets.NUGET_API_KEY` reference remains
- zero unshipped analyzer rule rows
- temporary lightweight-tag validation:
  - `SemVer2`: `0.0.3-alpha.1`
  - `NuGetPackageVersion`: `0.0.3-alpha-0001`
- adversarial release review found no blocking issues

## Release gate

This PR does **not** tag or publish anything. Public publication requires explicit approval after this PR merges and CI is green.