### PR TITLE
fix: gate releases on successful main CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,6 +224,12 @@ jobs:
       if: success() && github.ref == 'refs/heads/main' && github.event_name == 'push'
       run: python scripts/trim-cloudflare-mirror.py gh-pages-mirror --keep 20
 
+    - name: Setup Node.js
+      if: success() && github.ref == 'refs/heads/main' && github.event_name == 'push'
+      uses: actions/setup-node@v4
+      with:
+        node-version: '24'
+
     - name: Deploy Documentation to Cloudflare Pages
       if: success() && github.ref == 'refs/heads/main' && github.event_name == 'push'
       uses: cloudflare/wrangler-action@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,67 @@ env:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
 
 jobs:
+  verify-main-ci:
+    name: Verify main CI
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      actions: read
+      contents: read
+
+    steps:
+    - name: Wait for successful same-commit main CI
+      uses: actions/github-script@v8
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const deadline = Date.now() + (40 * 60 * 1000);
+          let lastRun;
+          while (Date.now() < deadline) {
+            try {
+              const { data } = await github.rest.actions.listWorkflowRuns({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'ci.yml',
+                branch: 'main',
+                event: 'push',
+                per_page: 100
+              });
+              const run = data.workflow_runs
+                .filter(candidate =>
+                  candidate.head_sha === context.sha &&
+                  candidate.head_branch === 'main')
+                .sort((left, right) =>
+                  new Date(right.created_at) - new Date(left.created_at))[0];
+
+              if (run) {
+                lastRun = run;
+                core.info(
+                  `Main CI ${run.id} for ${context.sha} is ${run.status}` +
+                  `${run.conclusion ? ` (${run.conclusion})` : ''}.`);
+                if (run.status === 'completed') {
+                  if (run.conclusion !== 'success') {
+                    core.setFailed(
+                      `Main CI must succeed before release: ${run.html_url}`);
+                  }
+                  return;
+                }
+              } else {
+                core.info(`Waiting for main CI on ${context.sha}.`);
+              }
+            } catch (error) {
+              core.warning(`Could not query main CI: ${error.message}`);
+            }
+
+            await new Promise(resolve => setTimeout(resolve, 15000));
+          }
+
+          core.setFailed(
+            `Timed out waiting for successful main CI on ${context.sha}.` +
+            `${lastRun ? ` Last observed run: ${lastRun.html_url}` : ''}`);
+
   publish:
+    needs: verify-main-ci
     # PitCrew default. Set CI_RUNNER=ubuntu-latest for the manual cloud fallback.
     runs-on: ${{ vars.CI_RUNNER || fromJSON('["self-hosted","linux","x64","general-purpose"]') }}
     environment: release
@@ -305,6 +365,11 @@ jobs:
     # Also removes the checkout's .git so it is not uploaded.
     - name: Trim mirror before Cloudflare deploy
       run: python scripts/trim-cloudflare-mirror.py gh-pages-mirror --keep 20
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '24'
 
     - name: Deploy Documentation to Cloudflare Pages
       uses: cloudflare/wrangler-action@v4

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -33,19 +33,22 @@ git pull
 # 4. Dry-run the release script to validate every gate passes.
 ./scripts/release.ps1 -Prerelease alpha -Base 0.0.3 -DryRun
 
-# 5. Run for real. This bumps version.json, commits, tags, and pushes.
+# 5. Run for real. This bumps version.json, pushes the commit to main,
+#    then tags that exact commit.
 ./scripts/release.ps1 -Prerelease alpha -Base 0.0.3
 ```
 
 Pushing the `v0.0.3-alpha.N` tag to `origin` triggers
 `.github/workflows/release.yml`, which:
 
-1. Builds the solution with `-p:PublicRelease=true`.
-2. Runs the full test suite with coverage.
-3. Packs every `NexusLabs.Needlr*.csproj` except `*.Tests`, `*.Benchmarks`, `*IntegrationTests`.
-4. Exchanges the GitHub OIDC identity for a short-lived NuGet.org API key.
-5. Pushes all `.nupkg` + `.snupkg` files to NuGet.org and GitHub Packages.
-6. Creates a GitHub Release (flagged pre-release because the tag contains `-`)
+1. Waits for the `ci.yml` push run on `main` for the exact tag commit to
+   complete successfully.
+2. Builds the solution with `-p:PublicRelease=true`.
+3. Runs the full test suite with coverage.
+4. Packs every `NexusLabs.Needlr*.csproj` except `*.Tests`, `*.Benchmarks`, `*IntegrationTests`.
+5. Exchanges the GitHub OIDC identity for a short-lived NuGet.org API key.
+6. Pushes all `.nupkg` + `.snupkg` files to NuGet.org and GitHub Packages.
+7. Creates a GitHub Release (flagged pre-release because the tag contains `-`)
    with release notes extracted from `CHANGELOG.md`.
 
 ## Gates enforced by `scripts/release.ps1`

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -466,26 +466,31 @@ The real run, in order:
 1. Runs all gates.
 2. Runs `nbgv set-version <new>` to bump `version.json`.
 3. Creates a commit: `chore: bump version to 0.0.3-alpha.2`.
-4. Creates a lightweight tag via `nbgv tag`.
-5. Runs `git push origin HEAD --tags`.
+4. Rebases and pushes the version commit to `main`, retrying a bounded number
+   of times if the coverage-badge bot wins the push race.
+5. Creates a lightweight tag via `nbgv tag` on the exact commit now present on
+   `main`.
+6. Pushes that tag to trigger the release workflow.
 
 ### When the tag lands on origin
 
 `.github/workflows/release.yml` fires on the tag push. Its steps:
 
-1. Checkout + setup .NET 10.
-2. Restore, build `src/NexusLabs.Needlr.slnx` with `-p:PublicRelease=true`.
-3. Run full test suite with coverage collection.
-4. Pack every `NexusLabs.Needlr*.csproj` except tests, benchmarks,
+1. Wait for the `ci.yml` push run on `main` for the exact tag commit to
+   complete successfully.
+2. Checkout + setup .NET 10.
+3. Restore, build `src/NexusLabs.Needlr.slnx` with `-p:PublicRelease=true`.
+4. Run full test suite with coverage collection.
+5. Pack every `NexusLabs.Needlr*.csproj` except tests, benchmarks,
    integration tests.
-5. Exchange the GitHub OIDC identity for a short-lived NuGet.org API key
+6. Exchange the GitHub OIDC identity for a short-lived NuGet.org API key
    through `NuGet/login@v1`.
-6. `dotnet nuget push` every `.nupkg` to NuGet.org with
+7. `dotnet nuget push` every `.nupkg` to NuGet.org with
    `--skip-duplicate`.
-7. `dotnet nuget push` every `.nupkg` to GitHub Packages using
+8. `dotnet nuget push` every `.nupkg` to GitHub Packages using
    `${{ secrets.GITHUB_TOKEN }}` with `--skip-duplicate`.
-8. Extract the matching `## [<version>]` section from `CHANGELOG.md`.
-9. Create a GitHub Release via `softprops/action-gh-release@v2`
+9. Extract the matching `## [<version>]` section from `CHANGELOG.md`.
+10. Create a GitHub Release via `softprops/action-gh-release@v2`
    flagged as pre-release because the tag contains `-`, attaching
    every `.nupkg` and `.snupkg` file.
 
@@ -609,6 +614,11 @@ the bundle packages.
 
 Check the Actions tab for the workflow run. Common causes:
 
+- The same-commit `ci.yml` push run on `main` is missing, still running, or
+  did not complete successfully.
+- A manually-created tag points to a commit that was never pushed to `main`.
+  `release.ps1` avoids this by landing the version commit before creating the
+  tag.
 - The NuGet trusted publishing policy does not match the repository owner,
   repository, workflow filename, or `release` environment.
 - The publish job is missing `id-token: write`, `environment: release`, or the

--- a/scripts/release.ps1
+++ b/scripts/release.ps1
@@ -79,7 +79,13 @@ if (Test-Path $changelogPath) {
   }
 }
 
-if (-not $DryRun) { Ensure-CleanRepo }
+if (-not $DryRun) {
+  Ensure-CleanRepo
+  $currentBranch = (git branch --show-current).Trim()
+  if ($currentBranch -ne 'main') {
+    throw "Releases must run from the local main branch. Current branch: $currentBranch"
+  }
+}
 
 # CI gate: verify all check runs on HEAD are green before releasing
 if (-not $SkipCiCheck -and -not $DryRun) {
@@ -226,9 +232,9 @@ if ($DryRun) {
   Write-Host "[DRY RUN] Would run:"
   Write-Host "  nbgv set-version $Version"
   Write-Host "  git commit -am 'chore: bump version to $Version'"
-  Write-Host "  nbgv tag"
-  Write-Host "  git push origin --tags"
   Write-Host "  git pull --rebase && git push origin HEAD"
+  Write-Host "  nbgv tag"
+  Write-Host "  git push origin refs/tags/v$Version"
   exit 0
 }
 
@@ -257,31 +263,39 @@ try {
   }
 }
 
+$mainPushed = $false
+for ($attempt = 1; $attempt -le 3; $attempt++) {
+  git pull --rebase
+  if ($LASTEXITCODE -ne 0) {
+    throw "Rebase failed before release. Resolve the working tree; no tag was created."
+  }
+
+  git push origin HEAD
+  if ($LASTEXITCODE -eq 0) {
+    $mainPushed = $true
+    break
+  }
+
+  if ($attempt -lt 3) {
+    Write-Host "Main push raced with another commit; retrying ($attempt/3)." -ForegroundColor Yellow
+    Start-Sleep -Seconds 2
+  }
+}
+
+if (-not $mainPushed) {
+  throw "Version bump commit could not be pushed after 3 attempts. No tag was created."
+}
+Write-Host "Version bump committed to main." -ForegroundColor Green
+
 & nbgv tag
 if ($LASTEXITCODE -ne 0) {
-  throw "nbgv tag failed. The version bump commit exists on HEAD but no tag was created. Inspect tags with 'git tag --list v$Version' and resolve before re-running."
+  throw "nbgv tag failed after the version commit reached main. Inspect tags with 'git tag --list v$Version' before re-running."
 }
 
-# Push tags first so release.yml fires immediately on the new v* tag.
-# Then rebase+push HEAD separately to handle the coverage-badge bot race:
-# CI's "chore: update coverage badge [skip ci]" auto-commit often lands
-# between the CI gate check and this push, causing a non-fast-forward
-# rejection on HEAD. The tag push always succeeds (new ref). Splitting
-# them means the release is never blocked by the race — worst case the
-# version-bump commit needs one rebase attempt.
 git push origin "refs/tags/v$Version"
 if ($LASTEXITCODE -ne 0) {
-  throw "Tag push failed for v$Version. Inspect remote state; the tag exists locally but is not on origin."
+  throw "Tag push failed for v$Version. The version commit is on main but the release was not triggered."
 }
-Write-Host "Tag v$Version pushed — release.yml is firing." -ForegroundColor Green
-
-git pull --rebase 2>&1 | Out-Null
-git push origin HEAD
-if ($LASTEXITCODE -ne 0) {
-  Write-Host "WARNING: Version bump commit push failed (likely coverage-badge race)." -ForegroundColor Yellow
-  Write-Host "The tag and release are fine. Run 'git pull --rebase && git push' manually to land the bump." -ForegroundColor Yellow
-} else {
-  Write-Host "Version bump committed to main." -ForegroundColor Green
-}
+Write-Host "Tag v$Version pushed — release.yml is waiting for same-commit main CI." -ForegroundColor Green
 
 Write-Host "Tagged and pushed v$Version"


### PR DESCRIPTION
## Summary

Prevent future Needlr package publication while the same commit's main CI is pending or failed, and make Wrangler deployment reliable on PitCrew runners.

## Root cause

Needlr `v0.0.3-alpha.1` was tagged while the post-merge main CI run was still in progress. That run later failed only at Cloudflare deployment because the runner lacked `npm`; the independent release workflow completed its own build/test/package checks and published successfully.

## Changes

- add a hosted `verify-main-ci` release job that waits for successful `ci.yml` push CI on `main` for the exact tag SHA
- make package publication depend on that gate
- retry transient GitHub API query failures and report the last observed run
- change `release.ps1` to rebase/push the version commit to `main` before creating and pushing the tag
- retry bounded main-push races before tagging
- require real releases to run from the local `main` branch
- install Node.js 24 before Wrangler in both CI and release workflows
- document the same-SHA release invariant and troubleshooting

## Validation

- both workflow files parse as YAML
- embedded `actions/github-script` JavaScript parses in its async wrapper
- `release.ps1` parses as PowerShell
- `python -m mkdocs build --strict`
- the gate's REST query identifies the actual failed same-SHA CI run for `f9ee369`

This PR does not modify the already-published `0.0.3-alpha.1` release.