### PR TITLE
chore: prepare 0.0.3-alpha.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+## [0.0.3-alpha.2] - 2026-07-22
+
 ### Added
 
 - **`NexusLabs.Needlr.Generators` — `[GenerateConstructor]`: source-generate a public constructor, field assignments, and guard clauses for a partial class from its eligible private `readonly` fields, eliminating hand-written constructor and guard-clause boilerplate given that a source generator still cannot inject statements into a user-authored (including primary) constructor.**

--- a/src/NexusLabs.Needlr.Generators/AnalyzerReleases.Shipped.md
+++ b/src/NexusLabs.Needlr.Generators/AnalyzerReleases.Shipped.md
@@ -1,6 +1,31 @@
 ; Shipped analyzer releases
 ; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
 
+## Release 0.0.3
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+NDLRGEN039 | NexusLabs.Needlr.Generators | Error | GeneratedConstructorAnalyzer, Generated-constructor type must be partial
+NDLRGEN040 | NexusLabs.Needlr.Generators | Error | GeneratedConstructorAnalyzer, Generated-constructor type shape is unsupported (record or nested type)
+NDLRGEN041 | NexusLabs.Needlr.Generators | Error | GeneratedConstructorAnalyzer, Generated-constructor conflicts with an explicit constructor
+NDLRGEN042 | NexusLabs.Needlr.Generators | Error | GeneratedConstructorAnalyzer, Generated-constructor base type requires a parameterless constructor
+NDLRGEN043 | NexusLabs.Needlr.Generators | Error | GeneratedConstructorAnalyzer, No eligible field for generated-constructor generation
+NDLRGEN044 | NexusLabs.Needlr.Generators | Error | GeneratedConstructorAnalyzer, Generated-constructor parameter names collide
+NDLRGEN045 | NexusLabs.Needlr.Generators | Warning | GeneratedConstructorAnalyzer, Constructor guard attribute has no effect
+NDLRGEN046 | NexusLabs.Needlr.Generators | Error | GeneratedConstructorAnalyzer, Constructor guard attribute applied to an ineligible field
+NDLRGEN047 | NexusLabs.Needlr.Generators | Error | GeneratedConstructorAnalyzer, Invalid constructor guard enum value
+NDLRGEN048 | NexusLabs.Needlr.Generators | Error | GeneratedConstructorAnalyzer, Constructor guard incompatible with field type
+NDLRGEN049 | NexusLabs.Needlr.Generators | Error | GeneratedConstructorAnalyzer, Custom constructor guard type is invalid
+NDLRGEN050 | NexusLabs.Needlr.Generators | Error | GeneratedConstructorAnalyzer, Custom constructor guard method name is invalid
+NDLRGEN051 | NexusLabs.Needlr.Generators | Error | GeneratedConstructorAnalyzer, Custom constructor guard method is invalid
+NDLRGEN052 | NexusLabs.Needlr.Generators | Error | GeneratedConstructorAnalyzer, Custom constructor guard method is ambiguous
+NDLRGEN053 | NexusLabs.Needlr.Generators | Error | GeneratedConstructorAnalyzer, [ConstructorGuardDefinition] target is invalid
+NDLRGEN054 | NexusLabs.Needlr.Generators | Error | GeneratedConstructorAnalyzer, [ConstructorGuardDefinition] guard contract is unresolved
+NDLRGEN055 | NexusLabs.Needlr.Generators | Error | GeneratedConstructorAnalyzer, Constructor guard alias usage argument is unsupported
+NDLRGEN056 | NexusLabs.Needlr.Generators | Error | GeneratedConstructorAnalyzer, Custom constructor guard method is incompatible with forwarded alias arguments
+
 ## Release 0.0.2
 
 ### New Rules

--- a/src/NexusLabs.Needlr.Generators/AnalyzerReleases.Unshipped.md
+++ b/src/NexusLabs.Needlr.Generators/AnalyzerReleases.Unshipped.md
@@ -5,21 +5,3 @@
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
-NDLRGEN039 | NexusLabs.Needlr.Generators | Error | GeneratedConstructorAnalyzer, Generated-constructor type must be partial
-NDLRGEN040 | NexusLabs.Needlr.Generators | Error | GeneratedConstructorAnalyzer, Generated-constructor type shape is unsupported (record or nested type)
-NDLRGEN041 | NexusLabs.Needlr.Generators | Error | GeneratedConstructorAnalyzer, Generated-constructor conflicts with an explicit constructor
-NDLRGEN042 | NexusLabs.Needlr.Generators | Error | GeneratedConstructorAnalyzer, Generated-constructor base type requires a parameterless constructor
-NDLRGEN043 | NexusLabs.Needlr.Generators | Error | GeneratedConstructorAnalyzer, No eligible field for generated-constructor generation
-NDLRGEN044 | NexusLabs.Needlr.Generators | Error | GeneratedConstructorAnalyzer, Generated-constructor parameter names collide
-NDLRGEN045 | NexusLabs.Needlr.Generators | Warning | GeneratedConstructorAnalyzer, Constructor guard attribute has no effect
-NDLRGEN046 | NexusLabs.Needlr.Generators | Error | GeneratedConstructorAnalyzer, Constructor guard attribute applied to an ineligible field
-NDLRGEN047 | NexusLabs.Needlr.Generators | Error | GeneratedConstructorAnalyzer, Invalid constructor guard enum value
-NDLRGEN048 | NexusLabs.Needlr.Generators | Error | GeneratedConstructorAnalyzer, Constructor guard incompatible with field type
-NDLRGEN049 | NexusLabs.Needlr.Generators | Error | GeneratedConstructorAnalyzer, Custom constructor guard type is invalid
-NDLRGEN050 | NexusLabs.Needlr.Generators | Error | GeneratedConstructorAnalyzer, Custom constructor guard method name is invalid
-NDLRGEN051 | NexusLabs.Needlr.Generators | Error | GeneratedConstructorAnalyzer, Custom constructor guard method is invalid
-NDLRGEN052 | NexusLabs.Needlr.Generators | Error | GeneratedConstructorAnalyzer, Custom constructor guard method is ambiguous
-NDLRGEN053 | NexusLabs.Needlr.Generators | Error | GeneratedConstructorAnalyzer, [ConstructorGuardDefinition] target is invalid
-NDLRGEN054 | NexusLabs.Needlr.Generators | Error | GeneratedConstructorAnalyzer, [ConstructorGuardDefinition] guard contract is unresolved
-NDLRGEN055 | NexusLabs.Needlr.Generators | Error | GeneratedConstructorAnalyzer, Constructor guard alias usage argument is unsupported
-NDLRGEN056 | NexusLabs.Needlr.Generators | Error | GeneratedConstructorAnalyzer, Custom constructor guard method is incompatible with forwarded alias arguments

--- a/src/NexusLabs.Needlr.SignalR.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/NexusLabs.Needlr.SignalR.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,6 +1,14 @@
 ; Shipped analyzer releases
 ; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
 
+## Release 0.0.3
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+NDLRSIG003 | NexusLabs.Needlr.SignalR | Error | HubRegistrationPluginConstructorAnalyzer, IHubRegistrationPlugin implementation cannot use generated-constructor generation
+
 ## Release 0.0.2
 
 ### New Rules

--- a/src/NexusLabs.Needlr.SignalR.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/NexusLabs.Needlr.SignalR.Analyzers/AnalyzerReleases.Unshipped.md
@@ -5,4 +5,3 @@
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
-NDLRSIG003 | NexusLabs.Needlr.SignalR | Error | HubRegistrationPluginConstructorAnalyzer, IHubRegistrationPlugin implementation cannot use generated-constructor generation


### PR DESCRIPTION
## Summary

- promote the generated-constructor release notes from Unreleased to `0.0.3-alpha.2` dated 2026-07-22
- ship NDLRGEN039-NDLRGEN056 under the analyzer release-tracking `0.0.3` section
- ship NDLRSIG003 under the SignalR analyzer release-tracking `0.0.3` section
- leave `version.json` unchanged so `scripts/release.ps1` remains the sole version-bump/tagging mechanism after merge

## Validation

- `./scripts/release.ps1 -Prerelease alpha -Base 0.0.3 -DryRun` computed `0.0.3-alpha.2`
- changelog section detected
- analyzer release-tracking gate passed with zero unshipped NDLR rules
- solution pack passed
- package validation passed: 13 package checks, 39 example projects, and integration validation
- `git diff --check` passed

## After merge

Run from clean, green `main`:

```powershell
./scripts/release.ps1 -Prerelease alpha -Base 0.0.3
```

The script will set `version.json`, push the version commit to `main`, then create and push `v0.0.3-alpha.2`.