### PR TITLE
Document generated constructor guard exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Added
+
+- Generated constructors now emit coalesced XML `<exception>` documentation for effective built-in guards, including distinct null, empty, and white-space failure contracts. Suppressed defaults, `None`, duplicate guards, and custom guards do not produce unsupported exception claims.
+
 ## [0.0.3-alpha.2] - 2026-07-22
 
 ### Added

--- a/docs/generated-constructors.md
+++ b/docs/generated-constructors.md
@@ -77,9 +77,16 @@ partial class TenantService
     /// <summary>Initializes a new instance of the <see cref="TenantService"/> class.</summary>
     /// <param name="repository">The value used to initialize <c>_repository</c>.</param>
     /// <param name="tenantName">The value used to initialize <c>_tenantName</c>.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="repository"/> or <paramref name="tenantName"/> is null.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="tenantName"/> is empty or consists only of white-space characters.
+    /// </exception>
     public TenantService(IRepository repository, string tenantName)
     {
         global::System.ArgumentNullException.ThrowIfNull(repository);
+        global::System.ArgumentNullException.ThrowIfNull(tenantName);
         global::System.ArgumentException.ThrowIfNullOrWhiteSpace(tenantName);
 
         _repository = repository;
@@ -264,6 +271,8 @@ Requesting `NotNull` on a non-nullable value type (e.g. plain `int`) is rejected
 | `NotNullOrWhiteSpace` | `string` | `ArgumentException.ThrowIfNullOrWhiteSpace(value)` | `ArgumentNullException` when `null`; `ArgumentException` when empty or white space |
 
 Every built-in guard emits the exact same standard .NET guard-clause call a hand-written constructor would use, so the reported exception type and `ParamName` are identical to what you would get by hand -- `ParamName` is always the generated constructor's parameter name.
+
+The generated constructor's XML documentation also describes the exceptions implied by its effective built-in guards. Repeated guards and parameters are coalesced deterministically into one `ArgumentNullException` element and, when applicable, one `ArgumentException` element. `None`, a suppressed class-level default, and custom guards do not produce exception claims.
 
 `NotNullOrEmpty` and `NotNullOrWhiteSpace` are rejected on a non-`string` field by [NDLRGEN048](analyzers/NDLRGEN048.md). A guard kind not defined on `ConstructorGuardKind` (e.g. produced by casting an out-of-range integer) is rejected by [NDLRGEN047](analyzers/NDLRGEN047.md).
 

--- a/src/NexusLabs.Needlr.Generators.Tests/GeneratedConstructorGeneratorTests.cs
+++ b/src/NexusLabs.Needlr.Generators.Tests/GeneratedConstructorGeneratorTests.cs
@@ -109,6 +109,13 @@ public sealed class GeneratedConstructorGeneratorTests
         var generatedCode = RunGenerator(source);
 
         Assert.Contains("global::System.ArgumentNullException.ThrowIfNull(repository);", generatedCode);
+        Assert.Contains(
+            """
+                /// <exception cref="global::System.ArgumentNullException">
+                /// <paramref name="repository"/> is <see langword="null"/>.
+                /// </exception>
+            """,
+            generatedCode);
         Assert.Contains("_repository = repository;", generatedCode);
     }
 
@@ -333,6 +340,115 @@ public sealed class GeneratedConstructorGeneratorTests
         var generatedCode = RunGenerator(source);
 
         Assert.Contains("global::System.ArgumentException.ThrowIfNullOrEmpty(orderId);", generatedCode);
+    }
+
+    [Fact]
+    public void ExplicitBuiltInGuards_EmitCoalescedExceptionDocumentationDeterministically()
+    {
+        var source = """
+            #nullable enable
+            using NexusLabs.Needlr.Generators;
+
+            namespace TestApp
+            {
+                public interface IRepository { }
+
+                [GenerateConstructor(ConstructorNullGuardMode.None)]
+                public partial class TenantService
+                {
+                    [ConstructorGuard(ConstructorGuardKind.NotNull)]
+                    private readonly IRepository _repository;
+
+                    [ConstructorGuard(ConstructorGuardKind.NotNullOrEmpty)]
+                    private readonly string _displayName;
+
+                    [ConstructorGuard(ConstructorGuardKind.NotNullOrWhiteSpace)]
+                    private readonly string _tenantName;
+                }
+            }
+            """;
+
+        var generatedCode = RunGenerator(source);
+
+        Assert.Contains(
+            """
+                /// <exception cref="global::System.ArgumentNullException">
+                /// <paramref name="repository"/>, <paramref name="displayName"/>, or <paramref name="tenantName"/> is <see langword="null"/>.
+                /// </exception>
+                /// <exception cref="global::System.ArgumentException">
+                /// <paramref name="displayName"/> is empty; or <paramref name="tenantName"/> is empty or consists only of white-space characters.
+                /// </exception>
+            """,
+            generatedCode);
+    }
+
+    [Fact]
+    public void NoneSuppressionAndCustomGuards_DoNotEmitExceptionDocumentation()
+    {
+        var source = """
+            #nullable enable
+            using NexusLabs.Needlr.Generators;
+
+            namespace TestApp
+            {
+                public static class CustomGuard
+                {
+                    public static void Validate(string value, string parameterName) { }
+                }
+
+                [GenerateConstructor(ConstructorNullGuardMode.None)]
+                public partial class UnguardedService
+                {
+                    private readonly string _value;
+                }
+
+                [GenerateConstructor(ConstructorNullGuardMode.NonNullableReferences)]
+                public partial class CustomGuardedService
+                {
+                    [ConstructorGuard(ConstructorGuardKind.None)]
+                    [ConstructorGuard(typeof(CustomGuard))]
+                    private readonly string _value;
+                }
+            }
+            """;
+
+        var generatedCode = RunGenerator(source);
+
+        Assert.Contains("global::TestApp.CustomGuard.Validate(value, nameof(value));", generatedCode);
+        Assert.DoesNotContain("<exception", generatedCode);
+    }
+
+    [Fact]
+    public void DuplicateEffectiveBuiltInGuards_EmitSingleExceptionElementPerType()
+    {
+        var source = """
+            #nullable enable
+            using NexusLabs.Needlr.Generators;
+
+            namespace TestApp
+            {
+                [GenerateConstructor(ConstructorNullGuardMode.NonNullableReferences)]
+                public partial class TenantService
+                {
+                    [ConstructorGuard(ConstructorGuardKind.NotNull)]
+                    [ConstructorGuard(ConstructorGuardKind.NotNull)]
+                    [ConstructorGuard(ConstructorGuardKind.NotNullOrWhiteSpace)]
+                    [ConstructorGuard(ConstructorGuardKind.NotNullOrWhiteSpace)]
+                    private readonly string _tenantName;
+                }
+            }
+            """;
+
+        var generatedCode = RunGenerator(source);
+
+        Assert.Equal(1, CountOccurrences(generatedCode, "<exception cref=\"global::System.ArgumentNullException\">"));
+        Assert.Equal(1, CountOccurrences(generatedCode, "<exception cref=\"global::System.ArgumentException\">"));
+        Assert.Equal(1, CountOccurrences(generatedCode, "<paramref name=\"tenantName\"/> is <see langword=\"null\"/>."));
+        Assert.Equal(
+            1,
+            CountOccurrences(
+                generatedCode,
+                "<paramref name=\"tenantName\"/> is empty or consists only of white-space characters."));
     }
 
     [Fact]

--- a/src/NexusLabs.Needlr.Generators/CodeGen/GeneratedConstructorCodeGenerator.cs
+++ b/src/NexusLabs.Needlr.Generators/CodeGen/GeneratedConstructorCodeGenerator.cs
@@ -53,6 +53,10 @@ internal static class GeneratedConstructorCodeGenerator
         builder.AppendLine($"partial class {model.ContainingTypeName}{model.TypeParameterList}");
         builder.AppendLine("{");
 
+        var effectiveGuards = model.Fields
+            .Select(field => ComposeEffectiveGuards(model.NullGuardMode, field))
+            .ToArray();
+
         builder.AppendLine("    /// <summary>");
         builder.AppendLine($"    /// Initializes a new instance of the <see cref=\"{model.ContainingTypeName}{ToCrefTypeParameterList(model.TypeParameterList)}\"/> class.");
         builder.AppendLine("    /// </summary>");
@@ -62,15 +66,24 @@ internal static class GeneratedConstructorCodeGenerator
             builder.AppendLine($"    /// <param name=\"{field.ParameterName}\">The value used to initialize <c>{field.FieldName}</c>.</param>");
         }
 
+        WriteExceptionDocumentation(builder, model.Fields, effectiveGuards);
+
         var parameterList = string.Join(", ", model.Fields.Select(f => $"{f.ParameterTypeName} {f.ParameterName}"));
         builder.AppendLine($"    public {model.ContainingTypeName}({parameterList})");
         builder.AppendLine("    {");
 
         var emittedAnyGuard = false;
-        foreach (var field in model.Fields)
+        for (var i = 0; i < model.Fields.Length; i++)
         {
-            foreach (var guardCall in ComposeGuardCalls(model.NullGuardMode, field))
+            var field = model.Fields[i];
+            foreach (var guard in effectiveGuards[i])
             {
+                var guardCall = BuildGuardCall(
+                    guard.Kind,
+                    field.ParameterName,
+                    guard.CustomGuardTypeName,
+                    guard.CustomGuardMethodName,
+                    guard.ForwardedArgumentLiterals);
                 builder.AppendLine($"        {guardCall}");
                 emittedAnyGuard = true;
             }
@@ -100,17 +113,127 @@ internal static class GeneratedConstructorCodeGenerator
         return typeParameterList.Replace('<', '{').Replace('>', '}');
     }
 
-    private static List<string> ComposeGuardCalls(GeneratedConstructorNullGuardMode mode, EligibleConstructorField field)
+    private static void WriteExceptionDocumentation(
+        StringBuilder builder,
+        EligibleConstructorField[] fields,
+        List<ConstructorFieldGuard>[] effectiveGuards)
+    {
+        var nullParameters = new List<string>();
+        var emptyParameters = new List<string>();
+        var whiteSpaceParameters = new List<string>();
+
+        for (var i = 0; i < fields.Length; i++)
+        {
+            var documentsNullFailure = false;
+            var documentsEmptyFailure = false;
+            var documentsWhiteSpaceFailure = false;
+
+            foreach (var guard in effectiveGuards[i])
+            {
+                switch (guard.Kind)
+                {
+                    case GeneratedConstructorGuardKind.NotNull:
+                        documentsNullFailure = true;
+                        break;
+                    case GeneratedConstructorGuardKind.NotNullOrEmpty:
+                        documentsNullFailure = true;
+                        documentsEmptyFailure = true;
+                        break;
+                    case GeneratedConstructorGuardKind.NotNullOrWhiteSpace:
+                        documentsNullFailure = true;
+                        documentsWhiteSpaceFailure = true;
+                        break;
+                }
+            }
+
+            if (documentsNullFailure)
+            {
+                nullParameters.Add(fields[i].ParameterName);
+            }
+
+            if (documentsWhiteSpaceFailure)
+            {
+                whiteSpaceParameters.Add(fields[i].ParameterName);
+            }
+            else if (documentsEmptyFailure)
+            {
+                emptyParameters.Add(fields[i].ParameterName);
+            }
+        }
+
+        if (nullParameters.Count > 0)
+        {
+            var description = BuildParameterCondition(
+                nullParameters,
+                "is <see langword=\"null\"/>.");
+            WriteExceptionElement(builder, "global::System.ArgumentNullException", description);
+        }
+
+        if (emptyParameters.Count == 0 && whiteSpaceParameters.Count == 0)
+            return;
+
+        var argumentExceptionDescriptions = new List<string>();
+        if (emptyParameters.Count > 0)
+        {
+            argumentExceptionDescriptions.Add(BuildParameterCondition(
+                emptyParameters,
+                "is empty"));
+        }
+
+        if (whiteSpaceParameters.Count > 0)
+        {
+            argumentExceptionDescriptions.Add(BuildParameterCondition(
+                whiteSpaceParameters,
+                "is empty or consists only of white-space characters"));
+        }
+
+        var argumentExceptionDescription = string.Join("; or ", argumentExceptionDescriptions) + ".";
+        WriteExceptionElement(builder, "global::System.ArgumentException", argumentExceptionDescription);
+    }
+
+    private static string BuildParameterCondition(
+        IReadOnlyList<string> parameterNames,
+        string condition)
+    {
+        return $"{FormatParameterReferences(parameterNames)} {condition}";
+    }
+
+    private static string FormatParameterReferences(IReadOnlyList<string> parameterNames)
+    {
+        if (parameterNames.Count == 1)
+            return $"<paramref name=\"{parameterNames[0]}\"/>";
+
+        if (parameterNames.Count == 2)
+        {
+            return $"<paramref name=\"{parameterNames[0]}\"/> or <paramref name=\"{parameterNames[1]}\"/>";
+        }
+
+        var references = parameterNames
+            .Select(parameterName => $"<paramref name=\"{parameterName}\"/>")
+            .ToArray();
+        return string.Join(", ", references.Take(references.Length - 1)) + $", or {references[references.Length - 1]}";
+    }
+
+    private static void WriteExceptionElement(StringBuilder builder, string exceptionTypeName, string description)
+    {
+        builder.AppendLine($"    /// <exception cref=\"{exceptionTypeName}\">");
+        builder.AppendLine($"    /// {description}");
+        builder.AppendLine("    /// </exception>");
+    }
+
+    private static List<ConstructorFieldGuard> ComposeEffectiveGuards(
+        GeneratedConstructorNullGuardMode mode,
+        EligibleConstructorField field)
     {
         var suppressDefault = field.ExplicitGuards.Any(g => g.Kind == GeneratedConstructorGuardKind.None);
         var seen = new HashSet<(GeneratedConstructorGuardKind Kind, string? Type, string? Method, string ForwardedArguments)>();
-        var calls = new List<string>();
+        var guards = new List<ConstructorFieldGuard>();
 
         if (mode == GeneratedConstructorNullGuardMode.NonNullableReferences && field.IsNonNullableReferenceType && !suppressDefault)
         {
             if (seen.Add((GeneratedConstructorGuardKind.NotNull, null, null, string.Empty)))
             {
-                calls.Add(BuildGuardCall(GeneratedConstructorGuardKind.NotNull, field.ParameterName, null, null, Array.Empty<string>()));
+                guards.Add(new ConstructorFieldGuard(GeneratedConstructorGuardKind.NotNull));
             }
         }
 
@@ -123,10 +246,10 @@ internal static class GeneratedConstructorCodeGenerator
             if (!seen.Add(key))
                 continue;
 
-            calls.Add(BuildGuardCall(guard.Kind, field.ParameterName, guard.CustomGuardTypeName, guard.CustomGuardMethodName, guard.ForwardedArgumentLiterals));
+            guards.Add(guard);
         }
 
-        return calls;
+        return guards;
     }
 
     private static string BuildGuardCall(
@@ -169,4 +292,3 @@ internal static class GeneratedConstructorCodeGenerator
         return $"{customGuardTypeName}.{customGuardMethodName}({argumentList}, nameof({parameterName}));";
     }
 }
-


### PR DESCRIPTION
## Summary
- emit coalesced XML exception documentation for effective built-in generated-constructor guards
- distinguish null failures from empty and white-space failures without fabricating contracts for custom guards
- document the behavior in the generated-constructor guide and changelog

## Test plan
- `dotnet test src\NexusLabs.Needlr.Generators.Tests\NexusLabs.Needlr.Generators.Tests.csproj --filter "FullyQualifiedName~GeneratedConstructorGeneratorTests" --no-restore --verbosity quiet` (38 passed, 0 failed, 0 skipped)
- `dotnet build src\Examples\SourceGen\GeneratedConstructorExample\GeneratedConstructorExample.csproj --no-restore --verbosity quiet` (0 warnings, 0 errors)