### PR TITLE
Make release Python setup safe on self-hosted runners

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -163,7 +163,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install MkDocs
-        run: pip install "mkdocs>=1.5,<2.0" mkdocs-material
+        run: python -m pip install -r docs/requirements.txt
 
       - name: Generate Articles Page
         run: python scripts/generate-articles.py docs/articles.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
         python-version: '3.x'
 
     - name: Install MkDocs
-      run: pip install "mkdocs>=1.5,<2.0" mkdocs-material
+      run: python -m pip install -r docs/requirements.txt
 
     - name: Restore dotnet tools
       run: dotnet tool restore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -235,30 +235,6 @@ jobs:
           }
         }
 
-    - name: Authenticate to NuGet.org
-      id: nuget-login
-      uses: NuGet/login@v1
-      with:
-        user: ncosentino
-
-    - name: Push to NuGet.org
-      env:
-        NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
-      run: |
-        dotnet nuget push "artifacts/packages/*.nupkg" \
-          --api-key "$NUGET_API_KEY" \
-          --source https://api.nuget.org/v3/index.json \
-          --skip-duplicate
-
-    - name: Push to GitHub Packages
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        dotnet nuget push "artifacts/packages/*.nupkg" \
-          --api-key "$GITHUB_TOKEN" \
-          --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" \
-          --skip-duplicate
-
     - name: Extract Release Notes from CHANGELOG
       id: release-notes
       shell: bash
@@ -290,10 +266,15 @@ jobs:
           echo "CHANGELOG_EOF"
         } >> "$GITHUB_OUTPUT"
 
+    # Build documentation before publishing packages so Python setup and
+    # documentation-build failures happen before irreversible publication.
     - name: Setup Python for MkDocs
-      run: |
-        python3 -m pip install --upgrade pip
-        pip install "mkdocs>=1.5,<2.0" mkdocs-material
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+
+    - name: Install MkDocs
+      run: python -m pip install -r docs/requirements.txt
 
     - name: Restore dotnet tools
       run: dotnet tool restore
@@ -324,6 +305,35 @@ jobs:
       run: |
         mkdir -p site/coverage
         cp -r coverage/report/* site/coverage/
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '24'
+
+    - name: Authenticate to NuGet.org
+      id: nuget-login
+      uses: NuGet/login@v1
+      with:
+        user: ncosentino
+
+    - name: Push to NuGet.org
+      env:
+        NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
+      run: |
+        dotnet nuget push "artifacts/packages/*.nupkg" \
+          --api-key "$NUGET_API_KEY" \
+          --source https://api.nuget.org/v3/index.json \
+          --skip-duplicate
+
+    - name: Push to GitHub Packages
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        dotnet nuget push "artifacts/packages/*.nupkg" \
+          --api-key "$GITHUB_TOKEN" \
+          --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" \
+          --skip-duplicate
 
     - name: Restrict deploy to release.yml-owned paths
       run: |
@@ -365,11 +375,6 @@ jobs:
     # Also removes the checkout's .git so it is not uploaded.
     - name: Trim mirror before Cloudflare deploy
       run: python scripts/trim-cloudflare-mirror.py gh-pages-mirror --keep 20
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '24'
 
     - name: Deploy Documentation to Cloudflare Pages
       uses: cloudflare/wrangler-action@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Generated constructors now emit coalesced XML `<exception>` documentation for effective built-in guards, including distinct null, empty, and white-space failure contracts. Suppressed defaults, `None`, duplicate guards, and custom guards do not produce unsupported exception claims.
 
+### Fixed
+
+- Release documentation now uses an action-managed Python environment on self-hosted runners, avoiding PEP 668 system-Python failures. Python setup, documentation generation/build, and Node.js setup complete before package publication, while all documentation workflows share `docs/requirements.txt`.
+
 ## [0.0.3-alpha.2] - 2026-07-22
 
 ### Added

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -38,7 +38,7 @@ the release script:
 | PowerShell 7+ (`pwsh`) | Runs `release.ps1` | [aka.ms/pwsh](https://aka.ms/pwsh) |
 | `nbgv` | Bumps `version.json` and tags | `dotnet tool install -g nbgv` |
 | `gh` CLI | CI gate queries GitHub check runs | [cli.github.com](https://cli.github.com) |
-| Python + mkdocs (optional) | Local docs validation | `pip install -r docs/requirements.txt` |
+| Python + mkdocs (optional) | Local docs validation | `python -m pip install -r docs/requirements.txt` |
 
 You also need:
 
@@ -482,17 +482,25 @@ The real run, in order:
 3. Restore, build `src/NexusLabs.Needlr.slnx` with `-p:PublicRelease=true`.
 4. Run full test suite with coverage collection.
 5. Pack every `NexusLabs.Needlr*.csproj` except tests, benchmarks,
-   integration tests.
-6. Exchange the GitHub OIDC identity for a short-lived NuGet.org API key
+   integration tests, then validate every package version.
+6. Extract the release notes, provision an action-managed Python environment,
+   install `docs/requirements.txt`, build the versioned documentation site, and
+   provision Node.js for the Cloudflare deployment.
+7. Exchange the GitHub OIDC identity for a short-lived NuGet.org API key
    through `NuGet/login@v1`.
-7. `dotnet nuget push` every `.nupkg` to NuGet.org with
+8. `dotnet nuget push` every `.nupkg` to NuGet.org with
    `--skip-duplicate`.
-8. `dotnet nuget push` every `.nupkg` to GitHub Packages using
+9. `dotnet nuget push` every `.nupkg` to GitHub Packages using
    `${{ secrets.GITHUB_TOKEN }}` with `--skip-duplicate`.
-9. Extract the matching `## [<version>]` section from `CHANGELOG.md`.
-10. Create a GitHub Release via `softprops/action-gh-release@v2`
+10. Deploy the merged documentation site to GitHub Pages and Cloudflare Pages.
+11. Create a GitHub Release via `softprops/action-gh-release@v2`
    flagged as pre-release because the tag contains `-`, attaching
    every `.nupkg` and `.snupkg` file.
+
+The publish job defaults to the PitCrew self-hosted Linux runner and supports
+`CI_RUNNER=ubuntu-latest` as a manual fallback. `actions/setup-python` provides
+the isolated Python environment on either runner; do not install documentation
+dependencies into the runner's system Python or bypass PEP 668 protections.
 
 Watch the workflow run at
 [Actions](https://github.com/ncosentino/needlr/actions/workflows/release.yml)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+mkdocs>=1.5,<2.0
+mkdocs-material


### PR DESCRIPTION
Closes #73

## Summary
- provision Python through `actions/setup-python@v5` in the release workflow instead of modifying the self-hosted runner's distro-managed Python
- centralize MkDocs dependencies in `docs/requirements.txt` and reuse it from CI, release, and benchmark workflows
- complete Python setup, documentation generation/build, and Node.js setup before publishing packages
- update release guidance and the changelog

## Validation
- parsed all three changed workflow YAML files successfully
- verified release step ordering places Python, documentation build, and Node.js setup before NuGet authentication and package pushes
- verified the release workflow contains neither direct system-Python installation nor `--break-system-packages`
- `python -m mkdocs build --strict` completed with 0 errors; Material for MkDocs emitted its upstream MkDocs 2.0 informational warning

## Known limitation
Package publication and documentation deployment cannot be fully atomic: GitHub Pages, Cloudflare Pages, or GitHub Release creation can still fail after packages publish. Existing `--skip-duplicate` package pushes keep recovery reruns safe.