### PR TITLE
Initialize referenced source-gen modules deterministically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 
 - Release documentation now uses an action-managed Python environment on self-hosted runners, avoiding PEP 668 system-Python failures. Python setup, documentation generation/build, and Node.js setup complete before package publication, while all documentation workflows share `docs/requirements.txt`.
+- Source-generated bootstraps now explicitly run referenced TypeRegistry module constructors instead of relying on `typeof(...).Assembly`, which does not guarantee module initialization. This makes transitive registry loading deterministic and removes test-order dependence from Carter, SignalR, and cross-generator bootstrap coverage.
 
 ## [0.0.3-alpha.2] - 2026-07-22
 

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -962,30 +962,31 @@ The generator emits error `NDLRGEN002` if it detects internal plugin types in a 
 
 ### Automatic Assembly Loading
 
-When using source generation, Needlr automatically discovers all referenced assemblies that have `[GenerateTypeRegistry]` and ensures they are loaded at startup. This is critical because:
+When using source generation, Needlr automatically discovers all referenced assemblies that have `[GenerateTypeRegistry]` and ensures their module initializers complete at startup. This is critical because:
 
 
-- **Module initializers only run when an assembly is loaded** - If your code never directly references a type from an assembly, that assembly never loads
+- **Assembly metadata access is insufficient** - Obtaining a `Type` or `Assembly` does not guarantee the module initializer has completed
 - **Transitive dependencies** - Plugin assemblies referenced by your project but never directly used in code would be invisible to the type registry
 
-Needlr solves this by generating a `ForceLoadReferencedAssemblies()` method that uses `typeof()` to force assembly loading:
+Needlr solves this by generating a `ForceLoadReferencedAssemblies()` method that explicitly runs each referenced registry module's constructor:
 
 ```csharp
 // Generated in NeedlrSourceGenBootstrap.g.cs
-[MethodImpl(MethodImplOptions.NoInlining)]
 private static void ForceLoadReferencedAssemblies()
 {
-    _ = typeof(global::MyApp.Features.Logging.Generated.TypeRegistry).Assembly;
-    _ = typeof(global::MyApp.Features.Scheduling.Generated.TypeRegistry).Assembly;
+    RuntimeHelpers.RunModuleConstructor(
+        typeof(global::MyApp.Features.Logging.Generated.TypeRegistry).Module.ModuleHandle);
+    RuntimeHelpers.RunModuleConstructor(
+        typeof(global::MyApp.Features.Scheduling.Generated.TypeRegistry).Module.ModuleHandle);
     // ... all discovered assemblies with [GenerateTypeRegistry]
 }
 ```
 
-This is fully AOT-compatible - `typeof()` is resolved at compile time.
+`RunModuleConstructor` is idempotent, so dependencies that were already initialized are unaffected. The module handles are derived from statically known `typeof()` references, keeping this path AOT-compatible without runtime assembly scanning or name-based loading.
 
-### Controlling Assembly Load Order with [NeedlrAssemblyOrder]
+### Controlling Module Initialization Order with [NeedlrAssemblyOrder]
 
-By default, referenced assemblies are loaded in alphabetical order. If you need specific assemblies to load before or after others (e.g., when plugins have dependencies on other plugins being registered first), use the `[NeedlrAssemblyOrder]` attribute:
+By default, referenced module constructors run in assembly-name order. If you need specific registries initialized before or after others (e.g., when plugins have dependencies on other plugins being registered first), use the `[NeedlrAssemblyOrder]` attribute:
 
 ```csharp
 using NexusLabs.Needlr.Generators;
@@ -998,16 +999,16 @@ using NexusLabs.Needlr.Generators;
 ```
 
 **How ordering works:**
-1. Assemblies in `First` are loaded first, in the order specified
-2. All other discovered assemblies are loaded alphabetically
-3. Assemblies in `Last` are loaded last, in the order specified
+1. Module constructors for assemblies in `First` run first, in the order specified
+2. All other discovered module constructors run in assembly-name order
+3. Module constructors for assemblies in `Last` run last, in the order specified
 
 **Example scenario:** Your `AuthenticationPlugin` needs `ILogger` which is registered by `LoggingPlugin`:
 
 ```csharp
 [assembly: GenerateTypeRegistry]
 [assembly: NeedlrAssemblyOrder(
-    First = new[] { "MyApp.Features.Logging" })]  // Logging loads first
+    First = new[] { "MyApp.Features.Logging" })]  // Logging initializes first
 
 namespace MyApp.Bootstrap;
 

--- a/src/Examples/MultiProjectApp/MultiProjectApp.Integration.Tests/CrossGeneratorPluginDiscoveryTests.cs
+++ b/src/Examples/MultiProjectApp/MultiProjectApp.Integration.Tests/CrossGeneratorPluginDiscoveryTests.cs
@@ -1,3 +1,6 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
 using MultiProjectApp.Features.CrossGenSimulation;
 using MultiProjectApp.Features.Notifications;
 using NexusLabs.Needlr.Generators;
@@ -27,37 +30,34 @@ public sealed class CrossGeneratorPluginDiscoveryTests
     [Fact]
     public void RegisterPlugins_ModuleInitializer_ContributesTypeAbsentFromTypeRegistry()
     {
-        // SimulatedGeneratorPlugin is ONLY in the registry because RegisterPlugins() ran.
-        // TypeRegistryGenerator produced no Register() for this assembly.
+        var crossGenAssembly = InitializeCrossGeneratorModule();
         var found = NeedlrSourceGenBootstrap.TryGetProviders(
             out _,
             out var pluginProvider);
 
-        Assert.True(found);
+        Assert.True(found, "Expected the simulated generator module initializer to register its plugin provider");
 
         var factory = new GeneratedPluginFactory(pluginProvider!);
-        var assembly = typeof(SimulatedGeneratorPlugin).Assembly;
-
         var plugins = factory.CreatePluginsFromAssemblies<ICrossGeneratedPlugin>(
-            [assembly]).ToList();
+            [crossGenAssembly]).ToList();
 
+        Assert.Single(plugins);
         Assert.Contains(plugins, p => p is SimulatedGeneratorPlugin);
     }
 
     [Fact]
     public void RegisterPlugins_ExactlyOneInstance_NoSpuriousDuplicates()
     {
+        var crossGenAssembly = InitializeCrossGeneratorModule();
         var found = NeedlrSourceGenBootstrap.TryGetProviders(
             out _,
             out var pluginProvider);
 
-        Assert.True(found);
+        Assert.True(found, "Expected the simulated generator module initializer to register its plugin provider");
 
         var factory = new GeneratedPluginFactory(pluginProvider!);
-        var assembly = typeof(SimulatedGeneratorPlugin).Assembly;
-
         var plugins = factory.CreatePluginsFromAssemblies<ICrossGeneratedPlugin>(
-            [assembly]).OfType<SimulatedGeneratorPlugin>().ToList();
+            [crossGenAssembly]).OfType<SimulatedGeneratorPlugin>().ToList();
 
         Assert.Single(plugins);
     }
@@ -65,11 +65,12 @@ public sealed class CrossGeneratorPluginDiscoveryTests
     [Fact]
     public void RegisterPlugins_AssemblyFilter_TypeNotVisibleFromOtherAssemblies()
     {
+        _ = InitializeCrossGeneratorModule();
         var found = NeedlrSourceGenBootstrap.TryGetProviders(
             out _,
             out var pluginProvider);
 
-        Assert.True(found);
+        Assert.True(found, "Expected the simulated generator module initializer to register its plugin provider");
 
         var factory = new GeneratedPluginFactory(pluginProvider!);
 
@@ -83,14 +84,12 @@ public sealed class CrossGeneratorPluginDiscoveryTests
     [Fact]
     public void RegisterPlugins_DeduplicatesWithTypeRegistryGenerator_ForHandWrittenNotificationSink()
     {
-        // AuditLogNotificationSink is hand-written, so BOTH TypeRegistryGenerator (via Register())
-        // AND our CrossGeneratedPlugins module initializer (via RegisterPlugins()) contribute it.
-        // Combine() must deduplicate to exactly one instance.
+        _ = InitializeCrossGeneratorModule();
         var found = NeedlrSourceGenBootstrap.TryGetProviders(
             out _,
             out var pluginProvider);
 
-        Assert.True(found);
+        Assert.True(found, "Expected the simulated generator module initializer to register its plugin provider");
 
         var factory = new GeneratedPluginFactory(pluginProvider!);
         var notificationsAssembly = typeof(AuditLogNotificationSink).Assembly;
@@ -100,5 +99,11 @@ public sealed class CrossGeneratorPluginDiscoveryTests
 
         Assert.Single(sinks);
     }
-}
 
+    private static Assembly InitializeCrossGeneratorModule()
+    {
+        var module = typeof(SimulatedGeneratorPlugin).Module;
+        RuntimeHelpers.RunModuleConstructor(module.ModuleHandle);
+        return module.Assembly;
+    }
+}

--- a/src/Examples/MultiProjectApp/MultiProjectApp.WorkerApp.Tests/WorkerAppIntegrationTests.cs
+++ b/src/Examples/MultiProjectApp/MultiProjectApp.WorkerApp.Tests/WorkerAppIntegrationTests.cs
@@ -1,5 +1,5 @@
-using Microsoft.Extensions.DependencyInjection;
-using MultiProjectApp.Features.Notifications;
+using System.Reflection;
+
 using NexusLabs.Needlr.Injection;
 using NexusLabs.Needlr.Injection.SourceGen;
 using Xunit;
@@ -13,8 +13,8 @@ namespace MultiProjectApp.WorkerApp.Tests;
 /// <para>
 /// Unlike <c>MultiProjectApp.ConsoleApp.Tests</c>, this project does NOT reference any
 /// <c>MultiProjectApp.WorkerApp</c> or <c>MultiProjectApp.Features.Notifications</c> types
-/// directly in test code (the <c>using</c> directives above are only for type-checking the
-/// resolved service — the service is obtained purely through the DI container).
+/// directly before building the service provider. The test resolves the notification service
+/// by assembly and type name only after source-generated registration has completed.
 /// </para>
 /// <para>
 /// Because <c>NexusLabs.Needlr.Build</c> activates the source generator on this project,
@@ -29,19 +29,19 @@ public sealed class WorkerAppIntegrationTests
     [Fact]
     public void NotificationService_IsRegistered_EvenThoughNoTestCodeReferencesItDirectly()
     {
-        // Build the service provider using only source-gen discovery.
-        // The generated NeedlrSourceGenModuleInitializer.ForceLoadReferencedAssemblies() has
-        // already run (module initializer), ensuring WorkerApp and its Notifications dependency
-        // are loaded. No test code here references INotificationService or NotificationWorker
-        // directly — we only resolve via DI.
         var provider = new Syringe()
             .UsingSourceGen()
             .BuildServiceProvider();
 
-        // If the generator were not running on this project (e.g., NexusLabs.Needlr.Build
-        // not applied), this would throw because the TypeRegistry for Notifications would
-        // never have been registered.
-        var service = provider.GetRequiredService<INotificationService>();
+        var notificationsAssembly = Assembly.Load("MultiProjectApp.Features.Notifications");
+        var serviceType = notificationsAssembly.GetType(
+            "MultiProjectApp.Features.Notifications.INotificationService");
+        Assert.NotNull(serviceType);
+
+        var service = provider.GetService(serviceType);
         Assert.NotNull(service);
+        Assert.Equal(
+            "MultiProjectApp.Features.Notifications.InMemoryNotificationService",
+            service.GetType().FullName);
     }
 }

--- a/src/Examples/SourceGen/TransitiveDependencyDemo/README.md
+++ b/src/Examples/SourceGen/TransitiveDependencyDemo/README.md
@@ -22,8 +22,8 @@ When using source generation with multi-project solutions, you may encounter a s
 Needlr's source generator automatically:
 
 1. **Discovers** all referenced assemblies with `[GenerateTypeRegistry]`
-2. **Generates** `typeof()` calls to force those assemblies to load
-3. **Loads** assemblies in alphabetical order by default
+2. **Runs** each referenced registry module's constructor explicitly
+3. **Initializes** registry modules in assembly-name order by default
 
 ## Controlling Assembly Order
 
@@ -87,19 +87,20 @@ After building, check `TransitiveDemo.Host/obj/Generated/` for the generated boo
 
 ```csharp
 // In NeedlrSourceGenBootstrap.g.cs
-[MethodImpl(MethodImplOptions.NoInlining)]
 private static void ForceLoadReferencedAssemblies()
 {
-    _ = typeof(global::TransitiveDemo.FeatureA.Generated.TypeRegistry).Assembly;
-    _ = typeof(global::TransitiveDemo.FeatureB.Generated.TypeRegistry).Assembly;
+    RuntimeHelpers.RunModuleConstructor(
+        typeof(global::TransitiveDemo.FeatureA.Generated.TypeRegistry).Module.ModuleHandle);
+    RuntimeHelpers.RunModuleConstructor(
+        typeof(global::TransitiveDemo.FeatureB.Generated.TypeRegistry).Module.ModuleHandle);
 }
 ```
 
-This ensures both assemblies load before any plugins are executed.
+This guarantees both module initializers complete before any plugins are executed.
 
 ## AOT Compatibility
 
 This feature is fully AOT-compatible because:
-- `typeof()` is resolved at compile time
-- No reflection is used
-- The assembly references are statically known
+- The registry types and module handles are statically known
+- No assembly scanning or name-based loading is used
+- Re-running an already initialized module constructor is safe

--- a/src/NexusLabs.Needlr.Carter.Tests/SourceGenIntegrationTests.cs
+++ b/src/NexusLabs.Needlr.Carter.Tests/SourceGenIntegrationTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 using NexusLabs.Needlr.AspNet;
 using NexusLabs.Needlr.Generators;
@@ -55,20 +56,22 @@ public sealed class SourceGenIntegrationTests
     [Fact]
     public void Carter_ModuleInitializerRegistersPlugins()
     {
-        if (!NeedlrSourceGenBootstrap.TryGetProviders(out _, out var pluginProvider))
-        {
-            Assert.Fail("NeedlrSourceGenBootstrap has no registered providers");
-            return;
-        }
+        var carterPluginType = typeof(CarterWebApplicationBuilderPlugin);
+        var carterAssembly = carterPluginType.Assembly;
+        RuntimeHelpers.RunModuleConstructor(carterPluginType.Module.ModuleHandle);
+
+        var found = NeedlrSourceGenBootstrap.TryGetProviders(out _, out var pluginProvider);
+        Assert.True(found, "Expected the Carter module initializer to register Needlr providers");
 
         var allPluginTypes = pluginProvider().ToList();
         var carterPluginTypes = allPluginTypes
-            .Where(p => p.PluginType.Assembly == typeof(CarterWebApplicationBuilderPlugin).Assembly)
+            .Where(p => p.PluginType.Assembly == carterAssembly)
             .Select(p => p.PluginType.Name)
             .ToList();
 
-        Assert.Contains(carterPluginTypes, n => n == "CarterWebApplicationBuilderPlugin");
-        Assert.Contains(carterPluginTypes, n => n == "CarterWebApplicationPlugin");
+        Assert.Equal(2, carterPluginTypes.Count);
+        Assert.Contains("CarterWebApplicationBuilderPlugin", carterPluginTypes);
+        Assert.Contains("CarterWebApplicationPlugin", carterPluginTypes);
     }
 
     [Fact]

--- a/src/NexusLabs.Needlr.Generators.Tests/BootstrapCodeGeneratorRuntimeTests.cs
+++ b/src/NexusLabs.Needlr.Generators.Tests/BootstrapCodeGeneratorRuntimeTests.cs
@@ -1,0 +1,201 @@
+using System.Reflection;
+using System.Runtime.Loader;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+using NexusLabs.Needlr.Generators.CodeGen;
+
+using Xunit;
+
+namespace NexusLabs.Needlr.Generators.Tests;
+
+/// <summary>
+/// Runtime tests for generated source-bootstrap behavior across assembly boundaries.
+/// </summary>
+public sealed class BootstrapCodeGeneratorRuntimeTests
+{
+    [Fact]
+    public void ReferencedModuleConstructor_RunsBeforeHostRegistration()
+    {
+        var probeKey = $"Needlr.BootstrapProbe.{Guid.NewGuid():N}";
+        var hostRegistrationKey = $"Needlr.HostRegistrationProbe.{Guid.NewGuid():N}";
+        var referencedSource = $$"""
+            #nullable enable
+            using System;
+            using System.Runtime.CompilerServices;
+
+            namespace ReferencedLib
+            {
+                internal static class ReferencedModuleInitializer
+                {
+                    [ModuleInitializer]
+                    internal static void Initialize()
+                    {
+                        AppContext.SetData("{{probeKey}}", true);
+                    }
+                }
+            }
+
+            namespace ReferencedLib.Generated
+            {
+                public static class TypeRegistry
+                {
+                }
+            }
+            """;
+
+        var referencedAssembly = CompileAssembly(
+            "ReferencedLib",
+            [referencedSource],
+            []);
+        var referencedMetadata = MetadataReference.CreateFromImage(referencedAssembly);
+
+        var bootstrapSource = BootstrapCodeGenerator.GenerateModuleInitializerBootstrapSource(
+            "HostApp",
+            ["ReferencedLib"],
+            new BreadcrumbWriter(BreadcrumbLevel.None),
+            hasFactories: false,
+            hasOptions: false,
+            hasProviders: false);
+        var hostSupportSource = $$"""
+            #nullable enable
+            using System;
+            using System.Collections.Generic;
+
+            namespace Microsoft.Extensions.Configuration
+            {
+                public interface IConfiguration
+                {
+                }
+            }
+
+            namespace Microsoft.Extensions.DependencyInjection
+            {
+                public interface IServiceCollection
+                {
+                }
+            }
+
+            namespace NexusLabs.Needlr.Generators
+            {
+                public sealed class InjectableTypeInfo
+                {
+                }
+
+                public sealed class PluginTypeInfo
+                {
+                }
+
+                public static class NeedlrSourceGenBootstrap
+                {
+                    public static void Register(
+                        Func<IReadOnlyList<InjectableTypeInfo>> injectableTypeProvider,
+                        Func<IReadOnlyList<PluginTypeInfo>> pluginTypeProvider,
+                        Action<object> decoratorApplier,
+                        Action<object, object>? optionsRegistrar)
+                    {
+                        AppContext.SetData(
+                            "{{hostRegistrationKey}}",
+                            AppContext.GetData("{{probeKey}}"));
+                    }
+                }
+            }
+
+            namespace HostApp.Generated
+            {
+                using Microsoft.Extensions.DependencyInjection;
+                using NexusLabs.Needlr.Generators;
+
+                internal static class TypeRegistry
+                {
+                    internal static IReadOnlyList<InjectableTypeInfo> GetInjectableTypes() =>
+                        Array.Empty<InjectableTypeInfo>();
+
+                    internal static IReadOnlyList<PluginTypeInfo> GetPluginTypes() =>
+                        Array.Empty<PluginTypeInfo>();
+
+                    internal static void ApplyDecorators(IServiceCollection services)
+                    {
+                    }
+                }
+            }
+
+            namespace HostApp
+            {
+                public static class EntryPoint
+                {
+                    public static void Touch()
+                    {
+                    }
+                }
+            }
+            """;
+        var hostAssembly = CompileAssembly(
+            "HostApp",
+            [bootstrapSource, hostSupportSource],
+            [referencedMetadata]);
+
+        var loadContext = new AssemblyLoadContext(
+            $"Needlr.BootstrapRuntimeTest.{Guid.NewGuid():N}",
+            isCollectible: true);
+        loadContext.Resolving += (_, assemblyName) =>
+        {
+            if (!string.Equals(assemblyName.Name, "ReferencedLib", StringComparison.Ordinal))
+                return null;
+
+            using var referencedAssemblyStream = new MemoryStream(referencedAssembly);
+            return loadContext.LoadFromStream(referencedAssemblyStream);
+        };
+
+        try
+        {
+            using var hostAssemblyStream = new MemoryStream(hostAssembly);
+            var loadedHostAssembly = loadContext.LoadFromStream(hostAssemblyStream);
+            var entryPointType = loadedHostAssembly.GetType("HostApp.EntryPoint");
+            Assert.NotNull(entryPointType);
+
+            var touchMethod = entryPointType.GetMethod(
+                "Touch",
+                BindingFlags.Public | BindingFlags.Static);
+            Assert.NotNull(touchMethod);
+
+            _ = touchMethod.Invoke(null, null);
+
+            Assert.Equal(true, AppContext.GetData(probeKey));
+            Assert.Equal(true, AppContext.GetData(hostRegistrationKey));
+        }
+        finally
+        {
+            AppContext.SetData(probeKey, null);
+            AppContext.SetData(hostRegistrationKey, null);
+            loadContext.Unload();
+        }
+    }
+
+    private static byte[] CompileAssembly(
+        string assemblyName,
+        IReadOnlyList<string> sources,
+        IReadOnlyList<MetadataReference> additionalReferences)
+    {
+        var syntaxTrees = sources
+            .Select(source => CSharpSyntaxTree.ParseText(source))
+            .ToArray();
+        var references = Basic.Reference.Assemblies.Net100.References.All
+            .Concat(additionalReferences)
+            .ToArray();
+        var compilation = CSharpCompilation.Create(
+            assemblyName,
+            syntaxTrees,
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using var assemblyStream = new MemoryStream();
+        var emitResult = compilation.Emit(assemblyStream);
+        Assert.True(
+            emitResult.Success,
+            $"Expected {assemblyName} to compile: {string.Join("; ", emitResult.Diagnostics)}");
+
+        return assemblyStream.ToArray();
+    }
+}

--- a/src/NexusLabs.Needlr.Generators.Tests/TypeRegistryGeneratorTests.cs
+++ b/src/NexusLabs.Needlr.Generators.Tests/TypeRegistryGeneratorTests.cs
@@ -871,8 +871,15 @@ namespace MainApp
 
         // Should generate ForceLoadReferencedAssemblies method
         Assert.Contains("ForceLoadReferencedAssemblies", mainGeneratedCode);
-        Assert.Contains("MethodImpl(MethodImplOptions.NoInlining)", mainGeneratedCode);
-        Assert.Contains("typeof(global::ReferencedLib.Generated.TypeRegistry).Assembly", mainGeneratedCode);
+        Assert.Contains(
+            "global::System.Runtime.CompilerServices.RuntimeHelpers.RunModuleConstructor(",
+            mainGeneratedCode);
+        Assert.Contains(
+            "typeof(global::ReferencedLib.Generated.TypeRegistry).Module.ModuleHandle);",
+            mainGeneratedCode);
+        Assert.DoesNotContain(
+            "typeof(global::ReferencedLib.Generated.TypeRegistry).Assembly",
+            mainGeneratedCode);
     }
 
     [Fact]
@@ -894,35 +901,6 @@ namespace TestApp
 
         // Should NOT generate ForceLoadReferencedAssemblies method when no referenced assemblies have [GenerateTypeRegistry]
         Assert.DoesNotContain("ForceLoadReferencedAssemblies", generatedCode);
-    }
-
-    [Fact]
-    public void Generator_ForceLoadIncludesRuntimeCompilerServicesUsing()
-    {
-        var referencedAssemblySource = @"
-using NexusLabs.Needlr.Generators;
-
-[assembly: GenerateTypeRegistry(IncludeNamespacePrefixes = new[] { ""ReferencedLib"" })]
-
-namespace ReferencedLib
-{
-    public class ReferencedService { }
-}";
-
-        var mainAssemblySource = @"
-using NexusLabs.Needlr.Generators;
-
-[assembly: GenerateTypeRegistry(IncludeNamespacePrefixes = new[] { ""MainApp"" })]
-
-namespace MainApp
-{
-    public class MainService { }
-}";
-
-        var (_, mainGeneratedCode) = RunGeneratorWithReferencedAssembly(referencedAssemblySource, mainAssemblySource);
-
-        // Should include the using for MethodImpl attribute
-        Assert.Contains("using System.Runtime.CompilerServices;", mainGeneratedCode);
     }
 
     private (string referencedGeneratedCode, string mainGeneratedCode) RunGeneratorWithReferencedAssembly(
@@ -1222,7 +1200,9 @@ namespace NotAParticipant
                 .Select(d => d.GetMessage())));
 
         // The aggregator force-loads the participant's registry, and that reference now resolves.
-        Assert.Contains("typeof(global::DomainOnly.Generated.TypeRegistry).Assembly", aggregatorGenerated);
+        Assert.Contains(
+            "typeof(global::DomainOnly.Generated.TypeRegistry).Module.ModuleHandle);",
+            aggregatorGenerated);
         Assert.DoesNotContain(aggregatorEmit.Diagnostics, d => d.Id == "CS0234");
         Assert.True(aggregatorEmit.Success,
             "Aggregator failed to compile: " +

--- a/src/NexusLabs.Needlr.Generators/CodeGen/BootstrapCodeGenerator.cs
+++ b/src/NexusLabs.Needlr.Generators/CodeGen/BootstrapCodeGenerator.cs
@@ -13,7 +13,7 @@ internal static class BootstrapCodeGenerator
 {
     /// <summary>
     /// Emits the module-initializer bootstrap source that registers TypeRegistry
-    /// callbacks and force-loads referenced assemblies.
+    /// callbacks and runs referenced TypeRegistry module constructors.
     /// </summary>
     internal static string GenerateModuleInitializerBootstrapSource(string assemblyName, IReadOnlyList<string> referencedAssemblies, BreadcrumbWriter breadcrumbs, bool hasFactories, bool hasOptions, bool hasProviders)
     {
@@ -22,8 +22,6 @@ internal static class BootstrapCodeGenerator
 
         breadcrumbs.WriteFileHeader(builder, assemblyName, "Needlr Source-Gen Bootstrap");
         builder.AppendLine("#nullable enable");
-        builder.AppendLine();
-        builder.AppendLine("using System.Runtime.CompilerServices;");
         builder.AppendLine();
         builder.AppendLine("using Microsoft.Extensions.Configuration;");
         builder.AppendLine("using Microsoft.Extensions.DependencyInjection;");
@@ -36,10 +34,10 @@ internal static class BootstrapCodeGenerator
         builder.AppendLine("    internal static void Initialize()");
         builder.AppendLine("    {");
 
-        // Generate ForceLoadAssemblies call if there are referenced assemblies with [GenerateTypeRegistry]
+        // Generate the referenced-module initialization call when dependencies have registries.
         if (referencedAssemblies.Count > 0)
         {
-            builder.AppendLine("        // Force-load referenced assemblies to ensure their module initializers run");
+            builder.AppendLine("        // Run referenced module constructors so their registries register");
             builder.AppendLine("        ForceLoadReferencedAssemblies();");
             builder.AppendLine();
         }
@@ -95,21 +93,21 @@ internal static class BootstrapCodeGenerator
         {
             builder.AppendLine();
             builder.AppendLine("    /// <summary>");
-            builder.AppendLine("    /// Forces referenced assemblies with [GenerateTypeRegistry] to load,");
-            builder.AppendLine("    /// ensuring their module initializers execute and register their types.");
+            builder.AppendLine("    /// Runs module constructors for referenced assemblies with");
+            builder.AppendLine("    /// [GenerateTypeRegistry], ensuring their registries register.");
             builder.AppendLine("    /// </summary>");
             builder.AppendLine("    /// <remarks>");
-            builder.AppendLine("    /// Without this, transitive dependencies that are never directly referenced");
-            builder.AppendLine("    /// in code would not be loaded by the CLR, and their plugins would not be discovered.");
+            builder.AppendLine("    /// A typeof expression alone does not guarantee module initialization.");
+            builder.AppendLine("    /// RunModuleConstructor is idempotent when a dependency was already initialized.");
             builder.AppendLine("    /// </remarks>");
-            builder.AppendLine("    [MethodImpl(MethodImplOptions.NoInlining)]");
             builder.AppendLine("    private static void ForceLoadReferencedAssemblies()");
             builder.AppendLine("    {");
 
             foreach (var referencedAssembly in referencedAssemblies)
             {
                 var safeRefAssemblyName = GeneratorHelpers.SanitizeIdentifier(referencedAssembly);
-                builder.AppendLine($"        _ = typeof(global::{safeRefAssemblyName}.Generated.TypeRegistry).Assembly;");
+                builder.AppendLine("        global::System.Runtime.CompilerServices.RuntimeHelpers.RunModuleConstructor(");
+                builder.AppendLine($"            typeof(global::{safeRefAssemblyName}.Generated.TypeRegistry).Module.ModuleHandle);");
             }
 
             builder.AppendLine("    }");

--- a/src/NexusLabs.Needlr.SignalR.Tests/SourceGenIntegrationTests.cs
+++ b/src/NexusLabs.Needlr.SignalR.Tests/SourceGenIntegrationTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.SignalR;
@@ -107,19 +108,22 @@ public sealed class SourceGenIntegrationTests
     [Fact]
     public void SignalR_ModuleInitializerRegistersPlugins()
     {
-        if (!NeedlrSourceGenBootstrap.TryGetProviders(out _, out var pluginProvider))
-        {
-            Assert.Fail("NeedlrSourceGenBootstrap has no registered providers");
-            return;
-        }
+        var signalRPluginType = typeof(SignalRWebApplicationBuilderPlugin);
+        var signalRAssembly = signalRPluginType.Assembly;
+        RuntimeHelpers.RunModuleConstructor(signalRPluginType.Module.ModuleHandle);
+
+        var found = NeedlrSourceGenBootstrap.TryGetProviders(out _, out var pluginProvider);
+        Assert.True(found, "Expected the SignalR module initializer to register Needlr providers");
 
         var allPluginTypes = pluginProvider().ToList();
         var signalRPluginTypes = allPluginTypes
-            .Where(p => p.PluginType.Assembly == typeof(SignalRWebApplicationBuilderPlugin).Assembly)
+            .Where(p => p.PluginType.Assembly == signalRAssembly)
             .Select(p => p.PluginType.Name)
             .ToList();
 
-        Assert.Contains(signalRPluginTypes, n => n == "SignalRWebApplicationBuilderPlugin");
+        Assert.Equal(2, signalRPluginTypes.Count);
+        Assert.Contains("SignalRHubRegistrationPlugin", signalRPluginTypes);
+        Assert.Contains("SignalRWebApplicationBuilderPlugin", signalRPluginTypes);
     }
 }
 


### PR DESCRIPTION
Closes #74

## Root cause

The Carter test queried `NeedlrSourceGenBootstrap` before executing any code from the Carter module, so it depended on another test loading Carter first. The same invalid assumption existed in SignalR and cross-generator tests.

The investigation also found a production defect in generated transitive bootstrapping: `_ = typeof(Referenced.Generated.TypeRegistry).Assembly` obtains assembly metadata but does not guarantee the referenced module initializer has completed.

## Changes

- emit `RuntimeHelpers.RunModuleConstructor(typeof(...TypeRegistry).Module.ModuleHandle)` for every referenced Needlr registry
- remove the obsolete `NoInlining` workaround used by the metadata-only implementation
- make Carter, SignalR, and simulated cross-generator package tests explicitly execute the module constructor they own
- add an in-memory runtime regression proving a referenced module initializer completes before host registration
- strengthen multi-project cascade coverage so the service type is not referenced until after provider construction
- update advanced usage, the transitive dependency example, and the changelog

## Validation

- 75 distinct related tests passed, 0 failed, 0 skipped
- isolated Carter bootstrap test: 20/20 Debug runs passed
- isolated Carter bootstrap test: 10/10 Release runs with XPlat coverage passed
- full Carter Release suite with coverage: 22/22 passed
- transitive dependency demo ran successfully
- Release consumer build: 0 warnings, 0 errors
- strict MkDocs build: 0 errors; Material emitted its upstream MkDocs 2.0 informational warning

No workflow retry, test retry, or skipped-test workaround was added. NativeAOT publishing remains covered by hosted PR CI rather than a local publish run.