### PR TITLE
Prepare Needlr for protected main

### DIFF
--- a/.github/badges/coverage.json
+++ b/.github/badges/coverage.json
@@ -1,6 +1,0 @@
-{
-  "schemaVersion": 1,
-  "label": "coverage",
-  "message": "89.1%",
-  "color": "red"
-}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,13 +72,6 @@ jobs:
           -targetdir:"coverage/report" \
           -reporttypes:"Html;JsonSummary;MarkdownSummaryGithub;Badges"
 
-    - name: Extract Coverage Percentage
-      id: coverage
-      run: |
-        COVERAGE=$(jq '.summary.linecoverage' coverage/report/Summary.json)
-        echo "percentage=$COVERAGE" >> $GITHUB_OUTPUT
-        echo "Coverage: $COVERAGE%"
-
     - name: Add Coverage to Job Summary
       run: cat coverage/report/SummaryGithub.md >> $GITHUB_STEP_SUMMARY
 
@@ -141,35 +134,6 @@ jobs:
       run: |
         mkdir -p site/coverage
         cp -r coverage/report/* site/coverage/
-
-    - name: Update Coverage Badge JSON
-      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-      run: |
-        mkdir -p .github/badges
-        cat > .github/badges/coverage.json << EOF
-        {
-          "schemaVersion": 1,
-          "label": "coverage",
-          "message": "${{ steps.coverage.outputs.percentage }}%",
-          "color": "$([ $(echo "${{ steps.coverage.outputs.percentage }} >= 80" | bc -l) -eq 1 ] && echo 'brightgreen' || ([ $(echo "${{ steps.coverage.outputs.percentage }} >= 60" | bc -l) -eq 1 ] && echo 'yellow' || echo 'red'))"
-        }
-        EOF
-
-    - name: Commit Coverage Badge
-      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-      continue-on-error: true
-      run: |
-        git config user.name "github-actions[bot]"
-        git config user.email "github-actions[bot]@users.noreply.github.com"
-        TEMP_BADGE=$(mktemp)
-        cp .github/badges/coverage.json "$TEMP_BADGE"
-        git fetch origin main
-        git reset --hard origin/main
-        cp "$TEMP_BADGE" .github/badges/coverage.json
-        rm -f "$TEMP_BADGE"
-        git add .github/badges/coverage.json
-        git diff --staged --quiet || git commit -m "chore: update coverage badge [skip ci]"
-        git push
 
     - name: Restrict deploy to ci.yml-owned paths
       if: success() && github.ref == 'refs/heads/main' && github.event_name == 'push'
@@ -244,6 +208,10 @@ jobs:
       with:
         dotnet-version: |
           10.0.x
+
+    - name: Validate release finalization
+      shell: pwsh
+      run: scripts/test-release.ps1
 
     - name: Restore
       run: dotnet restore src/NexusLabs.Needlr.slnx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 - HttpClient name inference now treats types named exactly `HttpClientOptions`, `HttpClientSettings`, or `HttpClient` as empty inferred names, making NDLRHTTP004 reachable as documented instead of silently registering a suffix-only client name. HttpClient collision diagnostics are emitted deterministically, and generated client names and configuration section literals are escaped consistently.
 - CI now disables NBGV's per-project cloud build-number and version-variable publication, preventing parallel solution builds from corrupting GitHub Actions file-command files. The obsolete temporary `$GITHUB_ENV` redirection workarounds were removed.
 
+### Changed
+
+- Release preparation now lands version, changelog, analyzer-tracking, and version-specific documentation changes through a pull request. Finalization requires synchronized protected `main`, verifies same-commit CI, and pushes only the version tag. The coverage badge now reads the ReportGenerator SVG deployed with the live report instead of committing generated badge JSON back to `main`.
+
 ### Removed
 
 - Removed the unreferenced internal `MermaidHelpers` and `StringHelpers` duplicates and impossible `ref`/`out`/`in` handling for positional-record parameters.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Needlr
 
 [![CI](https://github.com/ncosentino/needlr/actions/workflows/ci.yml/badge.svg)](https://github.com/ncosentino/needlr/actions/workflows/ci.yml)
-[![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ncosentino/needlr/main/.github/badges/coverage.json)](https://github.devleader.ca/needlr/coverage/)
+[![Coverage](https://www.devleader.ca/projects/needlr/coverage/badge_linecoverage.svg)](https://www.devleader.ca/projects/needlr/coverage/)
 [![NuGet](https://img.shields.io/nuget/v/NexusLabs.Needlr.svg)](https://www.nuget.org/packages/NexusLabs.Needlr)
 
 Needlr is an opinionated fluent dependency injection library for .NET that provides automatic service registration and web application setup through a simple, discoverable API. It's designed to minimize boilerplate code by defaulting to registering types from scanned assemblies automatically.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,87 +1,101 @@
 # Releasing Needlr
 
 > **Full maintainer guide:** [`docs/releasing.md`](docs/releasing.md).
->
-> This file is the short, fast-lookup version for muscle memory. The
-> in-depth guide explains every step, every gate, and every common
-> failure mode.
+
+Needlr uses a protected-main release flow with two separate operations:
+
+1. Prepare all release content in a pull request.
+2. After the pull request is squash-merged and same-commit `main` CI succeeds,
+   create and push only the version tag.
+
+`scripts/release.ps1` performs the second operation. It never changes
+`version.json`, creates a commit, pulls/rebases, or pushes a branch.
 
 ## TL;DR — cut a new alpha
 
+### 1. Prepare the release pull request
+
 ```powershell
-# 1. Start from a clean tree on main with CI green on origin.
-git checkout main
-git pull
+git fetch origin main --tags
+git switch --create release/prepare-v0.0.3-alpha.3 origin/main
 
-# 2. Ship analyzers. Move every rule out of
-#    src/**/AnalyzerReleases.Unshipped.md into the matching
-#    AnalyzerReleases.Shipped.md under the EXISTING base-version
-#    release section (e.g. "## Release 0.0.3"). Keep rule IDs in
-#    alphanumeric order within the section.
-#
-#    The header uses the base version ONLY — RS2007 rejects
-#    pre-release labels, so "## Release 0.0.3-alpha.2" will not
-#    build. All alpha/beta/rc releases of 0.0.3 share one section.
-#
-#    Commit as: chore: ship analyzers for 0.0.3-alpha.N
-#    (scripts/release.ps1 refuses to proceed without this.)
-
-# 3. Add a CHANGELOG.md entry:
-#        ## [0.0.3-alpha.N] - YYYY-MM-DD
-#    with Added / Fixed / Changed sections.
-
-# 4. Dry-run the release script to validate every gate passes.
-./scripts/release.ps1 -Prerelease alpha -Base 0.0.3 -DryRun
-
-# 5. Run for real. This bumps version.json, pushes the commit to main,
-#    then tags that exact commit.
-./scripts/release.ps1 -Prerelease alpha -Base 0.0.3
+# Choose the next unused version, then update version.json on this branch.
+nbgv set-version 0.0.3-alpha.3
 ```
 
-Pushing the `v0.0.3-alpha.N` tag to `origin` triggers
-`.github/workflows/release.yml`, which:
+In the same pull request:
 
-1. Waits for the `ci.yml` push run on `main` for the exact tag commit to
-   complete successfully.
-2. Builds the solution with `-p:PublicRelease=true`.
-3. Runs the full test suite with coverage.
-4. Packs every `NexusLabs.Needlr*.csproj` except `*.Tests`, `*.Benchmarks`, `*IntegrationTests`.
-5. Exchanges the GitHub OIDC identity for a short-lived NuGet.org API key.
-6. Pushes all `.nupkg` + `.snupkg` files to NuGet.org and GitHub Packages.
-7. Creates a GitHub Release (flagged pre-release because the tag contains `-`)
-   with release notes extracted from `CHANGELOG.md`.
+- Move every rule row from `src/**/AnalyzerReleases.Unshipped.md` into
+  the matching `AnalyzerReleases.Shipped.md`.
+- Use the base-version analyzer header, such as `## Release 0.0.3`.
+  Roslyn rejects prerelease labels in analyzer release headers.
+- Move the applicable `CHANGELOG.md` content into an exact dated section:
+  `## [0.0.3-alpha.3] - YYYY-MM-DD`.
+- Update version-specific documentation when applicable.
+- Run `scripts/test-release.ps1` and the normal targeted validation.
+
+Push the feature branch, open a pull request, wait for required CI, and
+squash-merge it. Do not push the preparation commit directly to `main`.
+
+### 2. Finalize from synchronized main
+
+Wait for the `ci.yml` push run on the squash-merge commit to succeed, then:
+
+```powershell
+git fetch origin main --tags
+git switch main
+git pull --ff-only origin main
+
+./scripts/release.ps1 0.0.3-alpha.3 -DryRun
+./scripts/release.ps1 0.0.3-alpha.3
+```
+
+The real run validates the prepared commit, packs the solution, validates
+package contents, runs `nbgv tag`, and executes only:
+
+```text
+git push origin refs/tags/v0.0.3-alpha.3
+```
+
+The tag triggers `.github/workflows/release.yml`. That workflow independently
+requires a successful `ci.yml` push run for the exact tag commit before it can
+publish packages or documentation.
 
 ## Gates enforced by `scripts/release.ps1`
 
-The script refuses to proceed unless **all** of these pass:
+| Gate | Requirement |
+|---|---|
+| Clean working tree | No tracked, staged, or untracked changes |
+| NBGV available | `nbgv` is on `PATH` or under `~/.dotnet/tools/` |
+| Prepared version | `version.json` and NBGV both resolve exactly to the requested version |
+| Changelog | Exact `## [<version>]` section exists |
+| Analyzer tracking | Every `AnalyzerReleases.Unshipped.md` has zero rule rows |
+| Unused version | The version tag does not exist locally or on `origin` |
+| Protected-main position | Real runs use local `main` exactly equal to freshly fetched `origin/main` |
+| Same-commit CI | The successful `ci.yml` push run is for that exact `main` commit |
+| Build + pack | `dotnet pack src/NexusLabs.Needlr.slnx -c Release` succeeds |
+| Package contents | `scripts/test-packages.ps1 -NoBuild` succeeds |
+| Final race check | `main` and tag availability are checked again immediately before tagging |
 
-| Gate | What it checks | Bypass flag |
-|---|---|---|
-| Clean working tree | `git diff --quiet` is clean | _(none — fix the tree)_ |
-| `nbgv` CLI present | `nbgv` on PATH or under `~/.dotnet/tools/` | _(install it)_ |
-| CI green on HEAD | `gh api check-runs` for current commit — every run `completed` + `success`/`skipped`/`neutral` | `-SkipCiCheck` |
-| **Analyzer release tracking** | every `AnalyzerReleases.Unshipped.md` has zero rule rows | _(none — ship them)_ |
-| Build + pack | `dotnet pack` succeeds for every packable project | _(fix the error)_ |
-| Nuspec validation | `scripts/test-packages.ps1 -NoBuild` passes | _(fix the manifest)_ |
-
-If any gate fails, the script throws before touching `version.json` or git.
+There is no CI bypass. A release that is not on successful, synchronized
+`main` is not ready to tag.
 
 ## Version source of truth
 
-- `version.json` (Nerdbank.GitVersioning) — the single file the build
-  reads at compile time. Do not edit by hand; use `nbgv set-version` or
-  `release.ps1`.
-- Tag format: lightweight `v<SemVer>` with a dot before the prerelease
-  counter: `v0.0.3-alpha.2`, not `v0.0.3-alpha-0002`.
-- The release workflow's public-release regex is in `version.json` under
-  `publicReleaseRefSpec`.
+- `version.json` is the build-time source of truth.
+- Use `nbgv set-version <version>` only on the release-preparation branch.
+- The squash-merge commit must be the commit that introduces that version so
+  NBGV resolves the exact release version without a commit-height suffix.
+- Tags are lightweight `v<SemVer>` tags, for example
+  `v0.0.3-alpha.3`.
 
 ## After the release
 
-- Verify the packages appear on
-  [nuget.org/packages/NexusLabs.Needlr](https://www.nuget.org/packages/NexusLabs.Needlr).
-- Verify the GitHub Release page has the `.nupkg` + `.snupkg` attachments.
-- Verify the release notes section matches the CHANGELOG entry.
+- Verify the release workflow succeeded.
+- Verify the packages on
+  [NuGet.org](https://www.nuget.org/packages/NexusLabs.Needlr).
+- Verify the GitHub Release assets and notes.
+- Verify stable/versioned API documentation.
 
-See [`docs/releasing.md`](docs/releasing.md) for troubleshooting, first-time
-setup, and full rationale behind each gate.
+See [`docs/releasing.md`](docs/releasing.md) for preparation details,
+troubleshooting, and rollback guidance.

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ description: Needlr is a source-generation-first dependency injection library fo
 **Opinionated fluent dependency injection for .NET with source generation.**
 
 [![CI](https://github.com/ncosentino/needlr/actions/workflows/ci.yml/badge.svg)](https://github.com/ncosentino/needlr/actions/workflows/ci.yml)
-[![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ncosentino/needlr/main/.github/badges/coverage.json)](https://ncosentino.github.io/needlr/coverage/)
+[![Coverage](https://www.devleader.ca/projects/needlr/coverage/badge_linecoverage.svg)](https://www.devleader.ca/projects/needlr/coverage/)
 [![NuGet](https://img.shields.io/nuget/v/NexusLabs.Needlr.svg)](https://www.nuget.org/packages/NexusLabs.Needlr)
 
 ## What is Needlr?

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,313 +1,165 @@
 # Releasing Needlr
 
-This is the in-depth maintainer guide for cutting a new Needlr release
-(alpha, beta, rc, or stable). It exists so nobody — human or LLM
-assistant — has to rediscover the release process by reading commit
-history.
+This is the authoritative maintainer guide for cutting a Needlr release.
+The fast-lookup checklist is
+[`RELEASING.md`](https://github.com/ncosentino/needlr/blob/main/RELEASING.md).
 
-The fast-lookup version lives at [`RELEASING.md`](https://github.com/ncosentino/needlr/blob/main/RELEASING.md) in the repo root.
+## Release model
 
----
+Needlr uses protected `main`. A release is deliberately split into two
+operations:
 
-## What a release actually is
+1. **Release preparation through a pull request**
+   - update `version.json`;
+   - ship analyzer diagnostics;
+   - create the exact `CHANGELOG.md` release section;
+   - update version-specific documentation where applicable;
+   - pass required pull-request CI.
+2. **Tag-only finalization from synchronized `main`**
+   - verify the prepared version and release metadata;
+   - verify successful same-commit `main` CI;
+   - validate build and package contents;
+   - create and push only the version tag.
 
-A Needlr release is:
+The split is a safety boundary. The release script cannot write a version
+commit to protected `main`, and package publication cannot begin from a
+commit that bypassed pull-request validation.
 
-1. A move of every unshipped analyzer diagnostic from
-   `AnalyzerReleases.Unshipped.md` → `AnalyzerReleases.Shipped.md`.
-2. A `CHANGELOG.md` entry under a new `## [x.y.z-label.N]` heading.
-3. A version bump in `version.json` via Nerdbank.GitVersioning.
-4. A lightweight git tag `v<version>` on the bump commit.
-5. A push of the tag to `origin`, which triggers
-   `.github/workflows/release.yml` to build, test, pack, publish to
-   NuGet.org + GitHub Packages, and create a GitHub Release.
+## What a release contains
 
-Steps 1-4 are orchestrated by `scripts/release.ps1`. Step 5 is the CI
-workflow. Everything after the tag push is automated.
+A Needlr release consists of:
 
----
+1. Analyzer rule rows moved from every
+   `AnalyzerReleases.Unshipped.md` into the corresponding
+   `AnalyzerReleases.Shipped.md`.
+2. An exact dated `CHANGELOG.md` section:
+   `## [x.y.z-label.N] - YYYY-MM-DD`.
+3. The same version in `version.json`.
+4. A lightweight `v<version>` tag on the squash-merge commit.
+5. Automated build, test, packaging, publication, release creation, and
+   documentation deployment from `.github/workflows/release.yml`.
+
+The version, changelog, analyzer files, and documentation are reviewed in the
+preparation pull request. `scripts/release.ps1` only validates and tags the
+already-merged result.
 
 ## Prerequisites
 
-You need all of the following installed and working before running
-the release script:
-
 | Tool | Purpose | Install |
 |---|---|---|
-| .NET 10 SDK | Build + pack | [dot.net](https://dot.net) |
-| PowerShell 7+ (`pwsh`) | Runs `release.ps1` | [aka.ms/pwsh](https://aka.ms/pwsh) |
-| `nbgv` | Bumps `version.json` and tags | `dotnet tool install -g nbgv` |
-| `gh` CLI | CI gate queries GitHub check runs | [cli.github.com](https://cli.github.com) |
-| Python + mkdocs (optional) | Local docs validation | `python -m pip install -r docs/requirements.txt` |
+| .NET 10 SDK | Build and pack | [dot.net](https://dot.net) |
+| PowerShell 7+ (`pwsh`) | Run the release scripts | [aka.ms/pwsh](https://aka.ms/pwsh) |
+| `nbgv` | Update `version.json`, resolve versions, and create the tag | `dotnet tool install -g nbgv` |
+| `gh` CLI | Query the exact `main` CI workflow run | [cli.github.com](https://cli.github.com) |
+| Python and MkDocs | Local documentation validation | `python -m pip install -r docs/requirements.txt` |
 
-You also need:
+The maintainer needs permission to:
 
-- **Push access to `origin/main`** on `ncosentino/needlr`.
-- **A NuGet.org trusted publishing policy** for package owner `ncosentino`,
-  repository `ncosentino/needlr`, workflow `release.yml`, and environment
-  `release`.
-- **The GitHub-provided `GITHUB_TOKEN`** (automatic, no setup).
+- create and merge a release-preparation pull request;
+- push a version tag to `origin`;
+- use the configured NuGet.org trusted-publishing policy indirectly through
+  `release.yml`.
 
----
+Direct push access to `main` is neither required nor permitted.
 
 ## Version numbering
 
-Needlr uses [SemVer 2.0.0](https://semver.org/) with a specific tag
-format enforced by `version.json`.
+Needlr uses SemVer 2.0.0. Prerelease tags use a dot before the counter:
+
+```text
+v0.0.3-alpha.3
+```
+
+Do not use `v0.0.3-alpha-0003`. NuGet may normalize the displayed package
+version, but `version.json`, the changelog, and the git tag use the dotted
+form.
 
 ### Source of truth
 
-`version.json` at the repo root contains the version Nerdbank.GitVersioning
-resolves at build time. Every `.csproj` inherits from it — **there are
-zero hardcoded versions in individual project files**.
+`version.json` is the version source read by every project. Individual project
+files do not carry package versions.
 
-```json
-{
-  "version": "0.0.3-alpha.1",
-  "publicReleaseRefSpec": [
-    "^refs/heads/main$",
-    "^refs/heads/release/v\\d+\\.\\d+",
-    "^refs/tags/v\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z\\.]+)?$"
-  ]
-}
-```
+Use `nbgv set-version <version>` on the release-preparation branch. The
+tag-only release script intentionally does not call `nbgv set-version`.
 
-Do not edit `version.json` by hand during a release. Always go through
-`nbgv set-version` or `release.ps1 -Prerelease alpha`.
+Needlr is configured for squash-only merges. The squash-merge commit therefore
+introduces the new `version.json` value and NBGV resolves exactly that version
+on the merge commit. If NBGV reports a suffix such as `.g<sha>`, the current
+commit is not the version-reset commit and must not be tagged.
 
-### Tag format
+### Choosing the next prerelease
 
-Tags are lightweight (not annotated) and follow the pattern:
-
-```
-v<major>.<minor>.<patch>-<label>.<counter>
-```
-
-For alpha: `v0.0.3-alpha.1`, `v0.0.3-alpha.2`, ...
-
-**Watch the separator:** it's a **dot** between `alpha` and the
-counter, not a dash. `v0.0.3-alpha-0002` is wrong; `v0.0.3-alpha.2` is
-right. NuGet displays the version with different normalization in its
-UI but the tag and `version.json` use the dotted form.
-
-For example, tag `v0.0.3-alpha.1` publishes NuGet package version
-`0.0.3-alpha-0001`.
-
-### Finding the next version
+Fetch all tags and inspect the current sequence:
 
 ```powershell
-./scripts/release.ps1 -Prerelease alpha -Base 0.0.3 -DryRun
+git fetch origin main --tags
+git tag --list "v0.0.3-alpha.*" --sort=-version:refname |
+  Select-Object -First 10
 ```
 
-The `-Prerelease` flag scans existing tags for the highest
-`v0.0.3-alpha.*` and increments the counter. `-Base` pins the base
-version so a stale `version.json` doesn't confuse the calculation. The
-dry run prints what the real run would do.
-
----
-
-## Pre-release gates
-
-Before the script takes any destructive action (version bump, commit,
-tag, push) it runs the following gates. All must pass.
-
-### 1. Clean working tree
+Increment the highest published counter and confirm that neither the local nor
+remote tag exists:
 
 ```powershell
-git diff --quiet
+git tag --list "v0.0.3-alpha.3"
+git ls-remote --tags origin "refs/tags/v0.0.3-alpha.3"
 ```
 
-Dirty trees are rejected. Stash or commit first. This exists because
-`release.ps1` uses `git commit -am` for the version bump — any
-unrelated staged or unstaged changes would get dragged into the release
-commit.
+The release script repeats both checks before tagging.
 
-### 2. `nbgv` installed
+## Phase 1: prepare the release pull request
 
-The script checks `Get-Command nbgv` and falls back to
-`~/.dotnet/tools/nbgv.exe`. If neither is present it throws a
-remediation message pointing at `dotnet tool install -g nbgv`.
+### Create the branch
 
-### 3. CI green on HEAD
+Start from the latest remote `main`:
 
 ```powershell
-gh api "repos/$repoSlug/commits/$sha/check-runs"
+git fetch origin main --tags
+git switch --create release/prepare-v0.0.3-alpha.3 origin/main
 ```
 
-Every check run on the current commit must be `completed` with
-`conclusion` in `success` / `skipped` / `neutral`. Anything failing,
-pending, or neutral blocks the release.
+Never prepare the release by committing directly on local `main`.
 
-The rationale: the CI workflow on `main` runs the full test matrix
-(unit tests, integration tests, generator tests, AspNet tests, AOT
-publish, example builds). If any of those are red, the package you're
-about to ship is known-broken.
+### Update `version.json`
 
-Override with `-SkipCiCheck` only if you're deliberately cutting a
-release before CI finishes (for example, you just pushed a fix and
-don't want to wait five minutes, and you've personally verified the
-build locally). Never skip this on a release candidate or stable.
+Run NBGV on the preparation branch:
 
-### 4. Analyzer release tracking
-
-> This is the gate that was silently broken before
-> [`f66653c2`](https://github.com/ncosentino/needlr/commit/f66653c2). If
-> you are reading this because a past release shipped with stale
-> unshipped rules, welcome back.
-
-Every Needlr analyzer project includes two `AdditionalFiles`:
-
-- `AnalyzerReleases.Shipped.md` — every diagnostic ID that has shipped
-  in a prior release, grouped under `## Release <version>` headers.
-- `AnalyzerReleases.Unshipped.md` — every diagnostic ID that is in code
-  but has not yet been included in a released version.
-
-`Microsoft.CodeAnalysis.Analyzers` (referenced from every analyzer
-project) enforces these files via rules **RS2000**, **RS2001**, and
-**RS2002**:
-
-- **RS2000**: Add the new rule to `Unshipped.md` when you introduce it
-  in code.
-- **RS2001**: Rule IDs in `Unshipped.md` must eventually move to
-  `Shipped.md` before a release.
-- **RS2002**: Rules in `Shipped.md` must still exist in the analyzer.
-
-**Before every release**, every unshipped rule must move. The release
-script refuses to proceed otherwise:
-
-```
-BLOCKED: analyzer projects have unshipped rules.
-
-Before releasing, move each rule below from its AnalyzerReleases.Unshipped.md
-file into the matching AnalyzerReleases.Shipped.md under a new header:
-  ## Release 0.0.2-alpha.26
+```powershell
+nbgv set-version 0.0.3-alpha.3
 ```
 
-See [Shipping analyzers](#shipping-analyzers) below for the exact
-mechanical procedure.
+Review the resulting `version.json` diff. Do not manually change unrelated
+NBGV settings.
 
-### 5. Build + pack validation
+### Ship analyzer diagnostics
 
-The script walks every `.csproj` under `src/` that is neither a test
-project nor has `<IsPackable>false</IsPackable>`, and runs
-`dotnet pack -c Release -v q --no-restore` on each. First failure
-aborts the release. This catches:
+Every Needlr analyzer project has:
 
-- Projects that compile for `dotnet build` but fail at pack time
-  (missing `Description`, invalid package id, missing README).
-- Projects that ship a new analyzer DLL via a custom `None Include`
-  entry whose `OutputPath` doesn't exist yet.
-- Projects whose `netstandard2.0` target drifts against the generator
-  requirements.
+- `AnalyzerReleases.Shipped.md` for diagnostics included in a release;
+- `AnalyzerReleases.Unshipped.md` for diagnostics added since the last
+  applicable release.
 
-### 6. Nuspec validation
-
-After successful packs, `scripts/test-packages.ps1 -NoBuild` runs. It
-extracts every `.nupkg` from `artifacts/`, parses the embedded
-`.nuspec`, and asserts:
-
-- The `dependencies` graph matches expected shape.
-- Analyzer and generator DLLs are placed at the correct package paths
-  (`analyzers/dotnet/cs/`).
-- The `Needlr.Build` package correctly transitively delivers the
-  generator assembly (regression test for a past bug — see commit
-  `b77544fa`).
-
-This is the last gate before the version bump actually happens.
-
----
-
-## Shipping analyzers
-
-This is the step that historically got forgotten. `release.ps1` now
-blocks on it, but you still have to do the mechanical move yourself.
-
-### Finding what needs to ship
-
-The guardrail tells you exactly which files and which rule IDs. You
-can also check manually:
+Find pending rule rows:
 
 ```powershell
 Get-ChildItem src -Recurse -Filter AnalyzerReleases.Unshipped.md |
   ForEach-Object {
-    $rules = Get-Content $_.FullName | Where-Object { $_ -match '^NDLR' }
+    $rules = Get-Content $_.FullName |
+      Where-Object { $_ -match '^NDLR' }
     if ($rules) {
       Write-Host $_.FullName
-      $rules | ForEach-Object { Write-Host "  $($_ -split '\s*\|\s*' | Select-Object -First 1)" }
+      $rules
     }
   }
 ```
 
-### Version header format — the non-obvious rule
-
-**`Microsoft.CodeAnalysis.Analyzers` rule RS2007 rejects pre-release
-labels in the release header.** A header like `## Release 0.0.2-alpha.26`
-will fail the analyzer build with:
-
-```
-error RS2007: Analyzer release file 'AnalyzerReleases.Shipped.md' has a
-missing or invalid release header '## Release 0.0.2-alpha.26'
-```
-
-The authoritative format is the **base version only**, no pre-release
-label, no `v` prefix, no date:
-
-```
-## Release 0.0.2
-```
-
-**All alpha/beta/rc releases of `0.0.2` share the same
-`## Release 0.0.2` section.** You don't add a new section per alpha
-bump — you append the newly-shipped rules to the existing section.
-
-This is the single rule that has bounced every past release attempt
-(see fix commits `83ef38ab`, `6b7e1166`, `22bd5b64`). The commit
-`22bd5b64` (`fix: use semver-only release header for analyzer tracking`)
-was a retroactive fix that merged `## Release 0.0.2-alpha.17` back into
-`## Release 0.0.2` after the analyzer build rejected it.
-
-When `0.0.3` is the next base version, that's when a new section gets
-created.
-
-### The mechanical move
-
-For each `AnalyzerReleases.Unshipped.md` with unshipped rules:
+For each file with rule rows:
 
 1. Open the paired `AnalyzerReleases.Shipped.md`.
-2. Find the existing `## Release <base-version>` section that
-   corresponds to the current base version (e.g. `## Release 0.0.2`
-   if you're shipping `v0.0.2-alpha.26`). If one does not exist —
-   for example, this is the first time the analyzer project has
-   ever shipped anything — create it with the base version only:
+2. Find or create the base-version section, such as:
 
    ```markdown
-   ## Release 0.0.2
-
-   ### New Rules
-
-   Rule ID | Category | Severity | Notes
-   --------|----------|----------|-------
-   <paste every unshipped row here, unchanged>
-   ```
-
-3. If the section already exists, append the new rule rows to its
-   table in **alphanumeric order** by Rule ID (so `NDLRCOR012` goes
-   between `NDLRCOR011` and `NDLRCOR015`, not at the end of the
-   section). Consistent ordering makes diffs easier to review.
-
-4. Open `AnalyzerReleases.Unshipped.md` and **delete only the rule
-   data rows**. Keep:
-   - The `; Unshipped analyzer releases` comment at the top
-   - The help link comment
-   - The `### New Rules` heading
-   - The table header row (`Rule ID | Category | Severity | Notes`)
-   - The separator row (`--------|----------|----------|-------`)
-
-   The post-ship file should look like:
-
-   ```markdown
-   ; Unshipped analyzer releases
-   ; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+   ## Release 0.0.3
 
    ### New Rules
 
@@ -315,375 +167,327 @@ For each `AnalyzerReleases.Unshipped.md` with unshipped rules:
    --------|----------|----------|-------
    ```
 
-5. Repeat for each analyzer project with unshipped rules.
+3. Move every pending row into that section in alphanumeric diagnostic-ID
+   order.
+4. Delete only the rule data rows from `AnalyzerReleases.Unshipped.md`.
+   Keep its comments, heading, table header, and separator.
 
-6. Build each analyzer project locally to verify the updated files
-   are accepted by `Microsoft.CodeAnalysis.Analyzers`:
+The header uses the base version only. Roslyn rule RS2007 rejects a header such
+as `## Release 0.0.3-alpha.3`.
 
-   ```powershell
-   dotnet build src/NexusLabs.Needlr.Analyzers/NexusLabs.Needlr.Analyzers.csproj -c Release
-   dotnet build src/NexusLabs.Needlr.Generators/NexusLabs.Needlr.Generators.csproj -c Release
-   ```
+The release script fails if any line beginning with `NDLR` remains in an
+unshipped file.
 
-   If the build fails with `RS2001`, `RS2002`, or `RS2007`, re-read
-   the [Version header format](#version-header-format-the-non-obvious-rule)
-   section above and fix the header before proceeding.
+### Create the changelog section
 
-7. Commit with the conventional message:
-
-   ```
-   chore: ship analyzers for 0.0.2-alpha.26
-   ```
-
-### Example diff
-
-From the fix for `v0.0.2-alpha.26` (commits `f66653c2` + follow-up),
-the shipping change for `NexusLabs.Needlr.Analyzers` looked like:
-
-```diff
-  ## Release 0.0.2
-
-  ### New Rules
-
-  Rule ID | Category | Severity | Notes
-  --------|----------|----------|-------
-  ...
-  NDLRCOR011 | NexusLabs.Needlr | Info | KeyedServiceResolutionAnalyzer, ...
-+ NDLRCOR012 | NexusLabs.Needlr | Error | Disposable captive dependency - ...
-  NDLRCOR015 | NexusLabs.Needlr | Error | [RegisterAs<T>] type argument ...
-+ NDLRCOR016 | NexusLabs.Needlr | Warning | [DoNotAutoRegister] applied ...
-```
-
-Note how `NDLRCOR012` is inserted **in order** between `NDLRCOR011`
-and `NDLRCOR015`, not appended at the end.
-
-### If you add a new analyzer diagnostic between releases
-
-1. Add the `DiagnosticDescriptor` in the analyzer project.
-2. Add a row to that project's `AnalyzerReleases.Unshipped.md` under
-   `### New Rules` with the same `Rule ID | Category | Severity | Notes`
-   format. **Build immediately** — if you forget, the next release
-   script run will tell you, but it's much easier to fix at the source.
-3. Write the doc page at `docs/analyzers/NDLRXXX.md` following the
-   template in `.claude/rules/generated/docs.md`.
-4. Add a nav entry in `mkdocs.yml` under the appropriate analyzer
-   subgroup.
-5. Add a row to `docs/analyzers/README.md` in the matching table.
-
-The release script handles the shipping; you only have to remember the
-Unshipped.md row on the day you add the rule.
-
----
-
-## Writing the CHANGELOG entry
-
-`CHANGELOG.md` follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
-
-The release workflow extracts release notes by searching for a section
-matching `## [<version>]` — it takes everything from that header up
-until the next `## [` header.
-
-### Template
+Move the content being released out of `## [Unreleased]` and into an exact,
+dated section:
 
 ```markdown
-## [0.0.2-alpha.26] - 2026-04-10
+## [0.0.3-alpha.3] - 2026-07-24
 
 ### Added
 
-- **Feature name** — One-sentence description. Link to the PR or
-  feature docs if relevant.
+- ...
 
 ### Fixed
 
-- **Bug description** — What broke, how it was fixed, observable
-  symptom before the fix. Include issue/PR links.
+- ...
 
 ### Changed
 
-- Internal refactors or breaking changes. Breaking changes should be
-  clearly flagged.
+- ...
 
 ### Shipped analyzers
 
-- `NDLRXXX001`, `NDLRXXX002`, ... (list every ID moved to Shipped.md
-  in this release, even if they were added in a prior alpha).
+- `NDLRGEN057`, `NDLRGEN058`, ...
 ```
 
-The `### Shipped analyzers` section is a Needlr convention. It lets
-downstream consumers see at a glance which diagnostic IDs are now
-"released" in a given version, which helps them triage RS2000 errors
-that pop up when they upgrade.
+The release workflow and `release.ps1` both require the exact
+`## [<version>]` heading. The optional `### Shipped analyzers` section records
+which diagnostics moved into the shipped files.
 
-### Finding what changed
+### Update version-specific documentation
+
+Update any documentation whose examples, compatibility statements, or API
+links refer to the release version. Routine feature documentation should
+already be present before release preparation.
+
+### Validate the preparation
+
+Use the repository NuGet cache on this machine:
 
 ```powershell
-# Commits since the previous release tag.
-git log v0.0.2-alpha.25..HEAD --oneline
+$env:NUGET_PACKAGES = 'G:\dev\caches\nuget\packages'
 ```
 
-Turn that list into CHANGELOG sections manually, or use the
-`skills/changelog-generator/scripts/generate.py` helper referenced by
-the dry-run output:
+Run the targeted release regression test:
 
 ```powershell
-python skills/changelog-generator/scripts/generate.py \
-  --from v0.0.2-alpha.25 \
-  --to HEAD \
-  --version 0.0.2-alpha.26
+pwsh -NoProfile -File scripts/test-release.ps1
 ```
 
-Review the output, edit for tone, and append to `CHANGELOG.md`.
+That test creates an isolated local remote, exercises dry-run and real
+finalization with command shims, and proves:
 
----
+- no branch commit is created;
+- `origin/main` does not move;
+- the expected tag is the only remote write;
+- the tag points at the prepared `main` commit.
 
-## Running the release
+Then run the normal validation appropriate to the release content, including:
 
-### Dry run first
+```powershell
+dotnet build src/NexusLabs.Needlr.slnx -c Release
+pwsh -NoProfile -File scripts/test-packages.ps1
+python -m mkdocs build --strict
+```
+
+### Open and merge the pull request
+
+Push only the feature branch and open the release-preparation pull request:
+
+```powershell
+git push -u origin release/prepare-v0.0.3-alpha.3
+gh pr create
+```
+
+Wait for all required checks:
+
+- `build-and-test`;
+- `package-validation`;
+- `aot-console-app`;
+- `aot-web-app`.
+
+Resolve review conversations and squash-merge the pull request. The
+path-filtered `build-maui-example` workflow is not a required branch check;
+when it runs for relevant changes, it must still pass.
+
+## Phase 2: finalize the release tag
+
+### Wait for same-commit main CI
+
+After the preparation pull request merges, wait for the `ci.yml` **push** run
+on the squash-merge commit to complete successfully. Pull-request CI is not a
+substitute because the release workflow independently verifies the exact
+`main` commit.
+
+### Synchronize local main
+
+```powershell
+git fetch origin main --tags
+git switch main
+git pull --ff-only origin main
+git status --short
+```
+
+The status output must be empty. The script fetches again and requires:
+
+```text
+local HEAD == origin/main
+```
+
+It never pulls, rebases, commits, or pushes a branch on the maintainer's
+behalf.
+
+### Run the dry run
+
+Use the exact prepared version:
+
+```powershell
+./scripts/release.ps1 0.0.3-alpha.3 -DryRun
+```
+
+Dry run validates:
+
+- a completely clean working tree;
+- NBGV availability;
+- exact `version.json` and NBGV version agreement;
+- exact changelog section;
+- empty analyzer unshipped rule tables;
+- local and remote tag availability.
+
+It prints the real tag-only write operation. Dry run intentionally skips the
+real-run-only main-position, hosted-CI, pack, and package-content gates.
+
+The `-Prerelease` form remains available after the release version has already
+been prepared:
 
 ```powershell
 ./scripts/release.ps1 -Prerelease alpha -Base 0.0.3 -DryRun
 ```
 
-Dry run:
+The computed version must still exactly match `version.json`.
 
-- Runs every gate listed in [Pre-release gates](#pre-release-gates)
-  except the clean-working-tree check (so you can iterate).
-- Computes the next version number.
-- Extracts the `CHANGELOG.md` entry for that version and prints it.
-- Prints what it would commit, tag, and push — without doing any of it.
-
-If the dry run reports a missing CHANGELOG entry or unshipped
-analyzers, fix those and re-run.
-
-### Real run
+### Run finalization
 
 ```powershell
-./scripts/release.ps1 -Prerelease alpha -Base 0.0.3
+./scripts/release.ps1 0.0.3-alpha.3
 ```
 
-The real run, in order:
+The real run:
 
-1. Runs all gates.
-2. Runs `nbgv set-version <new>` to bump `version.json`.
-3. Creates a commit: `chore: bump version to 0.0.3-alpha.2`.
-4. Rebases and pushes the version commit to `main`, retrying a bounded number
-   of times if the coverage-badge bot wins the push race.
-5. Creates a lightweight tag via `nbgv tag` on the exact commit now present on
-   `main`.
-6. Pushes that tag to trigger the release workflow.
+1. Repeats every metadata and tag-availability check.
+2. Requires local `main` to equal freshly fetched `origin/main`.
+3. Requires a successful `ci.yml` push run for that exact SHA.
+4. Runs solution-level Release pack validation.
+5. Runs `scripts/test-packages.ps1 -NoBuild`.
+6. Rechecks the clean tree, remote `main`, and tag availability to close race
+   windows.
+7. Runs `nbgv tag`.
+8. Verifies the local tag resolves to `HEAD`.
+9. Pushes only `refs/tags/v<version>`.
 
-### When the tag lands on origin
+There is no `-SkipCiCheck` bypass. If same-commit `main` CI is missing,
+pending, or failing, the release is not ready.
 
-`.github/workflows/release.yml` fires on the tag push. Its steps:
+## Gates enforced by `release.ps1`
 
-1. Wait for the `ci.yml` push run on `main` for the exact tag commit to
-   complete successfully.
-2. Checkout + setup .NET 10.
-3. Restore, build `src/NexusLabs.Needlr.slnx` with `-p:PublicRelease=true`.
-4. Run full test suite with coverage collection.
-5. Pack every `NexusLabs.Needlr*.csproj` except tests, benchmarks,
-   integration tests, then validate every package version.
-6. Extract the release notes, provision an action-managed Python environment,
-   install `docs/requirements.txt`, build the versioned documentation site, and
-   provision Node.js for the Cloudflare deployment.
-7. Exchange the GitHub OIDC identity for a short-lived NuGet.org API key
-   through `NuGet/login@v1`.
-8. `dotnet nuget push` every `.nupkg` to NuGet.org with
-   `--skip-duplicate`.
-9. `dotnet nuget push` every `.nupkg` to GitHub Packages using
-   `${{ secrets.GITHUB_TOKEN }}` with `--skip-duplicate`.
-10. Deploy the merged documentation site to GitHub Pages and Cloudflare Pages.
-11. Create a GitHub Release via `softprops/action-gh-release@v2`
-   flagged as pre-release because the tag contains `-`, attaching
-   every `.nupkg` and `.snupkg` file.
+| Gate | Failure means |
+|---|---|
+| Clean repository | Tracked, staged, or untracked content could contaminate validation |
+| NBGV installed | The prepared version or tag cannot be resolved reliably |
+| Exact prepared version | `version.json`, NBGV, and the requested tag would disagree |
+| Exact changelog section | Release notes are incomplete or use the wrong version |
+| Analyzer release tracking | Diagnostics would ship while still marked unshipped |
+| Tag availability | The version was already used or a tag race occurred |
+| Synchronized protected main | The tag would not identify the reviewed merged commit |
+| Successful same-commit CI | The exact release commit has not passed `main` CI |
+| Solution pack | One or more packages cannot be built |
+| Package assertions | A NuGet dependency or packaged asset regressed |
+| Final race checks | `main`, the working tree, or tag state changed during validation |
 
-The publish job defaults to the PitCrew self-hosted Linux runner and supports
-`CI_RUNNER=ubuntu-latest` as a manual fallback. `actions/setup-python` provides
-the isolated Python environment on either runner; do not install documentation
-dependencies into the runner's system Python or bypass PEP 668 protections.
+Every gate fails closed. API errors, missing tools, and unparsable repository
+identity are release blockers rather than warnings.
 
-Watch the workflow run at
-[Actions](https://github.com/ncosentino/needlr/actions/workflows/release.yml)
-while it runs. It typically takes 6-10 minutes.
+## What the tag triggers
 
----
+Pushing `v<version>` starts `.github/workflows/release.yml`.
+
+Before publication, the workflow:
+
+1. Finds the `ci.yml` push run for `main` whose SHA equals the tag SHA.
+2. Waits for that run to complete.
+3. Fails unless its conclusion is `success`.
+4. Checks that the tag version equals NBGV's semantic version.
+5. Checks that the exact changelog section exists.
+6. Restores, builds, tests, packs, validates package versions, and builds
+   documentation.
+
+After those gates, trusted publishing:
+
+- exchanges the workflow OIDC identity for a short-lived NuGet.org key;
+- pushes packages to NuGet.org and GitHub Packages;
+- deploys stable and versioned API documentation;
+- creates the GitHub Release and attaches package artifacts.
+
+Tag pushes are separate from protected branch updates, so main protection does
+not block release finalization.
 
 ## Post-release verification
 
-After the workflow succeeds:
+After `release.yml` succeeds:
 
-1. **NuGet.org:** visit
-   [nuget.org/packages/NexusLabs.Needlr](https://www.nuget.org/packages/NexusLabs.Needlr)
-   and verify the new version appears under the Versions tab. Check a
-   few other key packages too (`NexusLabs.Needlr.AspNet`,
-   `NexusLabs.Needlr.Generators`, `NexusLabs.Needlr.SignalR`).
-2. **GitHub Release:** visit
-   [releases](https://github.com/ncosentino/needlr/releases) and verify
-   the new tag shows up, is marked as pre-release, has the CHANGELOG
-   section as the release notes, and has the `.nupkg` + `.snupkg`
-   assets attached.
-3. **GitHub Packages:** visit
-   [Packages](https://github.com/ncosentino/needlr/packages) and verify
-   the new version is present.
-4. **Smoke test:** create a scratch project that references the new
-   version and verifies the most critical feature still works. For a
-   web-path fix like `v0.0.2-alpha.26`, that means running the
-   `MinimalWebApiSourceGen` example against the new package reference.
-
-If any verification step fails, open an issue immediately and start
-the rollback conversation. See [Rolling back](#rolling-back).
-
----
-
-## Rolling back
-
-NuGet.org packages can be **unlisted** (hidden from search and version
-resolution) but not deleted. GitHub Releases can be deleted. Tags can
-be deleted (but doing so does not unpublish the NuGet packages).
-
-If a released version is broken:
-
-1. **Unlist the bad version on NuGet.org** via the web UI
-   (Manage Package → Listing). This stops new consumers from pulling
-   it but preserves package integrity for anyone who already has it
-   cached.
-2. **Delete the GitHub Release** (optional, only if the release page
-   itself is misleading).
-3. **Delete the local and remote tag** (optional, only if the tag
-   commit itself needs to be revised):
-   ```powershell
-   git tag -d v0.0.2-alpha.26
-   git push origin :refs/tags/v0.0.2-alpha.26
-   ```
-4. **Cut a new release** with the fix and a higher counter
-   (`v0.0.2-alpha.27`). Never re-use a version number that has been
-   pushed to NuGet.org.
-5. **Write a CHANGELOG entry** for the new release explaining the
-   rollback and what was broken in the unlisted version.
-
-Unlisting is cheap and reversible; deletion is not. Prefer unlist.
-
----
+1. Verify the new version on
+   [NuGet.org](https://www.nuget.org/packages/NexusLabs.Needlr).
+2. Verify the GitHub Release is marked correctly and has `.nupkg` and
+   `.snupkg` assets.
+3. Verify the release notes match the exact changelog section.
+4. Verify stable and versioned API documentation.
+5. Perform a focused consumer smoke test when the released change warrants it.
 
 ## Troubleshooting
 
-### `nbgv: command not found`
+### `version.json contains '<old>', not '<new>'`
 
-Install the tool:
+The release-preparation pull request did not update `version.json`, or local
+`main` has not been synchronized after merge. Do not let the release script
+change it. Prepare or merge the correct pull request, then update local
+`main`.
 
-```powershell
-dotnet tool install -g nbgv
-```
+### `NBGV resolves '<version>.g<sha>'`
 
-Make sure `~/.dotnet/tools` is on your `PATH` (the script also looks
-there directly as a fallback).
+The current commit is after the commit that introduced the version. A release
+tag must point at the exact squash-merge commit that resets the version height.
+Inspect the preparation pull request and repository merge method rather than
+tagging the suffixed version.
 
-### `BLOCKED: CI is not fully green on HEAD`
+### `Local main must exactly match origin/main`
 
-One of the GitHub check runs for the current commit is failing,
-pending, or neutral. Open the Actions tab for the commit on GitHub,
-find the failing run, fix the underlying issue, push, wait for the
-re-run to go green, then re-run the release script.
+Another commit reached `main`, or local `main` is behind/ahead. Fetch and use a
+fast-forward update. If the new remote commit changes release content, review
+it and wait for its same-commit CI before retrying.
 
-Override with `-SkipCiCheck` only in true emergencies and only when
-you've personally verified the build and tests locally.
+### `No ci.yml push run exists`
+
+Wait for the `main` push workflow to be created. Confirm the tag candidate is
+the actual `main` SHA and that Actions is enabled.
+
+### `Main CI must complete successfully`
+
+Open the run URL printed by the script. Fix failures through another pull
+request, merge it, update local `main`, and rerun all release checks.
 
 ### `BLOCKED: analyzer projects have unshipped rules`
 
-See [Shipping analyzers](#shipping-analyzers). The script prints every
-file and every rule ID that needs to be moved; just walk the list.
+Return to the preparation phase. Move every printed rule into the paired
+shipped file under the base-version header, commit that change through a pull
+request, and do not tag until it merges.
 
-### `Pack validation failed`
+### Package validation fails
 
-Some `.csproj` failed `dotnet pack`. Run the failing pack command
-manually to see the full error:
+Run the failing command directly:
 
 ```powershell
-dotnet pack src/NexusLabs.Needlr.<Whatever>/NexusLabs.Needlr.<Whatever>.csproj -c Release
+dotnet pack src/NexusLabs.Needlr.slnx -c Release
+pwsh -NoProfile -File scripts/test-packages.ps1 -NoBuild
 ```
 
-Common causes:
+Typical causes include missing package metadata, an incorrect analyzer asset
+path, or a transitive dependency exclusion regression.
 
-- Missing `<Description>` property on a new project.
-- `PackageReadmeFile` pointing at a README that wasn't marked as
-  included in the pack.
-- A newly-added analyzer DLL whose `OutputPath` doesn't resolve because
-  the build matrix is wrong (check the `<None Include>` entry in the
-  `.csproj`).
+### The tag exists locally after a failed push
 
-### Nuspec validation fails
+Inspect it before retrying:
 
-`scripts/test-packages.ps1` caught a packaging regression. Look at the
-specific assertion that fired in the output. Most common: a change to
-`Directory.Build.props` that broke a transitive dependency for one of
-the bundle packages.
+```powershell
+git show v0.0.3-alpha.3
+git ls-remote --tags origin refs/tags/v0.0.3-alpha.3
+```
 
-### The workflow fires but nothing publishes
+If the remote tag does not exist and the local tag points at the correct,
+unchanged `main` commit, retrying the push manually is possible. If there is
+any mismatch, stop and investigate; never move or reuse a published version
+tag casually.
 
-Check the Actions tab for the workflow run. Common causes:
+## Rolling back a bad release
 
-- The same-commit `ci.yml` push run on `main` is missing, still running, or
-  did not complete successfully.
-- A manually-created tag points to a commit that was never pushed to `main`.
-  `release.ps1` avoids this by landing the version commit before creating the
-  tag.
-- The NuGet trusted publishing policy does not match the repository owner,
-  repository, workflow filename, or `release` environment.
-- The publish job is missing `id-token: write`, `environment: release`, or the
-  `NuGet/login@v1` token exchange.
-- A transient NuGet.org outage. Re-run the workflow from the Actions
-  tab.
-- A package was already published at that version (`--skip-duplicate`
-  in the push command silently swallows this — it's usually a sign
-  someone manually published before the workflow ran, which shouldn't
-  happen).
+NuGet.org packages can be unlisted but not deleted.
 
-### Docs build fails in `mkdocs` strict mode
+1. Unlist the bad package version on NuGet.org.
+2. Delete the GitHub Release only if its page is misleading.
+3. Avoid deleting the tag unless the release record itself must be withdrawn.
+4. Fix the defect through a new pull request.
+5. Release a higher version. Never reuse a version that reached a package
+   feed.
 
-If your release adds new analyzer diagnostic doc pages, ensure:
+## Historical failure modes
 
-- Each new `docs/analyzers/NDLRXXX.md` exists.
-- Each new page has a nav entry in `mkdocs.yml` under the correct
-  analyzer subgroup.
-- Each new page has a row in `docs/analyzers/README.md`.
+- Forgetting to move analyzer rules before release.
+- Using prerelease text in Roslyn analyzer release headers.
+- Using `alpha-0003` instead of `alpha.3`.
+- Tagging a commit whose NBGV version contains a commit-height suffix.
+- Creating or pushing a release version commit directly on `main`.
+- Treating pull-request CI as proof that the exact merged `main` commit passed.
+- Releasing from a dirty repository.
 
-This is documented in `.claude/rules/generated/docs.md`. The `api/stable/*`
-warnings emitted by strict mode are pre-existing and expected locally;
-CI handles them with a placeholder step.
-
----
-
-## Historical gotchas (why this document exists)
-
-Every item here has bitten past releases. They're listed not to shame
-anybody, but so the next maintainer can recognize the failure mode:
-
-- **Forgetting the analyzer Unshipped→Shipped move.** Commits
-  `83ef38ab`, `6b7e1166`, `22bd5b64`, `6e0b08bb`, `22c7e284` are all
-  retroactive fixes or ship-catch-up commits. This is the single most
-  common release-day mistake, which is why
-  `scripts/release.ps1` now blocks on it.
-- **Wrong version header format.** Early releases used
-  `## Release <date>` or omitted the version entirely. The correct
-  format is `## Release <version>` with no date, no `v` prefix.
-- **Using `alpha-0026` instead of `alpha.26`.** The dot-separated form
-  is what `version.json`, `nbgv`, and the release workflow expect.
-  NuGet displays it differently in the web UI but the source of truth
-  uses the dot.
-- **Pushing to `origin/main` before CI runs.** Always wait for CI to
-  go green on the version-bump commit before the tag push. The release
-  script's CI gate enforces this for you.
-- **Releasing from a dirty working tree.** Early releases accidentally
-  included uncommitted changes in the version bump commit. The clean
-  tree gate catches this now.
-
----
+The current process converts each failure mode into an explicit gate.
 
 ## See also
 
-- [`RELEASING.md`](https://github.com/ncosentino/needlr/blob/main/RELEASING.md) — the
-  fast-lookup version at the repo root.
+- [`RELEASING.md`](https://github.com/ncosentino/needlr/blob/main/RELEASING.md)
 - [`scripts/release.ps1`](https://github.com/ncosentino/needlr/blob/main/scripts/release.ps1)
+- [`scripts/test-release.ps1`](https://github.com/ncosentino/needlr/blob/main/scripts/test-release.ps1)
 - [`.github/workflows/release.yml`](https://github.com/ncosentino/needlr/blob/main/.github/workflows/release.yml)
 - [`CHANGELOG.md`](https://github.com/ncosentino/needlr/blob/main/CHANGELOG.md)
-- [Roslyn analyzer release tracking docs](https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md)
+- [Roslyn analyzer release tracking](https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md)

--- a/scripts/release.ps1
+++ b/scripts/release.ps1
@@ -54,7 +54,7 @@ function Ensure-Nbgv {
   $toolName = if ($IsWindows) { 'nbgv.exe' } else { 'nbgv' }
   $toolsPath = Join-Path $toolsDir $toolName
   if (Test-Path $toolsPath) {
-    $env:Path = "$toolsDir$([System.IO.Path]::PathSeparator)$env:Path"
+    $env:PATH = "$toolsDir$([System.IO.Path]::PathSeparator)$env:PATH"
     return
   }
 

--- a/scripts/release.ps1
+++ b/scripts/release.ps1
@@ -1,187 +1,304 @@
+<#
+.SYNOPSIS
+    Finalizes a Needlr release from an already-prepared commit on protected main.
+
+.DESCRIPTION
+    Validates the release version, changelog, analyzer tracking, synchronized main
+    branch, same-commit CI, and package contents before creating and pushing only
+    the version tag. Version and release-note changes must already be merged through
+    a pull request.
+
+.PARAMETER Version
+    Exact semantic version to release, without the leading v.
+
+.PARAMETER Prerelease
+    Pre-release label used to calculate the next version from existing tags.
+
+.PARAMETER Base
+    Base X.Y.Z version used with Prerelease.
+
+.PARAMETER DryRun
+    Validates prepared release metadata and prints the tag-only actions without
+    requiring main, querying CI, packing, creating a tag, or pushing.
+#>
 param(
-  [Parameter(Position=0)][string]$Version,
+  [Parameter(Position = 0)][string]$Version,
   [string]$Prerelease,
   [string]$Base,
-  [switch]$DryRun,
-  [switch]$SkipCiCheck
+  [switch]$DryRun
 )
 
 $ErrorActionPreference = 'Stop'
 
-# Move to repo root (assumes scripts/ is directly under root)
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
-Set-Location -Path (Join-Path $scriptDir '..')
+$repoRoot = [System.IO.Path]::GetFullPath((Join-Path $scriptDir '..'))
+Set-Location -Path $repoRoot
 
 function Ensure-CleanRepo {
-  git diff --quiet
+  $status = & git status --porcelain 2>&1
   if ($LASTEXITCODE -ne 0) {
-    throw "Working tree not clean. Commit or stash first."
+    throw "Could not inspect the working tree.`n$($status | Out-String)"
+  }
+  if ($status) {
+    throw "Working tree not clean. Commit or stash every tracked and untracked change first."
   }
 }
 
 function Ensure-Nbgv {
-  # Check if nbgv is in PATH or in dotnet tools folder
   $nbgvPath = Get-Command nbgv -ErrorAction SilentlyContinue
-  if (-not $nbgvPath) {
-    $toolsPath = Join-Path $env:USERPROFILE ".dotnet\tools\nbgv.exe"
-    if (Test-Path $toolsPath) {
-      # Add to PATH for this session
-      $env:Path = "$env:USERPROFILE\.dotnet\tools;$env:Path"
-    } else {
-      throw "NBGV CLI not found. Install with: dotnet tool install -g nbgv"
-    }
+  if ($nbgvPath) {
+    return
+  }
+
+  $toolsDir = Join-Path (Join-Path $HOME '.dotnet') 'tools'
+  $toolName = if ($IsWindows) { 'nbgv.exe' } else { 'nbgv' }
+  $toolsPath = Join-Path $toolsDir $toolName
+  if (Test-Path $toolsPath) {
+    $env:Path = "$toolsDir$([System.IO.Path]::PathSeparator)$env:Path"
+    return
+  }
+
+  throw "NBGV CLI not found. Install with: dotnet tool install -g nbgv"
+}
+
+function Update-OriginState {
+  $fetchOutput = & git fetch --quiet origin main --tags 2>&1
+  if ($LASTEXITCODE -ne 0) {
+    throw "Could not refresh origin/main and release tags.`n$($fetchOutput | Out-String)"
   }
 }
 
 function Get-CurrentBaseVersion {
-  # Use SemVer2 and strip pre-release/build metadata
-  $semver = (& nbgv get-version -v SemVer2).Trim()  # e.g., 0.0.1-alpha.3 or 0.0.1
-  if (-not $semver) { throw "Could not get version from NBGV." }
-  return ($semver -split '[-+]')[0]                  # -> 0.0.1
+  $semver = (& nbgv get-version -v SemVer2 2>&1 | Out-String).Trim()
+  if ($LASTEXITCODE -ne 0 -or -not $semver) {
+    throw "Could not get the current version from NBGV."
+  }
+
+  return ($semver -split '[-+]')[0]
 }
 
-function Next-PrereleaseVersion([string]$base, [string]$label) {
-  # Find tags like v<base>-<label>.<N> and increment N
-  $pattern = "v$([regex]::Escape($base))-$([regex]::Escape($label)).*"
-  $tags = (& git tag --list $pattern) -split "`n" | Where-Object { $_ -ne "" }
+function Get-NextPrereleaseVersion {
+  param(
+    [Parameter(Mandatory = $true)][string]$BaseVersion,
+    [Parameter(Mandatory = $true)][string]$Label
+  )
+
+  if ($BaseVersion -notmatch '^\d+\.\d+\.\d+$') {
+    throw "Base version '$BaseVersion' must use X.Y.Z format."
+  }
+  if ($Label -notmatch '^[0-9A-Za-z-]+$') {
+    throw "Prerelease label '$Label' contains unsupported characters."
+  }
+
+  $pattern = "v$([regex]::Escape($BaseVersion))-$([regex]::Escape($Label)).*"
+  $tags = @(& git tag --list $pattern | Where-Object { $_ })
+  if ($LASTEXITCODE -ne 0) {
+    throw "Could not enumerate release tags."
+  }
 
   $max = 0
-  foreach ($t in $tags) {
-    if ($t -match "^v$([regex]::Escape($base))-$([regex]::Escape($label))\.(\d+)$") {
-      $n = [int]$Matches[1]
-      if ($n -gt $max) { $max = $n }
-    }
-  }
-  return "$base-$label.$([int]($max + 1))"
-}
-
-# ---- main ----
-Ensure-Nbgv
-
-if (-not $Version) {
-  if (-not $Prerelease) {
-    throw "Usage: release.ps1 <version> OR release.ps1 -Prerelease <label> [-Base <X.Y.Z>] [--DryRun]"
-  }
-  $base = if ($Base) { $Base } else { Get-CurrentBaseVersion }
-  $Version = Next-PrereleaseVersion -base $base -label $Prerelease
-}
-
-Write-Host "Preparing release for version: $Version"
-
-# Check for changelog entry
-$changelogPath = Join-Path $PSScriptRoot "..\CHANGELOG.md"
-$changelogEntry = $null
-if (Test-Path $changelogPath) {
-  $content = Get-Content $changelogPath -Raw
-  # Extract section for this version
-  if ($content -match "(?ms)^## \[$([regex]::Escape($Version))\].*?(?=^## \[|\z)") {
-    $changelogEntry = $Matches[0].Trim()
-  }
-}
-
-if (-not $DryRun) {
-  Ensure-CleanRepo
-  $currentBranch = (git branch --show-current).Trim()
-  if ($currentBranch -ne 'main') {
-    throw "Releases must run from the local main branch. Current branch: $currentBranch"
-  }
-}
-
-# CI gate: verify all check runs on HEAD are green before releasing
-if (-not $SkipCiCheck -and -not $DryRun) {
-  $sha = (git rev-parse HEAD).Trim()
-  $remoteUrl = (git remote get-url origin).Trim()
-  $repoSlug = if ($remoteUrl -match 'github\.com[:/](.+?)(?:\.git)?$') { $Matches[1] } else { $null }
-
-  if (-not $repoSlug) {
-    Write-Host "WARNING: Could not parse repo slug from remote URL. Skipping CI check." -ForegroundColor Yellow
-  } else {
-    Write-Host "Checking CI status for $repoSlug @ $sha ..." -ForegroundColor Cyan
-
-    $ghCheck = Get-Command gh -ErrorAction SilentlyContinue
-    if (-not $ghCheck) {
-      Write-Host "WARNING: gh CLI not found. Skipping CI check. Install gh to enable this gate." -ForegroundColor Yellow
-    } else {
-      $runsJson = gh api "repos/$repoSlug/commits/$sha/check-runs" --paginate --jq '.check_runs[] | {name: .name, status: .status, conclusion: .conclusion}' 2>&1
-      if ($LASTEXITCODE -ne 0) {
-        Write-Host "WARNING: Could not retrieve check runs (API error). Skipping CI check." -ForegroundColor Yellow
-      } else {
-        $runs = $runsJson | ForEach-Object { $_ | ConvertFrom-Json }
-        $notGreen = $runs | Where-Object {
-          $_.status -ne 'completed' -or ($_.conclusion -notin @('success', 'skipped', 'neutral'))
-        }
-        if ($notGreen) {
-          Write-Host "BLOCKED: CI is not fully green on HEAD ($sha)" -ForegroundColor Red
-          $notGreen | ForEach-Object {
-            $marker = if ($_.status -ne 'completed') { "[$($_.status)]" } else { "[$($_.conclusion)]" }
-            Write-Host "  $marker  $($_.name)" -ForegroundColor Yellow
-          }
-          throw "Fix failing CI checks before releasing. Use -SkipCiCheck to override."
-        }
-        Write-Host "CI gate passed ($($runs.Count) check(s) green)." -ForegroundColor Green
+  foreach ($tag in $tags) {
+    if ($tag -match "^v$([regex]::Escape($BaseVersion))-$([regex]::Escape($Label))\.(\d+)$") {
+      $counter = [int]$Matches[1]
+      if ($counter -gt $max) {
+        $max = $counter
       }
     }
   }
+
+  return "$BaseVersion-$Label.$($max + 1)"
 }
 
-# Analyzer release tracking gate: block if any analyzer project has unshipped
-# rules that have not been moved into AnalyzerReleases.Shipped.md under a new
-# "## Release <version>" header. Microsoft.CodeAnalysis.Analyzers enforces
-# RS2000/RS2001/RS2002 against these files, so forgetting this step ships a
-# broken package to consumers. This runs before pack so the release script
-# refuses to proceed — no maintainer (or LLM assistant) can forget.
-function Test-UnshippedAnalyzerRules {
+function Get-RepositorySlug {
+  $remoteUrl = (& git remote get-url origin 2>&1 | Out-String).Trim()
+  if ($LASTEXITCODE -ne 0) {
+    throw "Could not read the origin remote URL."
+  }
+
+  if ($remoteUrl -notmatch 'github\.com[:/](?<slug>[^/:\s]+/[^/\s]+?)(?:\.git)?$') {
+    throw "Could not parse a GitHub repository slug from origin URL '$remoteUrl'."
+  }
+
+  return $Matches['slug']
+}
+
+function Ensure-LocalMainMatchesOrigin {
+  $currentBranch = (& git branch --show-current 2>&1 | Out-String).Trim()
+  if ($LASTEXITCODE -ne 0) {
+    throw "Could not determine the current branch."
+  }
+  if ($currentBranch -ne 'main') {
+    throw "Release finalization must run from local main. Current branch: $currentBranch"
+  }
+
+  $headSha = (& git rev-parse HEAD 2>&1 | Out-String).Trim()
+  if ($LASTEXITCODE -ne 0) {
+    throw "Could not resolve local HEAD."
+  }
+
+  $originMainSha = (& git rev-parse origin/main 2>&1 | Out-String).Trim()
+  if ($LASTEXITCODE -ne 0) {
+    throw "Could not resolve origin/main after fetching it."
+  }
+
+  if ($headSha -ne $originMainSha) {
+    throw "Local main must exactly match origin/main before release finalization. Local: $headSha; origin/main: $originMainSha"
+  }
+}
+
+function Get-ChangelogEntry {
+  param(
+    [Parameter(Mandatory = $true)][string]$ReleaseVersion
+  )
+
+  $changelogPath = Join-Path $repoRoot 'CHANGELOG.md'
+  if (-not (Test-Path $changelogPath)) {
+    throw "CHANGELOG.md was not found."
+  }
+
+  $content = Get-Content $changelogPath -Raw
+  if ($content -match "(?ms)^## \[$([regex]::Escape($ReleaseVersion))\].*?(?=^## \[|\z)") {
+    return $Matches[0].Trim()
+  }
+
+  throw "CHANGELOG.md does not contain an exact '## [$ReleaseVersion]' release section."
+}
+
+function Ensure-VersionPrepared {
+  param(
+    [Parameter(Mandatory = $true)][string]$ReleaseVersion
+  )
+
+  if ($ReleaseVersion -notmatch '^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$') {
+    throw "Version '$ReleaseVersion' is not a supported semantic version without a leading v."
+  }
+
+  $versionJsonPath = Join-Path $repoRoot 'version.json'
+  $versionJson = Get-Content $versionJsonPath -Raw | ConvertFrom-Json
+  $declaredVersion = [string]$versionJson.version
+  if ($declaredVersion -ne $ReleaseVersion) {
+    throw "version.json contains '$declaredVersion', not '$ReleaseVersion'. Prepare and merge the version change through a pull request first."
+  }
+
+  $nbgvVersion = (& nbgv get-version -v SemVer2 2>&1 | Out-String).Trim()
+  if ($LASTEXITCODE -ne 0 -or -not $nbgvVersion) {
+    throw "Could not resolve the semantic version from NBGV."
+  }
+  if ($nbgvVersion -ne $ReleaseVersion) {
+    throw "NBGV resolves '$nbgvVersion', not '$ReleaseVersion'. The release tag must point at the exact merged version-preparation commit."
+  }
+}
+
+function Ensure-TagAvailable {
+  param(
+    [Parameter(Mandatory = $true)][string]$ReleaseVersion
+  )
+
+  $tagName = "v$ReleaseVersion"
+  $localTag = @(& git tag --list $tagName | Where-Object { $_ })
+  if ($LASTEXITCODE -ne 0) {
+    throw "Could not inspect local tags."
+  }
+  if ($localTag.Count -gt 0) {
+    throw "Local tag '$tagName' already exists. Never reuse a release version."
+  }
+
+  $remoteTag = @(& git ls-remote --tags origin "refs/tags/$tagName" 2>&1 | Where-Object { $_ })
+  if ($LASTEXITCODE -ne 0) {
+    throw "Could not inspect origin for tag '$tagName'."
+  }
+  if ($remoteTag.Count -gt 0) {
+    throw "Remote tag '$tagName' already exists. Never reuse a release version."
+  }
+}
+
+function Ensure-SuccessfulMainCi {
+  $ghCommand = Get-Command gh -ErrorAction SilentlyContinue
+  if (-not $ghCommand) {
+    throw "gh CLI not found. Install and authenticate gh before releasing."
+  }
+
+  $repoSlug = Get-RepositorySlug
+  $sha = (& git rev-parse HEAD 2>&1 | Out-String).Trim()
+  if ($LASTEXITCODE -ne 0) {
+    throw "Could not resolve HEAD for the CI gate."
+  }
+
+  Write-Host "Checking successful main CI for $repoSlug @ $sha ..." -ForegroundColor Cyan
+  $uri = "repos/$repoSlug/actions/workflows/ci.yml/runs"
+  $runsJson = & gh api --method GET $uri -f branch=main -f event=push -f "head_sha=$sha" -F per_page=100 2>&1
+  if ($LASTEXITCODE -ne 0) {
+    throw "Could not retrieve main CI workflow runs.`n$($runsJson | Out-String)"
+  }
+
+  try {
+    $response = ($runsJson | Out-String) | ConvertFrom-Json
+  } catch {
+    throw "GitHub returned invalid workflow-run JSON: $($_.Exception.Message)"
+  }
+
+  $run = @($response.workflow_runs) |
+    Where-Object {
+      $_.head_sha -eq $sha -and
+      $_.head_branch -eq 'main' -and
+      $_.event -eq 'push'
+    } |
+    Sort-Object { [datetime]$_.created_at } -Descending |
+    Select-Object -First 1
+
+  if (-not $run) {
+    throw "No ci.yml push run exists for main commit $sha."
+  }
+  if ($run.status -ne 'completed' -or $run.conclusion -ne 'success') {
+    throw "Main CI must complete successfully before release finalization. Status: $($run.status); conclusion: $($run.conclusion); run: $($run.html_url)"
+  }
+
+  Write-Host "Same-commit main CI gate passed: $($run.html_url)" -ForegroundColor Green
+}
+
+function Get-UnshippedAnalyzerRules {
   param(
     [Parameter(Mandatory = $true)][string]$SrcDir
   )
 
-  $unshippedFiles = Get-ChildItem -Path $SrcDir -Filter "AnalyzerReleases.Unshipped.md" -Recurse -File
+  $unshippedFiles = Get-ChildItem -Path $SrcDir -Filter 'AnalyzerReleases.Unshipped.md' -Recurse -File
   $filesWithRules = @()
 
   foreach ($file in $unshippedFiles) {
-    $content = Get-Content -Path $file.FullName
-    # A "rule row" is any line starting with "NDLR" — that's the Needlr
-    # analyzer prefix used across all diagnostic IDs (NDLRCOR, NDLRGEN,
-    # NDLRLOG, NDLRSIG, NDLRHTTP, etc.). Comment lines begin with ";" and
-    # header lines begin with "#" or "-".
-    $ruleLines = $content | Where-Object { $_ -match '^NDLR' }
-    if ($ruleLines.Count -gt 0) {
-      $relativePath = $file.FullName.Replace((Resolve-Path "$SrcDir\..").Path, '').TrimStart('\', '/')
-      $filesWithRules += [PSCustomObject]@{
-        Path  = $relativePath
-        Rules = $ruleLines
-      }
+    $ruleLines = @(Get-Content -Path $file.FullName | Where-Object { $_ -match '^NDLR' })
+    if ($ruleLines.Count -eq 0) {
+      continue
+    }
+
+    $relativePath = $file.FullName.Replace((Resolve-Path "$SrcDir\..").Path, '').TrimStart('\', '/')
+    $filesWithRules += [PSCustomObject]@{
+      Path = $relativePath
+      Rules = $ruleLines
     }
   }
 
-  return , $filesWithRules
+  return ,$filesWithRules
 }
 
-Write-Host "Checking analyzer release tracking..." -ForegroundColor Cyan
-$srcDir = Join-Path $PSScriptRoot "..\src"
-$unshippedAnalyzers = Test-UnshippedAnalyzerRules -SrcDir $srcDir
-if ($unshippedAnalyzers.Count -gt 0) {
-  # RS2007 rejects pre-release labels in the release header, so the canonical
-  # header uses only the base version (e.g. "0.0.2") and all prereleases of
-  # that base share a single section. See docs/releasing.md for rationale.
-  $baseVersion = ($Version -split '[-+]')[0]
+function Ensure-AnalyzerReleaseTracking {
+  param(
+    [Parameter(Mandatory = $true)][string]$ReleaseVersion
+  )
 
+  Write-Host "Checking analyzer release tracking..." -ForegroundColor Cyan
+  $srcDir = Join-Path $repoRoot 'src'
+  $unshippedAnalyzers = Get-UnshippedAnalyzerRules -SrcDir $srcDir
+  if ($unshippedAnalyzers.Count -eq 0) {
+    Write-Host "Analyzer release tracking gate passed." -ForegroundColor Green
+    return
+  }
+
+  $baseVersion = ($ReleaseVersion -split '[-+]')[0]
   Write-Host "BLOCKED: analyzer projects have unshipped rules." -ForegroundColor Red
   Write-Host ""
-  Write-Host "Before releasing, move each rule below from its AnalyzerReleases.Unshipped.md" -ForegroundColor Yellow
-  Write-Host "file into the matching AnalyzerReleases.Shipped.md under the existing header:" -ForegroundColor Yellow
+  Write-Host "Move each rule below into the matching AnalyzerReleases.Shipped.md" -ForegroundColor Yellow
+  Write-Host "under the base-version header before opening the release-preparation PR:" -ForegroundColor Yellow
   Write-Host "  ## Release $baseVersion" -ForegroundColor Yellow
-  Write-Host ""
-  Write-Host "(Microsoft.CodeAnalysis.Analyzers rule RS2007 rejects pre-release labels" -ForegroundColor Yellow
-  Write-Host "in the header, so '## Release $Version' will not build. Use the base" -ForegroundColor Yellow
-  Write-Host "version only and append new rules to the existing release section, keeping" -ForegroundColor Yellow
-  Write-Host "rule IDs in alphanumeric order.)" -ForegroundColor Yellow
-  Write-Host ""
-  Write-Host "Then delete the rule rows from Unshipped.md (keep the comment header," -ForegroundColor Yellow
-  Write-Host "### New Rules heading, table header row, and separator row)." -ForegroundColor Yellow
-  Write-Host ""
-  Write-Host "Commit message convention:" -ForegroundColor Yellow
-  Write-Host "  chore: ship analyzers for $Version" -ForegroundColor Yellow
   Write-Host ""
   Write-Host "Pending unshipped rules:" -ForegroundColor Red
   foreach ($entry in $unshippedAnalyzers) {
@@ -193,15 +310,59 @@ if ($unshippedAnalyzers.Count -gt 0) {
     }
   }
   Write-Host ""
-  throw "Fix unshipped analyzer rules before releasing. See docs/releasing.md for details."
-}
-Write-Host "Analyzer release tracking gate passed." -ForegroundColor Green
 
-# Build and pack validation - MUST pass before any release actions
-# Uses solution-level pack which lets MSBuild parallelize across projects
-# instead of the previous per-project sequential loop (~50 projects × ~10s each = ~8 min → ~1 min).
+  throw "Fix unshipped analyzer rules in the release-preparation pull request. See docs/releasing.md."
+}
+
+if ($Version -and $Prerelease) {
+  throw "Specify either Version or Prerelease, not both."
+}
+if ($Base -and -not $Prerelease) {
+  throw "Base can only be used with Prerelease."
+}
+
+Ensure-CleanRepo
+Ensure-Nbgv
+Update-OriginState
+
+if (-not $Version) {
+  if (-not $Prerelease) {
+    throw "Usage: release.ps1 <version> OR release.ps1 -Prerelease <label> [-Base <X.Y.Z>] [-DryRun]"
+  }
+
+  $baseVersion = if ($Base) { $Base } else { Get-CurrentBaseVersion }
+  $Version = Get-NextPrereleaseVersion -BaseVersion $baseVersion -Label $Prerelease
+}
+
+Write-Host "Finalizing release for version: $Version"
+
+Ensure-VersionPrepared -ReleaseVersion $Version
+$changelogEntry = Get-ChangelogEntry -ReleaseVersion $Version
+Ensure-AnalyzerReleaseTracking -ReleaseVersion $Version
+Ensure-TagAvailable -ReleaseVersion $Version
+
+if ($DryRun) {
+  Write-Host ""
+  Write-Host "=== CHANGELOG ENTRY ===" -ForegroundColor Cyan
+  Write-Host $changelogEntry -ForegroundColor Green
+  Write-Host ""
+  Write-Host "=== ACTIONS ===" -ForegroundColor Cyan
+  Write-Host "[DRY RUN] A real run would additionally require:"
+  Write-Host "  local main exactly matching origin/main"
+  Write-Host "  successful ci.yml push CI for that exact commit"
+  Write-Host "  successful solution pack and package-content validation"
+  Write-Host "[DRY RUN] It would then run:"
+  Write-Host "  nbgv tag"
+  Write-Host "  git push origin refs/tags/v$Version"
+  Write-Host "[DRY RUN] No branch commit or branch push will be performed."
+  exit 0
+}
+
+Ensure-LocalMainMatchesOrigin
+Ensure-SuccessfulMainCi
+
 Write-Host "Validating build and pack (solution-level, parallel)..." -ForegroundColor Cyan
-$slnx = Join-Path $PSScriptRoot "..\src\NexusLabs.Needlr.slnx"
+$slnx = Join-Path (Join-Path $repoRoot 'src') 'NexusLabs.Needlr.slnx'
 $packResult = & dotnet pack $slnx -c Release -v q 2>&1
 if ($LASTEXITCODE -ne 0) {
   Write-Host "  Pack FAILED" -ForegroundColor Red
@@ -210,92 +371,33 @@ if ($LASTEXITCODE -ne 0) {
 }
 Write-Host "Build and pack validation passed." -ForegroundColor Green
 
-# Assert nuspec contents for key packages
 Write-Host "Validating package contents (nuspec assertions)..." -ForegroundColor Cyan
-& (Join-Path $PSScriptRoot "test-packages.ps1") -NoBuild
+& (Join-Path $PSScriptRoot 'test-packages.ps1') -NoBuild
 if ($LASTEXITCODE -ne 0) {
   throw "Package content validation failed. Fix the packaging issue before releasing."
 }
 Write-Host "Package content validation passed." -ForegroundColor Green
 
-if ($DryRun) {
-  Write-Host ""
-  Write-Host "=== CHANGELOG ENTRY ===" -ForegroundColor Cyan
-  if ($changelogEntry) {
-    Write-Host $changelogEntry -ForegroundColor Green
-  } else {
-    Write-Host "[WARNING] No changelog entry found for version $Version" -ForegroundColor Yellow
-    Write-Host "Consider running: python skills/changelog-generator/scripts/generate.py --from <prev-tag> --to HEAD --version $Version" -ForegroundColor Yellow
-  }
-  Write-Host ""
-  Write-Host "=== ACTIONS ===" -ForegroundColor Cyan
-  Write-Host "[DRY RUN] Would run:"
-  Write-Host "  nbgv set-version $Version"
-  Write-Host "  git commit -am 'chore: bump version to $Version'"
-  Write-Host "  git pull --rebase && git push origin HEAD"
-  Write-Host "  nbgv tag"
-  Write-Host "  git push origin refs/tags/v$Version"
-  exit 0
-}
-
-& nbgv set-version $Version
-if ($LASTEXITCODE -ne 0) {
-  throw "nbgv set-version failed. Aborting — no commit, no tag, no push."
-}
-
-# The repo's pre-commit hook (genesis self-assessment gate) blocks commits
-# unless GENESIS_PRECOMMIT_ACK=true is set. The release script is a scripted
-# version bump with no human-authored code changes, so the gate doesn't apply.
-# Scope the env var to this commit only — do not leak it to the rest of the
-# session or subprocesses beyond this block.
-$previousAck = $env:GENESIS_PRECOMMIT_ACK
-try {
-  $env:GENESIS_PRECOMMIT_ACK = "true"
-  git commit -am "chore: bump version to $Version"
-  if ($LASTEXITCODE -ne 0) {
-    throw "git commit failed. Aborting — no tag, no push. Working tree still has the version bump; inspect with 'git status' and 'git diff'."
-  }
-} finally {
-  if ($null -eq $previousAck) {
-    Remove-Item Env:GENESIS_PRECOMMIT_ACK -ErrorAction SilentlyContinue
-  } else {
-    $env:GENESIS_PRECOMMIT_ACK = $previousAck
-  }
-}
-
-$mainPushed = $false
-for ($attempt = 1; $attempt -le 3; $attempt++) {
-  git pull --rebase
-  if ($LASTEXITCODE -ne 0) {
-    throw "Rebase failed before release. Resolve the working tree; no tag was created."
-  }
-
-  git push origin HEAD
-  if ($LASTEXITCODE -eq 0) {
-    $mainPushed = $true
-    break
-  }
-
-  if ($attempt -lt 3) {
-    Write-Host "Main push raced with another commit; retrying ($attempt/3)." -ForegroundColor Yellow
-    Start-Sleep -Seconds 2
-  }
-}
-
-if (-not $mainPushed) {
-  throw "Version bump commit could not be pushed after 3 attempts. No tag was created."
-}
-Write-Host "Version bump committed to main." -ForegroundColor Green
+Ensure-CleanRepo
+Update-OriginState
+Ensure-LocalMainMatchesOrigin
+Ensure-TagAvailable -ReleaseVersion $Version
 
 & nbgv tag
 if ($LASTEXITCODE -ne 0) {
-  throw "nbgv tag failed after the version commit reached main. Inspect tags with 'git tag --list v$Version' before re-running."
+  throw "nbgv tag failed. No remote changes were made."
 }
 
-git push origin "refs/tags/v$Version"
+$tagName = "v$Version"
+$headSha = (& git rev-parse HEAD 2>&1 | Out-String).Trim()
+$tagSha = (& git rev-parse "refs/tags/$tagName^{commit}" 2>&1 | Out-String).Trim()
+if ($LASTEXITCODE -ne 0 -or $tagSha -ne $headSha) {
+  throw "Local tag '$tagName' does not resolve to HEAD. Inspect and remove the local tag before retrying."
+}
+
+git push origin "refs/tags/$tagName"
 if ($LASTEXITCODE -ne 0) {
-  throw "Tag push failed for v$Version. The version commit is on main but the release was not triggered."
+  throw "Tag push failed for $tagName. No branch commit was pushed. Inspect the local tag before retrying."
 }
-Write-Host "Tag v$Version pushed — release.yml is waiting for same-commit main CI." -ForegroundColor Green
 
-Write-Host "Tagged and pushed v$Version"
+Write-Host "Tag $tagName pushed. release.yml will revalidate same-commit main CI before publishing." -ForegroundColor Green

--- a/scripts/test-release.ps1
+++ b/scripts/test-release.ps1
@@ -57,8 +57,17 @@ function Assert-Contains {
     )
 
     if (-not $Content.Contains($Expected)) {
-        throw "$Message Missing '$Expected'."
+        throw "$Message Missing '$Expected'. Actual output:`n$Content"
     }
+}
+
+function ConvertTo-PlainOutput {
+    param(
+        [Parameter(Mandatory = $true)]$Output
+    )
+
+    $text = $Output | Out-String
+    return [regex]::Replace($text, "`e\[[0-?]*[ -/]*[@-~]", '')
 }
 
 function Invoke-Git {
@@ -190,14 +199,16 @@ exit 0
         if ($LASTEXITCODE -eq 0) {
             throw 'Release dry run accepted a version that does not match version.json.'
         }
-        Assert-Contains -Content ($mismatchOutput | Out-String) -Expected "version.json contains '$releaseVersion', not '1.2.3-alpha.5'" -Message 'Version mismatch did not fail explicitly.'
+        $mismatchText = ConvertTo-PlainOutput -Output $mismatchOutput
+        Assert-Contains -Content $mismatchText -Expected 'version.json contains' -Message 'Version mismatch did not fail explicitly.'
+        Assert-Contains -Content $mismatchText -Expected '1.2.3-alpha.5' -Message 'Version mismatch did not report the requested version.'
 
         $dryRunOutput = & $pwsh -NoProfile -File $workReleaseScript -Version $releaseVersion -DryRun 2>&1
         if ($LASTEXITCODE -ne 0) {
             throw "Release dry run failed.`n$($dryRunOutput | Out-String)"
         }
 
-        $dryRunText = $dryRunOutput | Out-String
+        $dryRunText = ConvertTo-PlainOutput -Output $dryRunOutput
         Assert-Contains -Content $dryRunText -Expected 'git push origin refs/tags/v1.2.3-alpha.4' -Message 'Dry run did not report the tag push.'
         Assert-Contains -Content $dryRunText -Expected 'No branch commit or branch push will be performed.' -Message 'Dry run did not state the protected-main invariant.'
 
@@ -209,7 +220,7 @@ exit 0
         if ($LASTEXITCODE -eq 0) {
             throw 'Release finalization succeeded outside local main.'
         }
-        Assert-Contains -Content ($nonMainOutput | Out-String) -Expected 'Release finalization must run from local main.' -Message 'Non-main finalization did not fail explicitly.'
+        Assert-Contains -Content (ConvertTo-PlainOutput -Output $nonMainOutput) -Expected 'Release finalization must run from local main.' -Message 'Non-main finalization did not fail explicitly.'
         Invoke-Git -Arguments @('switch', 'main') -FailureMessage 'Could not return to fixture main.' | Out-Null
 
         $env:TEST_RELEASE_CI_CONCLUSION = 'failure'
@@ -217,7 +228,7 @@ exit 0
         if ($LASTEXITCODE -eq 0) {
             throw 'Release finalization succeeded with failed main CI.'
         }
-        Assert-Contains -Content ($failedCiOutput | Out-String) -Expected 'Main CI must complete successfully before release finalization.' -Message 'Failed CI did not block finalization explicitly.'
+        Assert-Contains -Content (ConvertTo-PlainOutput -Output $failedCiOutput) -Expected 'Main CI must complete successfully before release finalization.' -Message 'Failed CI did not block finalization explicitly.'
         $env:TEST_RELEASE_CI_CONCLUSION = 'success'
 
         $tagAfterFailures = Invoke-Git -Arguments @('ls-remote', '--tags', 'origin', "refs/tags/v$releaseVersion") -FailureMessage 'Could not inspect fixture tags after failed finalization attempts.'

--- a/scripts/test-release.ps1
+++ b/scripts/test-release.ps1
@@ -92,7 +92,7 @@ $workScriptsPath = Join-Path $workPath 'scripts'
 $workSrcPath = Join-Path $workPath 'src'
 $workAnalyzerPath = Join-Path $workSrcPath 'TestAnalyzer'
 $workReleaseScript = Join-Path $workScriptsPath 'release.ps1'
-$previousPath = $env:Path
+$previousPath = $env:PATH
 $previousVersion = $env:TEST_RELEASE_VERSION
 $previousSha = $env:TEST_RELEASE_SHA
 $previousCiConclusion = $env:TEST_RELEASE_CI_CONCLUSION
@@ -192,7 +192,7 @@ exit 0
         $env:TEST_RELEASE_VERSION = $releaseVersion
         $env:TEST_RELEASE_SHA = $expectedSha
         $env:TEST_RELEASE_CI_CONCLUSION = 'success'
-        $env:Path = "$shimPath$([System.IO.Path]::PathSeparator)$previousPath"
+        $env:PATH = "$shimPath$([System.IO.Path]::PathSeparator)$previousPath"
 
         $pwsh = (Get-Command pwsh -ErrorAction Stop).Source
         $mismatchOutput = & $pwsh -NoProfile -File $workReleaseScript -Version '1.2.3-alpha.5' -DryRun 2>&1
@@ -256,7 +256,7 @@ exit 0
 
     Write-Host 'Release script validation passed.' -ForegroundColor Green
 } finally {
-    $env:Path = $previousPath
+    $env:PATH = $previousPath
     if ($null -eq $previousVersion) {
         Remove-Item Env:TEST_RELEASE_VERSION -ErrorAction SilentlyContinue
     } else {

--- a/scripts/test-release.ps1
+++ b/scripts/test-release.ps1
@@ -1,0 +1,265 @@
+<#
+.SYNOPSIS
+    Validates that release.ps1 finalizes releases by pushing only a tag.
+
+.DESCRIPTION
+    Creates an isolated local Git remote and prepared main commit, runs both the
+    dry-run and real release paths with command shims, and proves that origin/main
+    remains unchanged while the expected tag is pushed.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$releaseScript = Join-Path $scriptDir 'release.ps1'
+$releaseSource = Get-Content $releaseScript -Raw
+
+$forbiddenPatterns = @(
+    @{ Pattern = '(?im)^\s*&?\s*nbgv\s+set-version\b'; Description = 'nbgv set-version' },
+    @{ Pattern = '(?im)^\s*&?\s*git\s+commit\b'; Description = 'git commit' },
+    @{ Pattern = '(?im)^\s*&?\s*git\s+pull\b'; Description = 'git pull' },
+    @{ Pattern = '(?im)^\s*&?\s*git\s+push\b(?!\s+origin\s+"refs/tags/\$tagName"\s*$)'; Description = 'a non-tag push' }
+)
+
+foreach ($forbidden in $forbiddenPatterns) {
+    if ($releaseSource -match $forbidden.Pattern) {
+        throw "release.ps1 contains forbidden release behavior: $($forbidden.Description)."
+    }
+}
+
+$tokens = $null
+$parseErrors = $null
+[void][System.Management.Automation.Language.Parser]::ParseFile(
+    $releaseScript,
+    [ref]$tokens,
+    [ref]$parseErrors)
+if ($parseErrors.Count -gt 0) {
+    throw "release.ps1 has PowerShell parse errors: $($parseErrors.Message -join '; ')"
+}
+
+function Assert-Equal {
+    param(
+        [Parameter(Mandatory = $true)]$Expected,
+        [Parameter(Mandatory = $true)]$Actual,
+        [Parameter(Mandatory = $true)][string]$Message
+    )
+
+    if ($Expected -ne $Actual) {
+        throw "$Message Expected '$Expected', actual '$Actual'."
+    }
+}
+
+function Assert-Contains {
+    param(
+        [Parameter(Mandatory = $true)][string]$Content,
+        [Parameter(Mandatory = $true)][string]$Expected,
+        [Parameter(Mandatory = $true)][string]$Message
+    )
+
+    if (-not $Content.Contains($Expected)) {
+        throw "$Message Missing '$Expected'."
+    }
+}
+
+function Invoke-Git {
+    param(
+        [Parameter(Mandatory = $true)][string[]]$Arguments,
+        [Parameter(Mandatory = $true)][string]$FailureMessage
+    )
+
+    $output = & git @Arguments 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "$FailureMessage`n$($output | Out-String)"
+    }
+
+    return ,$output
+}
+
+$tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) "needlr-release-test-$([System.IO.Path]::GetRandomFileName())"
+$barePath = Join-Path (Join-Path (Join-Path $tempRoot 'github.com') 'ncosentino') 'needlr.git'
+$workPath = Join-Path $tempRoot 'work'
+$shimPath = Join-Path $tempRoot 'bin'
+$workScriptsPath = Join-Path $workPath 'scripts'
+$workSrcPath = Join-Path $workPath 'src'
+$workAnalyzerPath = Join-Path $workSrcPath 'TestAnalyzer'
+$workReleaseScript = Join-Path $workScriptsPath 'release.ps1'
+$previousPath = $env:Path
+$previousVersion = $env:TEST_RELEASE_VERSION
+$previousSha = $env:TEST_RELEASE_SHA
+$previousCiConclusion = $env:TEST_RELEASE_CI_CONCLUSION
+
+try {
+    New-Item -ItemType Directory -Force -Path (Split-Path -Parent $barePath), $shimPath | Out-Null
+    Invoke-Git -Arguments @('init', '--bare', $barePath) -FailureMessage 'Could not create the test remote.' | Out-Null
+
+    $remoteUri = ([System.Uri]::new($barePath, [System.UriKind]::Absolute)).AbsoluteUri
+    Invoke-Git -Arguments @('clone', $remoteUri, $workPath) -FailureMessage 'Could not clone the test remote.' | Out-Null
+
+    New-Item -ItemType Directory -Force -Path $workScriptsPath, $workAnalyzerPath | Out-Null
+
+    Copy-Item $releaseScript $workReleaseScript
+    Set-Content -Path (Join-Path $workScriptsPath 'test-packages.ps1') -Encoding utf8NoBOM -Value @'
+param([switch]$NoBuild)
+exit 0
+'@
+    Set-Content -Path (Join-Path $workSrcPath 'NexusLabs.Needlr.slnx') -Encoding utf8NoBOM -Value '<Solution />'
+    Set-Content -Path (Join-Path $workAnalyzerPath 'AnalyzerReleases.Unshipped.md') -Encoding utf8NoBOM -Value @'
+; Unshipped analyzer releases
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+'@
+
+    $releaseVersion = '1.2.3-alpha.4'
+    Set-Content -Path (Join-Path $workPath 'version.json') -Encoding utf8NoBOM -Value @"
+{
+  "version": "$releaseVersion"
+}
+"@
+    Set-Content -Path (Join-Path $workPath 'CHANGELOG.md') -Encoding utf8NoBOM -Value @"
+## [$releaseVersion] - 2030-01-01
+
+### Changed
+
+- Prepared protected-main release fixture.
+"@
+
+    if ($IsWindows) {
+        Set-Content -Path (Join-Path $shimPath 'nbgv.cmd') -Encoding ascii -Value @'
+@echo off
+if "%1"=="get-version" (
+  echo %TEST_RELEASE_VERSION%
+  exit /b 0
+)
+if "%1"=="tag" (
+  git tag v%TEST_RELEASE_VERSION%
+  exit /b %errorlevel%
+)
+exit /b 1
+'@
+        Set-Content -Path (Join-Path $shimPath 'dotnet.cmd') -Encoding ascii -Value "@echo off`r`nexit /b 0"
+        Set-Content -Path (Join-Path $shimPath 'gh.cmd') -Encoding ascii -Value @'
+@echo off
+echo {"workflow_runs":[{"head_sha":"%TEST_RELEASE_SHA%","head_branch":"main","event":"push","status":"completed","conclusion":"%TEST_RELEASE_CI_CONCLUSION%","html_url":"https://example.invalid/ci","created_at":"2030-01-01T00:00:00Z"}]}
+exit /b 0
+'@
+    } else {
+        Set-Content -Path (Join-Path $shimPath 'nbgv') -Encoding utf8NoBOM -Value @'
+#!/usr/bin/env sh
+if [ "$1" = "get-version" ]; then
+  printf '%s\n' "$TEST_RELEASE_VERSION"
+  exit 0
+fi
+if [ "$1" = "tag" ]; then
+  git tag "v$TEST_RELEASE_VERSION"
+  exit $?
+fi
+exit 1
+'@
+        Set-Content -Path (Join-Path $shimPath 'dotnet') -Encoding utf8NoBOM -Value "#!/usr/bin/env sh`nexit 0"
+        Set-Content -Path (Join-Path $shimPath 'gh') -Encoding utf8NoBOM -Value @'
+#!/usr/bin/env sh
+printf '%s\n' "{\"workflow_runs\":[{\"head_sha\":\"$TEST_RELEASE_SHA\",\"head_branch\":\"main\",\"event\":\"push\",\"status\":\"completed\",\"conclusion\":\"$TEST_RELEASE_CI_CONCLUSION\",\"html_url\":\"https://example.invalid/ci\",\"created_at\":\"2030-01-01T00:00:00Z\"}]}"
+exit 0
+'@
+        & chmod +x (Join-Path $shimPath 'nbgv') (Join-Path $shimPath 'dotnet') (Join-Path $shimPath 'gh')
+        if ($LASTEXITCODE -ne 0) {
+            throw 'Could not make release command shims executable.'
+        }
+    }
+
+    Push-Location $workPath
+    try {
+        Invoke-Git -Arguments @('switch', '-c', 'main') -FailureMessage 'Could not create fixture main.' | Out-Null
+        Invoke-Git -Arguments @('config', 'user.name', 'Needlr Release Test') -FailureMessage 'Could not configure fixture user name.' | Out-Null
+        Invoke-Git -Arguments @('config', 'user.email', 'release-test@example.invalid') -FailureMessage 'Could not configure fixture user email.' | Out-Null
+        Invoke-Git -Arguments @('add', '.') -FailureMessage 'Could not stage fixture files.' | Out-Null
+        Invoke-Git -Arguments @('commit', '-m', 'chore: prepare release') -FailureMessage 'Could not commit fixture files.' | Out-Null
+        Invoke-Git -Arguments @('push', '-u', 'origin', 'main') -FailureMessage 'Could not push fixture main.' | Out-Null
+
+        $expectedSha = (Invoke-Git -Arguments @('rev-parse', 'HEAD') -FailureMessage 'Could not resolve fixture HEAD.').Trim()
+        $env:TEST_RELEASE_VERSION = $releaseVersion
+        $env:TEST_RELEASE_SHA = $expectedSha
+        $env:TEST_RELEASE_CI_CONCLUSION = 'success'
+        $env:Path = "$shimPath$([System.IO.Path]::PathSeparator)$previousPath"
+
+        $pwsh = (Get-Command pwsh -ErrorAction Stop).Source
+        $mismatchOutput = & $pwsh -NoProfile -File $workReleaseScript -Version '1.2.3-alpha.5' -DryRun 2>&1
+        if ($LASTEXITCODE -eq 0) {
+            throw 'Release dry run accepted a version that does not match version.json.'
+        }
+        Assert-Contains -Content ($mismatchOutput | Out-String) -Expected "version.json contains '$releaseVersion', not '1.2.3-alpha.5'" -Message 'Version mismatch did not fail explicitly.'
+
+        $dryRunOutput = & $pwsh -NoProfile -File $workReleaseScript -Version $releaseVersion -DryRun 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            throw "Release dry run failed.`n$($dryRunOutput | Out-String)"
+        }
+
+        $dryRunText = $dryRunOutput | Out-String
+        Assert-Contains -Content $dryRunText -Expected 'git push origin refs/tags/v1.2.3-alpha.4' -Message 'Dry run did not report the tag push.'
+        Assert-Contains -Content $dryRunText -Expected 'No branch commit or branch push will be performed.' -Message 'Dry run did not state the protected-main invariant.'
+
+        $tagBeforeRelease = Invoke-Git -Arguments @('ls-remote', '--tags', 'origin', "refs/tags/v$releaseVersion") -FailureMessage 'Could not inspect fixture tags.'
+        Assert-Equal -Expected 0 -Actual $tagBeforeRelease.Count -Message 'Dry run created a remote tag.'
+
+        Invoke-Git -Arguments @('switch', '-c', 'release/test-finalization') -FailureMessage 'Could not create the non-main fixture branch.' | Out-Null
+        $nonMainOutput = & $pwsh -NoProfile -File $workReleaseScript -Version $releaseVersion 2>&1
+        if ($LASTEXITCODE -eq 0) {
+            throw 'Release finalization succeeded outside local main.'
+        }
+        Assert-Contains -Content ($nonMainOutput | Out-String) -Expected 'Release finalization must run from local main.' -Message 'Non-main finalization did not fail explicitly.'
+        Invoke-Git -Arguments @('switch', 'main') -FailureMessage 'Could not return to fixture main.' | Out-Null
+
+        $env:TEST_RELEASE_CI_CONCLUSION = 'failure'
+        $failedCiOutput = & $pwsh -NoProfile -File $workReleaseScript -Version $releaseVersion 2>&1
+        if ($LASTEXITCODE -eq 0) {
+            throw 'Release finalization succeeded with failed main CI.'
+        }
+        Assert-Contains -Content ($failedCiOutput | Out-String) -Expected 'Main CI must complete successfully before release finalization.' -Message 'Failed CI did not block finalization explicitly.'
+        $env:TEST_RELEASE_CI_CONCLUSION = 'success'
+
+        $tagAfterFailures = Invoke-Git -Arguments @('ls-remote', '--tags', 'origin', "refs/tags/v$releaseVersion") -FailureMessage 'Could not inspect fixture tags after failed finalization attempts.'
+        Assert-Equal -Expected 0 -Actual $tagAfterFailures.Count -Message 'A failed finalization attempt pushed a tag.'
+
+        $releaseOutput = & $pwsh -NoProfile -File $workReleaseScript -Version $releaseVersion 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            throw "Release finalization failed.`n$($releaseOutput | Out-String)"
+        }
+
+        $localHead = (Invoke-Git -Arguments @('rev-parse', 'HEAD') -FailureMessage 'Could not resolve local fixture main.').Trim()
+        $remoteMainLines = @(Invoke-Git -Arguments @('ls-remote', 'origin', 'refs/heads/main') -FailureMessage 'Could not resolve remote fixture main.')
+        $remoteTagLines = @(Invoke-Git -Arguments @('ls-remote', 'origin', "refs/tags/v$releaseVersion") -FailureMessage 'Could not resolve remote fixture tag.')
+        $remoteMain = $remoteMainLines[0].Split("`t")[0]
+        $remoteTag = $remoteTagLines[0].Split("`t")[0]
+        $commitCount = [int](Invoke-Git -Arguments @('rev-list', '--count', 'HEAD') -FailureMessage 'Could not count fixture commits.').Trim()
+
+        Assert-Equal -Expected $expectedSha -Actual $localHead -Message 'Release finalization changed local main.'
+        Assert-Equal -Expected $expectedSha -Actual $remoteMain -Message 'Release finalization changed origin/main.'
+        Assert-Equal -Expected $expectedSha -Actual $remoteTag -Message 'Release tag does not point at the prepared main commit.'
+        Assert-Equal -Expected 1 -Actual $commitCount -Message 'Release finalization created an unexpected commit.'
+    } finally {
+        Pop-Location
+    }
+
+    Write-Host 'Release script validation passed.' -ForegroundColor Green
+} finally {
+    $env:Path = $previousPath
+    if ($null -eq $previousVersion) {
+        Remove-Item Env:TEST_RELEASE_VERSION -ErrorAction SilentlyContinue
+    } else {
+        $env:TEST_RELEASE_VERSION = $previousVersion
+    }
+    if ($null -eq $previousSha) {
+        Remove-Item Env:TEST_RELEASE_SHA -ErrorAction SilentlyContinue
+    } else {
+        $env:TEST_RELEASE_SHA = $previousSha
+    }
+    if ($null -eq $previousCiConclusion) {
+        Remove-Item Env:TEST_RELEASE_CI_CONCLUSION -ErrorAction SilentlyContinue
+    } else {
+        $env:TEST_RELEASE_CI_CONCLUSION = $previousCiConclusion
+    }
+    Remove-Item $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+}


### PR DESCRIPTION
## Summary

- replace the generated main-committed coverage badge JSON with the ReportGenerator SVG deployed beside the live coverage report
- convert `scripts/release.ps1` to fail-closed, protected-main release finalization that validates an already-prepared version and pushes only the version tag
- add cross-platform release regression coverage and update the maintainer release documentation for PR-prepared releases

## Validation

- full Release solution build: succeeded with 0 errors and 2 existing generated-example CS0162 warnings
- release finalization regression: passed; verifies version mismatch, non-main execution, and failed CI are blocked, dry-run is write-free, `origin/main` never moves, and the only successful remote write is the expected tag
- `NexusLabs.Needlr.Generators.Tests`: 828 passed, 0 failed, 0 skipped
- `NexusLabs.Needlr.Analyzers.Tests`: 113 passed, 0 failed, 0 skipped
- package validation: passed, including 40 example builds and 4 example test projects
- strict MkDocs build: passed
- all workflow YAML files and `version.json`: parsed successfully

## Intentional scope

- this PR does not apply repository protection settings; activation waits until this PR is merged and the same-commit `main` CI run succeeds
- `build-maui-example` remains non-required because its workflow is path-filtered and does not create a check for unrelated pull requests
- the release script has no CI bypass and no branch commit/push path