### PR TITLE
Fix release tag discovery with conflicting local tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 
 - Release documentation now uses an action-managed Python environment on self-hosted runners, avoiding PEP 668 system-Python failures. Python setup, documentation generation/build, and Node.js setup complete before package publication, while all documentation workflows share `docs/requirements.txt`.
+- Release finalization now reads existing version tags directly from `origin` instead of running `git fetch --tags`, so a historical local tag that differs from its remote ref cannot block release validation or cause local tag mutation.
 - Source-generated bootstraps now explicitly run referenced TypeRegistry module constructors instead of relying on `typeof(...).Assembly`, which does not guarantee module initialization. This makes transitive registry loading deterministic and removes test-order dependence from Carter, SignalR, and cross-generator bootstrap coverage.
 - HttpClient name inference now treats types named exactly `HttpClientOptions`, `HttpClientSettings`, or `HttpClient` as empty inferred names, making NDLRHTTP004 reachable as documented instead of silently registering a suffix-only client name. HttpClient collision diagnostics are emitted deterministically, and generated client names and configuration section literals are escaped consistently.
 - CI now disables NBGV's per-project cloud build-number and version-variable publication, preventing parallel solution builds from corrupting GitHub Actions file-command files. The obsolete temporary `$GITHUB_ENV` redirection workarounds were removed.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -16,7 +16,7 @@ Needlr uses a protected-main release flow with two separate operations:
 ### 1. Prepare the release pull request
 
 ```powershell
-git fetch origin main --tags
+git fetch origin main
 git switch --create release/prepare-v0.0.3-alpha.3 origin/main
 
 # Choose the next unused version, then update version.json on this branch.
@@ -42,7 +42,7 @@ squash-merge it. Do not push the preparation commit directly to `main`.
 Wait for the `ci.yml` push run on the squash-merge commit to succeed, then:
 
 ```powershell
-git fetch origin main --tags
+git fetch origin main
 git switch main
 git pull --ff-only origin main
 
@@ -70,6 +70,7 @@ publish packages or documentation.
 | Prepared version | `version.json` and NBGV both resolve exactly to the requested version |
 | Changelog | Exact `## [<version>]` section exists |
 | Analyzer tracking | Every `AnalyzerReleases.Unshipped.md` has zero rule rows |
+| Remote version sequence | Existing release tags are read from `origin` without modifying local tag refs |
 | Unused version | The version tag does not exist locally or on `origin` |
 | Protected-main position | Real runs use local `main` exactly equal to freshly fetched `origin/main` |
 | Same-commit CI | The successful `ci.yml` push run is for that exact `main` commit |

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -89,12 +89,12 @@ commit is not the version-reset commit and must not be tagged.
 
 ### Choosing the next prerelease
 
-Fetch all tags and inspect the current sequence:
+Refresh `main`, then inspect the remote tag sequence without importing or
+rewriting local tag refs:
 
 ```powershell
-git fetch origin main --tags
-git tag --list "v0.0.3-alpha.*" --sort=-version:refname |
-  Select-Object -First 10
+git fetch origin main
+git ls-remote --tags --refs origin "refs/tags/v0.0.3-alpha.*"
 ```
 
 Increment the highest published counter and confirm that neither the local nor
@@ -107,6 +107,12 @@ git ls-remote --tags origin "refs/tags/v0.0.3-alpha.3"
 
 The release script repeats both checks before tagging.
 
+Do not require `git fetch --tags` for release preparation. Historical local
+tags may intentionally or accidentally differ from remote tag objects, and Git
+rejects an all-tags fetch rather than clobbering them. The release script reads
+the authoritative remote sequence with `git ls-remote` and leaves every local
+historical tag unchanged.
+
 ## Phase 1: prepare the release pull request
 
 ### Create the branch
@@ -114,7 +120,7 @@ The release script repeats both checks before tagging.
 Start from the latest remote `main`:
 
 ```powershell
-git fetch origin main --tags
+git fetch origin main
 git switch --create release/prepare-v0.0.3-alpha.3 origin/main
 ```
 
@@ -275,7 +281,7 @@ substitute because the release workflow independently verifies the exact
 ### Synchronize local main
 
 ```powershell
-git fetch origin main --tags
+git fetch origin main
 git switch main
 git pull --ff-only origin main
 git status --short

--- a/scripts/release.ps1
+++ b/scripts/release.ps1
@@ -62,9 +62,9 @@ function Ensure-Nbgv {
 }
 
 function Update-OriginState {
-  $fetchOutput = & git fetch --quiet origin main --tags 2>&1
+  $fetchOutput = & git fetch --quiet origin main 2>&1
   if ($LASTEXITCODE -ne 0) {
-    throw "Could not refresh origin/main and release tags.`n$($fetchOutput | Out-String)"
+    throw "Could not refresh origin/main.`n$($fetchOutput | Out-String)"
   }
 }
 
@@ -90,10 +90,19 @@ function Get-NextPrereleaseVersion {
     throw "Prerelease label '$Label' contains unsupported characters."
   }
 
-  $pattern = "v$([regex]::Escape($BaseVersion))-$([regex]::Escape($Label)).*"
-  $tags = @(& git tag --list $pattern | Where-Object { $_ })
+  $pattern = "refs/tags/v$BaseVersion-$Label.*"
+  $remoteTagLines = @(& git ls-remote --tags --refs origin $pattern 2>&1 | Where-Object { $_ })
   if ($LASTEXITCODE -ne 0) {
-    throw "Could not enumerate release tags."
+    throw "Could not enumerate release tags on origin.`n$($remoteTagLines | Out-String)"
+  }
+
+  $tags = @($remoteTagLines | ForEach-Object {
+    if ($_ -match '^[0-9a-fA-F]+\s+refs/tags/(?<tag>.+)$') {
+      $Matches['tag']
+    }
+  })
+  if ($tags.Count -ne $remoteTagLines.Count) {
+    throw "Origin returned an unexpected release-tag reference."
   }
 
   $max = 0

--- a/scripts/test-release.ps1
+++ b/scripts/test-release.ps1
@@ -189,6 +189,27 @@ exit 0
         Invoke-Git -Arguments @('push', '-u', 'origin', 'main') -FailureMessage 'Could not push fixture main.' | Out-Null
 
         $expectedSha = (Invoke-Git -Arguments @('rev-parse', 'HEAD') -FailureMessage 'Could not resolve fixture HEAD.').Trim()
+
+        foreach ($counter in 1..3) {
+            $tag = "v1.2.3-alpha.$counter"
+            Invoke-Git -Arguments @('tag', $tag) -FailureMessage "Could not create fixture tag $tag." | Out-Null
+            Invoke-Git -Arguments @('push', 'origin', "refs/tags/$tag") -FailureMessage "Could not push fixture tag $tag." | Out-Null
+            Invoke-Git -Arguments @('tag', '-d', $tag) -FailureMessage "Could not remove local fixture tag $tag." | Out-Null
+        }
+
+        $conflictingTag = 'v0.9.0-alpha.1'
+        Invoke-Git -Arguments @('tag', $conflictingTag) -FailureMessage 'Could not create the remote-conflict fixture tag.' | Out-Null
+        Invoke-Git -Arguments @('push', 'origin', "refs/tags/$conflictingTag") -FailureMessage 'Could not push the remote-conflict fixture tag.' | Out-Null
+        Invoke-Git -Arguments @('tag', '-d', $conflictingTag) -FailureMessage 'Could not remove the lightweight fixture tag.' | Out-Null
+        Invoke-Git -Arguments @('tag', '-a', $conflictingTag, '-m', 'stale local tag object') -FailureMessage 'Could not create the conflicting annotated local tag.' | Out-Null
+
+        $localConflictingTag = (Invoke-Git -Arguments @('rev-parse', "refs/tags/$conflictingTag") -FailureMessage 'Could not resolve the conflicting local tag.').Trim()
+        $remoteConflictingTagLines = @(Invoke-Git -Arguments @('ls-remote', '--tags', 'origin', "refs/tags/$conflictingTag") -FailureMessage 'Could not resolve the conflicting remote tag.')
+        $remoteConflictingTag = $remoteConflictingTagLines[0].Split("`t")[0]
+        if ($localConflictingTag -eq $remoteConflictingTag) {
+            throw 'The release fixture did not establish a conflicting historical local tag.'
+        }
+
         $env:TEST_RELEASE_VERSION = $releaseVersion
         $env:TEST_RELEASE_SHA = $expectedSha
         $env:TEST_RELEASE_CI_CONCLUSION = 'success'
@@ -211,6 +232,12 @@ exit 0
         $dryRunText = ConvertTo-PlainOutput -Output $dryRunOutput
         Assert-Contains -Content $dryRunText -Expected 'git push origin refs/tags/v1.2.3-alpha.4' -Message 'Dry run did not report the tag push.'
         Assert-Contains -Content $dryRunText -Expected 'No branch commit or branch push will be performed.' -Message 'Dry run did not state the protected-main invariant.'
+
+        $computedDryRunOutput = & $pwsh -NoProfile -File $workReleaseScript -Prerelease alpha -Base 1.2.3 -DryRun 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            throw "Computed release dry run failed.`n$($computedDryRunOutput | Out-String)"
+        }
+        Assert-Contains -Content (ConvertTo-PlainOutput -Output $computedDryRunOutput) -Expected 'Finalizing release for version: 1.2.3-alpha.4' -Message 'Remote prerelease tag discovery did not calculate the next version.'
 
         $tagBeforeRelease = Invoke-Git -Arguments @('ls-remote', '--tags', 'origin', "refs/tags/v$releaseVersion") -FailureMessage 'Could not inspect fixture tags.'
         Assert-Equal -Expected 0 -Actual $tagBeforeRelease.Count -Message 'Dry run created a remote tag.'


### PR DESCRIPTION
## Summary

- stop importing every remote tag during release validation
- calculate the next prerelease directly from `origin` with `git ls-remote --tags --refs`
- cover a historical local tag whose object differs from the remote ref

## Why

Post-protection verification found this clone has `v0.0.2-alpha.52` pointing at a different object than `origin`. The previous `git fetch --tags` therefore aborted with `would clobber existing tag` before the release dry run reached its metadata gates. Release version discovery only needs authoritative remote tag names; it should not mutate or reconcile historical local tag refs.

## Validation

- isolated release regression passed, including remote prerelease calculation and a conflicting historical local tag
- real-clone dry run reached the expected NBGV release-preparation gate without a tag-fetch failure
- strict MkDocs build passed
- PowerShell parsing and `git diff --check` passed