### PR TITLE
Split agent marketplace and source validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,37 +13,116 @@ env:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      source_required: ${{ steps.scope.outputs.source_required }}
+      marketplace_required: ${{ steps.scope.outputs.marketplace_required }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Detect validation scope
+      id: scope
+      shell: pwsh
+      env:
+        BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        FORCE_ALL: ${{ github.event_name == 'workflow_dispatch' }}
+      run: |
+        $arguments = @{
+          BaseSha = $env:BASE_SHA
+          HeadSha = $env:HEAD_SHA
+        }
+        if ($env:FORCE_ALL -eq 'true') {
+          $arguments.ForceAll = $true
+        }
+        scripts/get-ci-scope.ps1 @arguments
+
+  marketplace-validation:
+    needs: changes
+    if: needs.changes.outputs.marketplace_required == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Validate agent marketplace
+      shell: pwsh
+      run: scripts/validate-agent-marketplace.ps1
+
   build-and-test:
+    needs: [changes, marketplace-validation]
+    if: always()
     # PitCrew default. Set CI_RUNNER=ubuntu-latest for the manual cloud fallback.
     # Untrusted fork pull requests always use GitHub-hosted infrastructure.
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && 'ubuntu-latest' || vars.CI_RUNNER || fromJSON('["self-hosted","linux","x64","general-purpose"]') }}
+    # Marketplace-only changes use a lightweight hosted no-op rather than occupying PitCrew.
+    runs-on: ${{ needs.changes.outputs.source_required != 'true' && 'ubuntu-latest' || github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && 'ubuntu-latest' || vars.CI_RUNNER || fromJSON('["self-hosted","linux","x64","general-purpose"]') }}
     permissions:
       contents: write
       pages: write
       id-token: write
 
     steps:
+    - name: Enforce validation routing
+      shell: bash
+      run: |
+        if [[ "${{ needs.changes.result }}" != "success" ]]; then
+          echo "::error::CI scope detection did not succeed."
+          exit 1
+        fi
+        marketplace_required="${{ needs.changes.outputs.marketplace_required }}"
+        marketplace_result="${{ needs.marketplace-validation.result }}"
+        if [[ "$marketplace_required" == "true" && "$marketplace_result" != "success" ]]; then
+          echo "::error::Required agent marketplace validation did not succeed."
+          exit 1
+        fi
+        if [[ "$marketplace_required" != "true" &&
+              "$marketplace_result" != "success" &&
+              "$marketplace_result" != "skipped" ]]; then
+          echo "::error::Agent marketplace validation ended unexpectedly."
+          exit 1
+        fi
+
+    - name: Source validation not required
+      if: needs.changes.outputs.source_required != 'true'
+      run: echo "Marketplace-only change; source, package, documentation, and AOT validation are not applicable."
+
     - name: Checkout
+      if: needs.changes.outputs.source_required == 'true'
       uses: actions/checkout@v4
       with:
         fetch-depth: 0 # Needed for NBGV / SourceLink / deterministic builds
 
     - name: Setup .NET
+      if: needs.changes.outputs.source_required == 'true'
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
           10.0.x
 
     - name: Add .NET global tools to PATH
+      if: needs.changes.outputs.source_required == 'true'
       run: echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
 
     - name: Restore
+      if: needs.changes.outputs.source_required == 'true'
       run: dotnet restore src/NexusLabs.Needlr.slnx
 
     - name: Build (Release)
+      if: needs.changes.outputs.source_required == 'true'
       run: dotnet build src/NexusLabs.Needlr.slnx --configuration Release --no-restore
 
     - name: Test with Coverage
+      if: needs.changes.outputs.source_required == 'true'
       run: |
         failed=0
         while IFS= read -r proj; do
@@ -63,9 +142,11 @@ jobs:
         exit $failed
 
     - name: Install ReportGenerator
+      if: needs.changes.outputs.source_required == 'true'
       run: dotnet tool install -g dotnet-reportgenerator-globaltool
 
     - name: Generate Coverage Reports
+      if: needs.changes.outputs.source_required == 'true'
       run: |
         reportgenerator \
           -reports:"coverage/**/coverage.cobertura.xml" \
@@ -73,26 +154,32 @@ jobs:
           -reporttypes:"Html;JsonSummary;MarkdownSummaryGithub;Badges"
 
     - name: Add Coverage to Job Summary
+      if: needs.changes.outputs.source_required == 'true'
       run: cat coverage/report/SummaryGithub.md >> $GITHUB_STEP_SUMMARY
 
     - name: Upload Coverage Report Artifact
+      if: needs.changes.outputs.source_required == 'true'
       uses: actions/upload-artifact@v4
       with:
         name: coverage-report
         path: coverage/report/
 
     - name: Setup Python for MkDocs
+      if: needs.changes.outputs.source_required == 'true'
       uses: actions/setup-python@v5
       with:
         python-version: '3.x'
 
     - name: Install MkDocs
+      if: needs.changes.outputs.source_required == 'true'
       run: python -m pip install -r docs/requirements.txt
 
     - name: Restore dotnet tools
+      if: needs.changes.outputs.source_required == 'true'
       run: dotnet tool restore
 
     - name: Generate API Documentation
+      if: needs.changes.outputs.source_required == 'true'
       run: ./scripts/generate-api-docs.sh docs/api/dev --update-index
 
     # NOTE: there used to be an "Ensure Stable API Docs Are Available" step
@@ -111,12 +198,15 @@ jobs:
     # real stable content on gh-pages written by release.yml.
 
     - name: Generate Articles Page
+      if: needs.changes.outputs.source_required == 'true'
       run: python scripts/generate-articles.py docs/articles.md
 
     - name: Build Documentation
+      if: needs.changes.outputs.source_required == 'true'
       run: python -m mkdocs build
 
     - name: Build sitemap index
+      if: needs.changes.outputs.source_required == 'true'
       # mkdocs's default /sitemap.xml is a single flat file containing only
       # pages mkdocs knows about at this build time — which excludes the
       # /api/stable/ slice owned by release.yml. Replace it with a sitemap
@@ -130,13 +220,13 @@ jobs:
       run: python scripts/build-sitemap-index.py ./site
 
     - name: Add Coverage Report to Site
-      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+      if: needs.changes.outputs.source_required == 'true' && github.ref == 'refs/heads/main' && github.event_name == 'push'
       run: |
         mkdir -p site/coverage
         cp -r coverage/report/* site/coverage/
 
     - name: Restrict deploy to ci.yml-owned paths
-      if: success() && github.ref == 'refs/heads/main' && github.event_name == 'push'
+      if: needs.changes.outputs.source_required == 'true' && success() && github.ref == 'refs/heads/main' && github.event_name == 'push'
       run: |
         # ci.yml owns: /api/dev/*, /coverage/*, home, feature pages, assets.
         # release.yml owns: /api/stable/*, /api/v<version>/*.
@@ -153,7 +243,7 @@ jobs:
         echo "Restricted ./site/ to ci.yml-owned paths."
 
     - name: Deploy Documentation and Coverage
-      if: success() && github.ref == 'refs/heads/main' && github.event_name == 'push'
+      if: needs.changes.outputs.source_required == 'true' && success() && github.ref == 'refs/heads/main' && github.event_name == 'push'
       uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -165,7 +255,7 @@ jobs:
     # by keep_files above) -- check it out fresh and mirror that whole tree
     # to Cloudflare Pages, rather than deploying our own partial ./site/.
     - name: Checkout gh-pages for Cloudflare mirror
-      if: success() && github.ref == 'refs/heads/main' && github.event_name == 'push'
+      if: needs.changes.outputs.source_required == 'true' && success() && github.ref == 'refs/heads/main' && github.event_name == 'push'
       uses: actions/checkout@v4
       with:
         ref: gh-pages
@@ -176,17 +266,17 @@ jobs:
     # older archives stay in gh-pages history but are not published here.
     # Also removes the checkout's .git so it is not uploaded.
     - name: Trim mirror before Cloudflare deploy
-      if: success() && github.ref == 'refs/heads/main' && github.event_name == 'push'
+      if: needs.changes.outputs.source_required == 'true' && success() && github.ref == 'refs/heads/main' && github.event_name == 'push'
       run: python scripts/trim-cloudflare-mirror.py gh-pages-mirror --keep 20
 
     - name: Setup Node.js
-      if: success() && github.ref == 'refs/heads/main' && github.event_name == 'push'
+      if: needs.changes.outputs.source_required == 'true' && success() && github.ref == 'refs/heads/main' && github.event_name == 'push'
       uses: actions/setup-node@v4
       with:
         node-version: '24'
 
     - name: Deploy Documentation to Cloudflare Pages
-      if: success() && github.ref == 'refs/heads/main' && github.event_name == 'push'
+      if: needs.changes.outputs.source_required == 'true' && success() && github.ref == 'refs/heads/main' && github.event_name == 'push'
       uses: cloudflare/wrangler-action@v4
       with:
         apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -194,51 +284,89 @@ jobs:
         command: pages deploy gh-pages-mirror --project-name=needlr --branch=main --commit-dirty=true
 
   package-validation:
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && 'ubuntu-latest' || vars.CI_RUNNER || fromJSON('["self-hosted","linux","x64","general-purpose"]') }}
-    # Runs in parallel with build-and-test (no 'needs')
+    needs: changes
+    if: always()
+    runs-on: ${{ needs.changes.outputs.source_required != 'true' && 'ubuntu-latest' || github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && 'ubuntu-latest' || vars.CI_RUNNER || fromJSON('["self-hosted","linux","x64","general-purpose"]') }}
+    # Runs in parallel with the other source jobs after scope detection.
 
     steps:
+    - name: Enforce validation routing
+      if: needs.changes.result != 'success'
+      run: |
+        echo "::error::CI scope detection did not succeed."
+        exit 1
+
+    - name: Source package validation not required
+      if: needs.changes.result == 'success' && needs.changes.outputs.source_required != 'true'
+      run: echo "Marketplace-only change; package validation is not applicable."
+
     - name: Checkout
+      if: needs.changes.outputs.source_required == 'true'
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
     - name: Setup .NET
+      if: needs.changes.outputs.source_required == 'true'
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
           10.0.x
 
+    - name: Validate CI scope classifier
+      if: needs.changes.outputs.source_required == 'true'
+      shell: pwsh
+      run: scripts/test-ci-scope.ps1
+
     - name: Validate release finalization
+      if: needs.changes.outputs.source_required == 'true'
       shell: pwsh
       run: scripts/test-release.ps1
 
     - name: Restore
+      if: needs.changes.outputs.source_required == 'true'
       run: dotnet restore src/NexusLabs.Needlr.slnx
 
     - name: Validate package contents
+      if: needs.changes.outputs.source_required == 'true'
       shell: pwsh
       run: scripts/test-packages.ps1
 
   aot-console-app:
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && 'ubuntu-latest' || vars.CI_RUNNER || fromJSON('["self-hosted","linux","x64","general-purpose"]') }}
-    # Runs in parallel with build-and-test (no 'needs')
+    needs: changes
+    if: always()
+    runs-on: ${{ needs.changes.outputs.source_required != 'true' && 'ubuntu-latest' || github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && 'ubuntu-latest' || vars.CI_RUNNER || fromJSON('["self-hosted","linux","x64","general-purpose"]') }}
+    # Runs in parallel with the other source jobs after scope detection.
 
     steps:
+    - name: Enforce validation routing
+      if: needs.changes.result != 'success'
+      run: |
+        echo "::error::CI scope detection did not succeed."
+        exit 1
+
+    - name: Source AOT console validation not required
+      if: needs.changes.result == 'success' && needs.changes.outputs.source_required != 'true'
+      run: echo "Marketplace-only change; AOT console validation is not applicable."
+
     - name: Checkout
+      if: needs.changes.outputs.source_required == 'true'
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
     - name: Setup .NET 10
+      if: needs.changes.outputs.source_required == 'true'
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 10.0.x
 
     - name: Install AOT dependencies
+      if: needs.changes.outputs.source_required == 'true'
       run: sudo apt-get update && sudo apt-get install -y clang zlib1g-dev file
 
     - name: Publish AOT Console App
+      if: needs.changes.outputs.source_required == 'true'
       run: |
         dotnet publish src/Examples/SourceGen/AotSourceGenConsoleApp/AotSourceGenConsoleApp.csproj \
           -c Release \
@@ -247,32 +375,50 @@ jobs:
           -o artifacts/console
 
     - name: Verify Console App Executable
+      if: needs.changes.outputs.source_required == 'true'
       run: |
         test -f artifacts/console/AotSourceGenConsoleApp
         file artifacts/console/AotSourceGenConsoleApp
 
     - name: Run Console App
+      if: needs.changes.outputs.source_required == 'true'
       run: artifacts/console/AotSourceGenConsoleApp || echo "App executed (exit expected for demo)"
 
   aot-web-app:
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && 'ubuntu-latest' || vars.CI_RUNNER || fromJSON('["self-hosted","linux","x64","general-purpose"]') }}
-    # Runs in parallel with build-and-test (no 'needs')
+    needs: changes
+    if: always()
+    runs-on: ${{ needs.changes.outputs.source_required != 'true' && 'ubuntu-latest' || github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && 'ubuntu-latest' || vars.CI_RUNNER || fromJSON('["self-hosted","linux","x64","general-purpose"]') }}
+    # Runs in parallel with the other source jobs after scope detection.
 
     steps:
+    - name: Enforce validation routing
+      if: needs.changes.result != 'success'
+      run: |
+        echo "::error::CI scope detection did not succeed."
+        exit 1
+
+    - name: Source AOT web validation not required
+      if: needs.changes.result == 'success' && needs.changes.outputs.source_required != 'true'
+      run: echo "Marketplace-only change; AOT web validation is not applicable."
+
     - name: Checkout
+      if: needs.changes.outputs.source_required == 'true'
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
     - name: Setup .NET 10
+      if: needs.changes.outputs.source_required == 'true'
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 10.0.x
 
     - name: Install AOT dependencies
+      if: needs.changes.outputs.source_required == 'true'
       run: sudo apt-get update && sudo apt-get install -y clang zlib1g-dev file
 
     - name: Publish AOT Web App
+      if: needs.changes.outputs.source_required == 'true'
       run: |
         dotnet publish src/Examples/SourceGen/AotSourceGenApp/AotSourceGenApp.csproj \
           -c Release \
@@ -281,6 +427,7 @@ jobs:
           -o artifacts/webapp
 
     - name: Verify Web App Executable
+      if: needs.changes.outputs.source_required == 'true'
       run: |
         test -f artifacts/webapp/AotSourceGenApp
         file artifacts/webapp/AotSourceGenApp

--- a/docs/adr/adr-0008-own-version-aware-agent-marketplace.md
+++ b/docs/adr/adr-0008-own-version-aware-agent-marketplace.md
@@ -1,0 +1,173 @@
+---
+title: "ADR-0008: Own a version-aware Needlr agent marketplace"
+status: "Accepted"
+date: "2026-07-24"
+authors: ["Nick Cosentino"]
+tags: ["architecture", "decision", "agents", "plugins", "marketplace", "ci"]
+supersedes: ""
+superseded_by: ""
+---
+
+## Context and scope
+
+Needlr has enough domain-specific behavior that a generic .NET or dependency-injection
+assistant cannot reliably infer its registration conventions, source-generation
+architecture, plugin lifecycles, framework integrations, and Native AOT constraints.
+Installable expert agents can make that knowledge available both to Needlr contributors
+and to consumers working in other repositories.
+
+The first Needlr-specific agents were distributed by the Genesis plugin. Genesis owns
+project templates, coding conventions, and scaffolding workflows rather than Needlr's
+product lifecycle. That ownership split allowed agent content to drift independently of
+Needlr. In particular, an Agent Framework specialist continued to describe packages and
+source paths after ADR-0004 moved all AI and agentic capabilities to Foundry.
+
+Needlr also protects `main` with required source-build, package-validation, and Native AOT
+checks. Agent and marketplace files do not produce .NET binaries, NuGet packages, or AOT
+executables. Running those expensive checks for an agent-only change consumes build
+capacity without increasing confidence. Future behavioral evaluations have the inverse
+constraint: they should run for agent changes, not for unrelated product changes.
+
+This decision governs ownership, specialization, research behavior, and CI isolation for
+Needlr's installable agent plugin. It does not define the future behavioral evaluation
+suite or move Foundry-specific agents into Needlr.
+
+## Decision drivers
+
+- Agent guidance must evolve in the same repository and review stream as Needlr.
+- Consumers must receive advice compatible with the Needlr version they use.
+- Planning questions without an existing package reference still require current external
+  research.
+- Agent prompts must remain small enough to avoid duplicating documentation and becoming a
+  second source of truth.
+- Specialist routing must be clear enough that overlapping agents do not provide
+  contradictory guidance.
+- Protected-branch checks must remain present for every pull request while avoiding
+  irrelevant source, package, AOT, or future evaluation workloads.
+- The initial marketplace must be useful without claiming unearned behavioral confidence.
+
+## Decision
+
+The Needlr repository owns and distributes a plugin marketplace containing one `needlr`
+plugin. Genesis will not remain the source of truth for Needlr-specific agents. Foundry
+owns AI and Agent Framework expertise, including its optional Needlr integrations.
+
+The Needlr plugin provides three specialists with non-overlapping primary responsibilities:
+
+- an application specialist for public DI APIs, registration design, lifetimes, plugins,
+  and version-compatible consumer guidance;
+- a source-generation specialist for Needlr's compile-time architecture, analyzers, build
+  integration, cross-assembly behavior, AOT, and contributor workflows;
+- an integrations specialist for ASP.NET Core, Carter, SignalR, hosting, logging,
+  validation, and UI framework packages.
+
+The specialists share a thin research skill instead of embedding a frozen API catalog.
+The research contract resolves evidence in this order:
+
+1. In a Needlr source checkout, the current checkout, its instructions, accepted ADRs,
+   implementation, and tests are authoritative.
+2. In a consumer repository with Needlr package references, the referenced package version
+   determines the matching release tag and documentation.
+3. When no checkout or package reference exists because the work is still being planned,
+   the agent researches current official Needlr documentation, repository sources,
+   releases, and NuGet metadata before answering.
+
+The marketplace MVP does not include a behavioral evaluation suite. Agent behavior remains
+explicitly unverified until calibrated evaluations are added. The plugin layout reserves a
+separate agent-evaluation scope so that later evaluations can run only for agent-related
+changes.
+
+CI classifies every change conservatively. A change is marketplace-only only when every
+changed path belongs to the plugin manifests, agent profiles, shared agent skill, plugin
+validator, or future agent-evaluation directory. Any unknown or mixed path runs the normal
+source pipeline. The existing required branch-protection contexts remain present on every
+pull request; for marketplace-only changes they complete as lightweight hosted no-ops after
+marketplace validation succeeds. Scope-detection failure blocks the required checks rather
+than silently skipping validation.
+
+## Alternatives considered
+
+### Keep the Needlr agents in Genesis
+
+This keeps all personal developer tooling in one marketplace and avoids adding plugin files
+to Needlr. It was rejected because Genesis cannot evolve atomically with Needlr APIs,
+architecture decisions, and integration fixes. The existing Agent Framework drift
+demonstrates that the ownership boundary is already producing incorrect guidance.
+
+### Maintain copies in both Genesis and Needlr
+
+This provides a transition period and lets either marketplace install the agents. It was
+rejected as a steady state because duplicate agent names and independently edited prompts
+create ambiguous routing and guarantee future drift. A short migration period may exist,
+but Needlr becomes the sole source of truth.
+
+### Publish one comprehensive Needlr agent
+
+One agent is easy to discover and avoids routing decisions. It was rejected because public
+application design, source-generator internals, and framework integrations require
+different evidence, invariants, and boundaries. A comprehensive prompt would either become
+a large duplicated manual or remain too shallow for contributor work.
+
+### Run every validation workload for every change
+
+This is simple and maximally conservative. It was rejected because agent-only changes
+cannot affect compiled assemblies, packages, or AOT applications, while future agent
+evaluations provide no evidence about unrelated source changes. Stable required contexts
+with fail-closed path classification preserve merge safety without running irrelevant work.
+
+## Consequences
+
+### Positive
+
+- Needlr agent behavior and product changes share ownership, review, and history.
+- Downstream consumers can install Needlr expertise without installing Genesis scaffolding.
+- Version-aware research avoids applying unreleased `main` APIs to older package versions.
+- Planning scenarios still receive current web and repository research.
+- Thin prompts rely on existing code, tests, ADRs, and documentation rather than copying
+  them.
+- Agent-only pull requests avoid expensive .NET, package, and AOT workloads.
+- Future evaluations have an isolated path trigger that does not burden product-only
+  changes.
+
+### Negative
+
+- Needlr gains a new published developer-tooling surface that requires maintenance.
+- Three agents require disciplined descriptions and boundaries to preserve correct routing.
+- Path classification becomes part of merge safety and must fail closed when uncertain.
+- Required source contexts still launch lightweight no-op jobs for marketplace-only pull
+  requests because branch protection requires those context names.
+- The MVP agents are not behaviorally verified until the deferred evaluation suite exists.
+
+### Neutral
+
+- The generic C# source-generator and Roslyn-analyzer agents remain useful for raw Roslyn
+  mechanics; Needlr specialists own cross-component Needlr semantics.
+- Marketplace versions describe plugin distribution and do not change Needlr's NuGet
+  package version.
+- Removing the obsolete Genesis agents and creating the Foundry replacement are separate
+  repository changes.
+
+## Confirmation
+
+Repository validation confirms the marketplace manifests, agent front matter, unique agent
+names, shared research-skill references, and absence of known stale Needlr AI identities.
+
+CI scope tests cover marketplace-only, source-only, mixed, unknown infrastructure, and
+manual full-validation cases. A marketplace-only pull request must show marketplace
+validation succeeding while the four protected source contexts complete without restore,
+build, package, or AOT steps. A source-only pull request must not execute the future
+agent-evaluation path.
+
+Behavioral quality, routing accuracy, latency, and token efficiency cannot be confirmed by
+the MVP repository checks. Those require the deferred calibrated evaluation suite.
+
+## References
+
+- ADR-0004 records that Foundry, not Needlr, owns AI and agentic runtime, workflow,
+  evaluation, generator, analyzer, and provider capabilities.
+- `AGENTS.md` and `.github/instructions/` remain the authoritative contributor contracts
+  that specialists must load when operating inside the Needlr repository.
+- `version.json`, release tags, and package references provide the version boundary used by
+  consumer-mode research.
+- GitHub's Copilot CLI plugin documentation defines root `plugin.json` manifests and
+  recognizes marketplaces from `.claude-plugin/marketplace.json`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -182,6 +182,7 @@ nav:
     - ADR-0005 Generate Guarded Constructors: adr/adr-0005-generate-guarded-constructors.md
     - ADR-0006 Generate Record Constructor Overloads: adr/adr-0006-generate-record-constructor-overloads.md
     - ADR-0007 Own Graph Source Locations Per Project: adr/adr-0007-own-graph-source-locations-per-project.md
+    - ADR-0008 Own a Version-Aware Agent Marketplace: adr/adr-0008-own-version-aware-agent-marketplace.md
 
 plugins:
   - search

--- a/scripts/get-ci-scope.ps1
+++ b/scripts/get-ci-scope.ps1
@@ -1,0 +1,89 @@
+<#
+.SYNOPSIS
+    Classifies changed files for Needlr source and agent-marketplace CI.
+
+.DESCRIPTION
+    Marketplace-only changes skip the expensive .NET, package, and AOT paths.
+    Any unrecognized path fails closed into source validation. Mixed changes
+    require both validation paths.
+#>
+param(
+    [string]$BaseSha,
+    [string]$HeadSha,
+    [string[]]$ChangedPaths,
+    [switch]$ForceAll,
+    [switch]$NoCiOutput
+)
+
+$ErrorActionPreference = 'Stop'
+
+$marketplaceOnlyPatterns = @(
+    '^\.claude-plugin/',
+    '^agents/',
+    '^evals/agents/',
+    '^skills/needlr-research/',
+    '^plugin\.json$',
+    '^scripts/validate-agent-marketplace\.ps1$'
+)
+
+function Test-AnyPattern {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string[]]$Patterns
+    )
+
+    return $null -ne ($Patterns | Where-Object { $Path -match $_ } | Select-Object -First 1)
+}
+
+if ($ForceAll -or $BaseSha -match '^0+$') {
+    $sourceRequired = $true
+    $marketplaceRequired = $true
+    $paths = @()
+} else {
+    if ($null -eq $ChangedPaths) {
+        if ([string]::IsNullOrWhiteSpace($BaseSha) -or
+            [string]::IsNullOrWhiteSpace($HeadSha)) {
+            throw 'BaseSha and HeadSha are required when ChangedPaths is not supplied.'
+        }
+
+        $diffOutput = & git diff --name-only "$BaseSha...$HeadSha" 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            throw "Could not determine changed files.`n$($diffOutput | Out-String)"
+        }
+        $paths = @($diffOutput | Where-Object { $_ })
+    } else {
+        $paths = @($ChangedPaths | Where-Object { $_ })
+    }
+
+    $normalizedPaths = @($paths | ForEach-Object { $_.Replace('\', '/') })
+    if ($normalizedPaths.Count -eq 0) {
+        $sourceRequired = $true
+        $marketplaceRequired = $true
+    } else {
+        $marketplaceRequired = $null -ne (
+            $normalizedPaths |
+                Where-Object {
+                    Test-AnyPattern -Path $_ -Patterns $marketplaceOnlyPatterns
+                } |
+                Select-Object -First 1)
+        $sourceRequired = $null -ne (
+            $normalizedPaths |
+                Where-Object {
+                    -not (Test-AnyPattern -Path $_ -Patterns $marketplaceOnlyPatterns)
+                } |
+                Select-Object -First 1)
+    }
+}
+
+$result = [ordered]@{
+    source_required = $sourceRequired
+    marketplace_required = $marketplaceRequired
+    changed_count = $paths.Count
+}
+
+if (-not $NoCiOutput -and -not [string]::IsNullOrWhiteSpace($env:GITHUB_OUTPUT)) {
+    Add-Content -Path $env:GITHUB_OUTPUT -Value "source_required=$($sourceRequired.ToString().ToLowerInvariant())"
+    Add-Content -Path $env:GITHUB_OUTPUT -Value "marketplace_required=$($marketplaceRequired.ToString().ToLowerInvariant())"
+}
+
+$result | ConvertTo-Json -Compress

--- a/scripts/test-ci-scope.ps1
+++ b/scripts/test-ci-scope.ps1
@@ -1,0 +1,93 @@
+<#
+.SYNOPSIS
+    Validates Needlr CI scope classification.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+$scriptPath = Join-Path $PSScriptRoot 'get-ci-scope.ps1'
+$previousGitHubOutput = $env:GITHUB_OUTPUT
+
+function Assert-Scope {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [string[]]$ChangedPaths,
+        [Parameter(Mandatory = $true)][bool]$ExpectedSource,
+        [Parameter(Mandatory = $true)][bool]$ExpectedMarketplace,
+        [switch]$ForceAll
+    )
+
+    $arguments = @{
+        ChangedPaths = $ChangedPaths
+        ForceAll = $ForceAll
+        NoCiOutput = $true
+    }
+    $result = (& $scriptPath @arguments | ConvertFrom-Json)
+
+    if ($result.source_required -ne $ExpectedSource -or
+        $result.marketplace_required -ne $ExpectedMarketplace) {
+        throw "$Name failed. Expected source=$ExpectedSource marketplace=$ExpectedMarketplace; actual source=$($result.source_required) marketplace=$($result.marketplace_required)."
+    }
+
+    Write-Host "PASS: $Name"
+}
+
+try {
+    Remove-Item Env:GITHUB_OUTPUT -ErrorAction SilentlyContinue
+
+    Assert-Scope `
+        -Name 'Agent profile only' `
+        -ChangedPaths @('agents/application.agent.md') `
+        -ExpectedSource $false `
+        -ExpectedMarketplace $true
+
+    Assert-Scope `
+        -Name 'Plugin manifests and shared skill' `
+        -ChangedPaths @(
+            '.claude-plugin/marketplace.json',
+            'plugin.json',
+            'skills/needlr-research/SKILL.md') `
+        -ExpectedSource $false `
+        -ExpectedMarketplace $true
+
+    Assert-Scope `
+        -Name 'Future agent eval only' `
+        -ChangedPaths @('evals/agents/routing.eval.ts') `
+        -ExpectedSource $false `
+        -ExpectedMarketplace $true
+
+    Assert-Scope `
+        -Name 'Source only' `
+        -ChangedPaths @('src/NexusLabs.Needlr/Syringe.cs') `
+        -ExpectedSource $true `
+        -ExpectedMarketplace $false
+
+    Assert-Scope `
+        -Name 'CI infrastructure fails into source validation' `
+        -ChangedPaths @('.github/workflows/ci.yml', 'scripts/get-ci-scope.ps1') `
+        -ExpectedSource $true `
+        -ExpectedMarketplace $false
+
+    Assert-Scope `
+        -Name 'Mixed source and marketplace change' `
+        -ChangedPaths @(
+            'agents/source-generation.agent.md',
+            'src/NexusLabs.Needlr.Generators/TypeRegistryGenerator.cs') `
+        -ExpectedSource $true `
+        -ExpectedMarketplace $true
+
+    Assert-Scope `
+        -Name 'Manual full validation' `
+        -ChangedPaths @() `
+        -ExpectedSource $true `
+        -ExpectedMarketplace $true `
+        -ForceAll
+
+    Write-Host 'CI scope validation passed.' -ForegroundColor Green
+} finally {
+    if ($null -eq $previousGitHubOutput) {
+        Remove-Item Env:GITHUB_OUTPUT -ErrorAction SilentlyContinue
+    } else {
+        $env:GITHUB_OUTPUT = $previousGitHubOutput
+    }
+}


### PR DESCRIPTION
## Summary

- add fail-closed CI path classification for source, marketplace-only, mixed, and manual changes
- preserve all four required branch-protection contexts while allowing marketplace-only changes to use hosted no-op source jobs
- record Needlr ownership, three-agent specialization, version-aware research, deferred evals, and isolated CI in ADR-0008

## Delivery split

This is the preparation PR. It intentionally contains no marketplace files, agent profiles, or eval suite. Its own diff classifies as `source_required=true`, so the complete existing .NET/package/AOT pipeline must pass.

After this merges, a second marketplace-only PR will prove that:

- marketplace validation runs;
- `build-and-test`, `package-validation`, `aot-console-app`, and `aot-web-app` remain present;
- restore/build/test/package/docs/AOT steps do not run;
- marketplace failure propagates through the required `build-and-test` context.

## Validation

- CI scope classifier: 7 passed, 0 failed
- PowerShell parsing: passed
- strict MkDocs build: passed
- workflow YAML parsing: passed
- `git diff --check`: passed

## Intentional omission

The MVP does not commit an agent evaluation suite. ADR-0008 records behavioral quality as unverified until calibrated evals are added under the isolated future `evals/agents/**` scope.