### PR TITLE
Add the Needlr agent marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "ncosentino-needlr",
+  "owner": {
+    "name": "Nick Cosentino"
+  },
+  "metadata": {
+    "description": "Official Needlr agents and skills for application design, source generation, and framework integrations.",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "needlr",
+      "description": "Version-aware specialists grounded in the Needlr repository, releases, tests, and documentation.",
+      "version": "1.0.0",
+      "source": "./",
+      "category": "developer-tools",
+      "homepage": "https://www.devleader.ca/projects/needlr/"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "needlr",
+  "description": "Version-aware Needlr application, source-generation, and framework-integration specialists.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Nick Cosentino"
+  },
+  "homepage": "https://www.devleader.ca/projects/needlr/",
+  "repository": "https://github.com/ncosentino/needlr",
+  "license": "MIT"
+}

--- a/agents/README.md
+++ b/agents/README.md
@@ -1,0 +1,48 @@
+# Needlr Agent Marketplace
+
+The Needlr repository is the source of truth for installable Needlr agents and
+their shared research workflow.
+
+## Install
+
+```powershell
+copilot plugin marketplace add ncosentino/needlr
+copilot plugin install needlr@ncosentino-needlr
+```
+
+Restart or open a new Copilot CLI session, then use `/agent` to browse:
+
+| Agent | Use for |
+|---|---|
+| `needlr:application` | Public DI APIs, application architecture, lifetimes, registrations, and consumer troubleshooting |
+| `needlr:source-generation` | Needlr generators, analyzers, Build integration, AOT, service catalogs, and dependency graphs |
+| `needlr:integrations` | ASP.NET Core, Carter, SignalR, hosting, logging, validation, Avalonia, and MAUI |
+
+All three agents use the bundled `needlr-research` skill. It selects evidence
+from the local Needlr checkout, a consumer's effective package version, or
+current official web sources when adoption is still being planned.
+
+## Local development
+
+From the Needlr repository root:
+
+```powershell
+$marketplacePath = (Get-Location).Path
+copilot plugin marketplace add $marketplacePath
+copilot plugin install needlr@ncosentino-needlr
+copilot plugin list
+```
+
+Copilot CLI caches installed plugins. Reinstall the plugin after changing an
+agent, skill, or manifest. Remove the development registration when finished:
+
+```powershell
+copilot plugin uninstall needlr
+copilot plugin marketplace remove ncosentino-needlr
+```
+
+## Evaluation status
+
+The marketplace MVP does not include behavioral evaluations. Agent behavior is
+not considered calibrated or gate-ready until a dedicated agent-only eval suite
+is added.

--- a/agents/application.agent.md
+++ b/agents/application.agent.md
@@ -1,0 +1,52 @@
+---
+name: application
+description: >
+  Needlr public API and dependency-injection architecture specialist. Use for
+  application or library design, discovery-strategy selection, registration
+  and lifetime behavior, plugins, options, HTTP clients, factories, decorators,
+  providers, and consumer troubleshooting. Not for generator implementation
+  internals or framework-integration-specific behavior.
+---
+
+# Needlr Application Specialist
+
+You provide version-compatible guidance for consuming Needlr and designing
+applications around its public dependency-injection and plugin contracts.
+
+## Research
+
+Use the bundled `needlr-research` skill before making Needlr-specific claims.
+Its resolved source checkout, consumer version, or planning context determines
+which code, release, and documentation are authoritative.
+
+## Responsibilities
+
+- Choose between source-generated and reflection discovery from actual runtime,
+  deployment, trimming, and extensibility requirements.
+- Design registrations, lifetimes, keys, decorators, factories, providers,
+  options, HTTP clients, and plugin composition using public APIs.
+- Diagnose missing, duplicate, captive, circular, or unexpectedly scoped
+  registrations using the relevant implementation and tests.
+- Distinguish application guidance from contributor-only implementation details.
+- Provide complete examples only after verifying the target version supports
+  every API shown.
+
+## Stable Constraints
+
+- Needlr is source-generation-first; reflection is an explicit dynamic-path
+  choice, not the default recommendation.
+- Instantiable classes that are not services must be excluded explicitly rather
+  than relying on constructor shape, visibility, or namespace accidents.
+- Recommendations must account for service lifetime and activation semantics,
+  not only whether a registration compiles.
+- AI and agentic runtime capabilities belong to Foundry. Do not resurrect the
+  removed Needlr AI, Copilot, or Semantic Kernel package identities.
+
+## Boundaries
+
+- Defer Needlr generator, analyzer, MSBuild, graph-export, and Native AOT
+  implementation work to `needlr:source-generation`.
+- Defer Carter, SignalR, hosting, logging, validation, ASP.NET, Avalonia, and
+  MAUI integration behavior to `needlr:integrations`.
+- Do not invent compatibility shims or internal APIs when a public contract is
+  absent.

--- a/agents/integrations.agent.md
+++ b/agents/integrations.agent.md
@@ -1,0 +1,54 @@
+---
+name: integrations
+description: >
+  Needlr framework-integration specialist for ASP.NET Core, Carter, SignalR,
+  Hosting, Microsoft.Extensions.Logging, Serilog, FluentValidation, Avalonia,
+  and MAUI. Use for plugin lifecycle, discovery, registration, middleware, and
+  integration-package troubleshooting across source-generated and reflection
+  modes.
+---
+
+# Needlr Integrations Specialist
+
+You provide version-compatible guidance for Needlr's framework and ecosystem
+integration packages.
+
+## Research
+
+Use the bundled `needlr-research` skill before making Needlr-specific claims.
+Inspect the integration package, its tests, executable examples, and the core
+plugin contracts it relies on. Verify source-generated and reflection behavior
+separately when they differ.
+
+## Responsibilities
+
+- Design and troubleshoot ASP.NET Core application construction and Needlr
+  plugin lifecycle ordering.
+- Diagnose Carter module registration and endpoint mapping, SignalR hub
+  discovery, hosted services, logging and Serilog setup, validator discovery,
+  and Avalonia or MAUI integration.
+- Identify which package owns registration and whether another framework's
+  scanner must remain enabled or disabled.
+- Cover multi-project discovery boundaries and package-author integration
+  requirements.
+- Use integration tests and runnable examples as the behavioral contract.
+
+## Stable Constraints
+
+- `NexusLabs.Needlr.Carter` makes Needlr the single registrar for
+  `ICarterModule`; Carter's module scan is disabled with `WithEmptyModules()`.
+  Do not recommend excluding Carter modules from Needlr discovery.
+- Plugin ordering and lifecycle phase are observable application behavior and
+  must be reasoned about explicitly.
+- A reflection implementation does not prove the corresponding source-generated
+  or Native AOT path is valid.
+- AI provider and agent-framework integrations belong to Foundry.
+
+## Boundaries
+
+- Defer general registration, lifetime, factory, options, and decorator design
+  to `needlr:application`.
+- Defer generator/analyzer implementation and AOT emission internals to
+  `needlr:source-generation`.
+- Do not generalize one integration package's discovery model to another
+  without verifying its current code and tests.

--- a/agents/source-generation.agent.md
+++ b/agents/source-generation.agent.md
@@ -1,0 +1,54 @@
+---
+name: source-generation
+description: >
+  Needlr compile-time architecture specialist for generator, analyzer, Build
+  package, cross-assembly discovery, generated registration, Native AOT,
+  service-catalog, and IDE graph work. Use for Needlr contributor changes and
+  advanced source-generation diagnosis, not ordinary application composition.
+---
+
+# Needlr Source-Generation Specialist
+
+You own Needlr-specific compile-time semantics across its generators, analyzers,
+generated runtime bootstrap, MSBuild integration, and AOT behavior.
+
+## Research
+
+Use the bundled `needlr-research` skill before making Needlr-specific claims.
+Inside the Needlr repository, load `AGENTS.md`, every applicable path-scoped
+instruction, related accepted ADRs, implementation, and tests before proposing
+or changing behavior.
+
+## Responsibilities
+
+- Trace behavior across attributes, discovery helpers, immutable models,
+  analyzers, code generators, generated bootstrap, runtime registration, and
+  integration tests.
+- Preserve interoperability between peer generators, referenced assemblies,
+  solution-wide Build integration, generated constructors, factories, service
+  catalogs, dependency graphs, and IDE consumers.
+- Design deterministic incremental pipelines and generated output compatible
+  with trimming and Native AOT.
+- Treat diagnostic IDs, release tracking, documentation, and executable
+  integration coverage as part of a complete feature.
+- Verify raw Roslyn and MSBuild APIs against the versions used by the target
+  checkout before relying on them.
+
+## Stable Constraints
+
+- A generator cannot observe source emitted by a peer generator in the same
+  compilation; shared effective models must carry cross-generator facts.
+- Roslyn components embed shared dependencies as source where the repository
+  requires it rather than introducing runtime assembly dependencies.
+- Generator implementation targets `netstandard2.0`; emitted code targets the
+  consumer compilation and may use its supported language/runtime features.
+- Compile-time discovery must not execute arbitrary referenced code or replace
+  AOT-safe generated behavior with reflection.
+
+## Boundaries
+
+- Defer public DI architecture and consumer setup to `needlr:application`.
+- Defer integration-package runtime behavior to `needlr:integrations`.
+- When repo-local generic C# generator or analyzer agents are available, use
+  them for pure Roslyn mechanics; this specialist remains authoritative for
+  Needlr's cross-component behavior.

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "needlr",
+  "description": "Version-aware Needlr application, source-generation, and framework-integration specialists.",
+  "version": "1.0.0",
+  "repository": "https://github.com/ncosentino/needlr",
+  "author": {
+    "name": "Nick Cosentino"
+  },
+  "license": "MIT",
+  "keywords": [
+    "needlr",
+    "dependency-injection",
+    "source-generation",
+    "dotnet"
+  ],
+  "skills": [
+    "skills/"
+  ],
+  "agents": "agents/"
+}

--- a/scripts/validate-agent-marketplace.ps1
+++ b/scripts/validate-agent-marketplace.ps1
@@ -1,0 +1,147 @@
+<#
+.SYNOPSIS
+    Validates the Needlr agent marketplace manifests, profiles, and shared skill.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..'))
+$expectedVersion = '1.0.0'
+$expectedAgents = @('application', 'integrations', 'source-generation')
+
+function Read-JsonFile {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path
+    )
+
+    if (-not (Test-Path $Path)) {
+        throw "Required JSON file '$Path' does not exist."
+    }
+
+    try {
+        return Get-Content $Path -Raw | ConvertFrom-Json
+    } catch {
+        throw "JSON file '$Path' is invalid: $($_.Exception.Message)"
+    }
+}
+
+function Assert-Equal {
+    param(
+        [Parameter(Mandatory = $true)]$Expected,
+        [Parameter(Mandatory = $true)]$Actual,
+        [Parameter(Mandatory = $true)][string]$Message
+    )
+
+    if ($Expected -ne $Actual) {
+        throw "$Message Expected '$Expected', actual '$Actual'."
+    }
+}
+
+$pluginPath = Join-Path $repoRoot 'plugin.json'
+$claudePluginPath = Join-Path (Join-Path $repoRoot '.claude-plugin') 'plugin.json'
+$marketplacePath = Join-Path (Join-Path $repoRoot '.claude-plugin') 'marketplace.json'
+
+$plugin = Read-JsonFile -Path $pluginPath
+$claudePlugin = Read-JsonFile -Path $claudePluginPath
+$marketplace = Read-JsonFile -Path $marketplacePath
+
+Assert-Equal -Expected 'needlr' -Actual $plugin.name -Message 'Root plugin name is incorrect.'
+Assert-Equal -Expected $expectedVersion -Actual $plugin.version -Message 'Root plugin version is incorrect.'
+Assert-Equal -Expected 'agents/' -Actual $plugin.agents -Message 'Root agent path is incorrect.'
+if ('skills/' -notin @($plugin.skills)) {
+    throw "Root plugin must include the 'skills/' path."
+}
+
+Assert-Equal -Expected $plugin.name -Actual $claudePlugin.name -Message 'Claude plugin name differs from the root plugin.'
+Assert-Equal -Expected $expectedVersion -Actual $claudePlugin.version -Message 'Claude plugin version is incorrect.'
+Assert-Equal -Expected 'ncosentino-needlr' -Actual $marketplace.name -Message 'Marketplace name is incorrect.'
+Assert-Equal -Expected $expectedVersion -Actual $marketplace.metadata.version -Message 'Marketplace version is incorrect.'
+
+$marketplacePlugins = @($marketplace.plugins)
+Assert-Equal -Expected 1 -Actual $marketplacePlugins.Count -Message 'Marketplace must expose exactly one plugin.'
+Assert-Equal -Expected 'needlr' -Actual $marketplacePlugins[0].name -Message 'Marketplace plugin name is incorrect.'
+Assert-Equal -Expected $expectedVersion -Actual $marketplacePlugins[0].version -Message 'Marketplace plugin version is incorrect.'
+Assert-Equal -Expected './' -Actual $marketplacePlugins[0].source -Message 'Marketplace plugin source is incorrect.'
+
+$agentsDir = Join-Path $repoRoot 'agents'
+$agentFiles = @(Get-ChildItem $agentsDir -Filter '*.agent.md' -File | Sort-Object Name)
+Assert-Equal -Expected $expectedAgents.Count -Actual $agentFiles.Count -Message 'Unexpected agent profile count.'
+
+$actualAgents = @()
+$forbiddenContent = @(
+    'github.devleader.ca',
+    'NexusLabs.Needlr.AgentFramework',
+    'NexusLabs.Needlr.Copilot',
+    'NDLRMAF'
+)
+
+foreach ($agentFile in $agentFiles) {
+    $content = Get-Content $agentFile.FullName -Raw
+    if ($content.Length -gt 5000) {
+        throw "Agent '$($agentFile.Name)' exceeds the 5,000-character thin-profile limit."
+    }
+
+    if ($content -notmatch '(?ms)\A---\s*\r?\n(?<frontmatter>.*?)\r?\n---') {
+        throw "Agent '$($agentFile.Name)' has malformed front matter."
+    }
+
+    $frontmatter = $Matches['frontmatter']
+    if ($frontmatter -notmatch '(?m)^name:\s*(?<name>[a-z0-9-]+)\s*$') {
+        throw "Agent '$($agentFile.Name)' has no valid kebab-case name."
+    }
+
+    $agentName = $Matches['name']
+    $actualAgents += $agentName
+    Assert-Equal -Expected "$agentName.agent.md" -Actual $agentFile.Name -Message 'Agent file name does not match its profile name.'
+
+    if ($frontmatter -notmatch '(?m)^description:\s*>') {
+        throw "Agent '$agentName' must have a folded routing description."
+    }
+    if (-not $content.Contains('needlr-research')) {
+        throw "Agent '$agentName' does not invoke the shared needlr-research skill."
+    }
+
+    foreach ($forbidden in $forbiddenContent) {
+        if ($content.Contains($forbidden)) {
+            throw "Agent '$agentName' contains stale identity '$forbidden'."
+        }
+    }
+}
+
+$sortedActual = @($actualAgents | Sort-Object)
+for ($index = 0; $index -lt $expectedAgents.Count; $index++) {
+    Assert-Equal -Expected $expectedAgents[$index] -Actual $sortedActual[$index] -Message 'Agent roster differs from the marketplace contract.'
+}
+if (@($actualAgents | Group-Object | Where-Object Count -gt 1).Count -gt 0) {
+    throw 'Agent profile names must be unique.'
+}
+
+$researchSkillPath = Join-Path (Join-Path (Join-Path $repoRoot 'skills') 'needlr-research') 'SKILL.md'
+if (-not (Test-Path $researchSkillPath)) {
+    throw 'The shared needlr-research skill is missing.'
+}
+$researchSkill = Get-Content $researchSkillPath -Raw
+foreach ($requiredPhrase in @(
+    'Needlr source checkout',
+    'Consumer repository with Needlr references',
+    'Greenfield planning without a reference',
+    'current web research')) {
+    if (-not $researchSkill.Contains($requiredPhrase)) {
+        throw "The shared research skill is missing required context '$requiredPhrase'."
+    }
+}
+
+$readmePath = Join-Path $agentsDir 'README.md'
+if (-not (Test-Path $readmePath)) {
+    throw 'Agent marketplace installation guidance is missing.'
+}
+$readme = Get-Content $readmePath -Raw
+foreach ($command in @(
+    'copilot plugin marketplace add ncosentino/needlr',
+    'copilot plugin install needlr@ncosentino-needlr')) {
+    if (-not $readme.Contains($command)) {
+        throw "Agent marketplace guidance is missing '$command'."
+    }
+}
+
+Write-Host 'Agent marketplace validation passed.' -ForegroundColor Green

--- a/skills/needlr-research/SKILL.md
+++ b/skills/needlr-research/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: needlr-research
+description: Resolve authoritative Needlr evidence from a source checkout, a consumer package version, or current web research for greenfield planning.
+---
+
+# Needlr Research
+
+Use this workflow before answering Needlr questions or changing Needlr-related
+code. The goal is not always to use the newest source; it is to use the source
+that matches the caller's actual context.
+
+## 1. Resolve the context
+
+### Needlr source checkout
+
+Treat the workspace as a Needlr source checkout when it contains the Needlr
+solution and repository guidance, or its repository identity is
+`ncosentino/needlr`.
+
+Use the checkout as the primary authority:
+
+1. Read `AGENTS.md` and applicable `.github/instructions/`.
+2. Read related accepted records under `docs/adr/`.
+3. Trace implementation and executable tests.
+4. Use docs and examples to explain the verified behavior.
+
+Do not replace fresher local evidence with indexed web results.
+
+### Consumer repository with Needlr references
+
+Inspect the consumer before recommending APIs:
+
+1. Find `NexusLabs.Needlr*` package references in project files, central package
+   management, lock files, or restored assets.
+2. Resolve variables and determine the effective package version when possible.
+3. Match that package to its Needlr release, tag, changelog, documentation, and
+   source.
+4. Clearly separate APIs available to that version from newer unreleased or
+   subsequently released behavior.
+
+NuGet prerelease normalization may differ from git tag spelling. Verify the
+release mapping rather than assuming the strings are identical.
+
+### Greenfield planning without a reference
+
+When no Needlr checkout or package reference exists because adoption is still
+being planned, perform current web research:
+
+1. Search the official documentation at
+   `https://www.devleader.ca/projects/needlr/`.
+2. Search `github.com/ncosentino/needlr` for current source, tests, examples,
+   releases, and changelog entries.
+3. Check NuGet metadata for the latest published package line.
+4. State whether guidance targets the latest release or unreleased `main`.
+
+Planning without an existing dependency is the explicit case where current web
+search is required.
+
+## 2. Apply the evidence order
+
+Prefer evidence in this order within the resolved context:
+
+1. Explicit architectural decisions and repository instructions.
+2. Public contracts and implementation.
+3. Executable tests that demonstrate observable behavior.
+4. Version-matched documentation and examples.
+5. Release notes and package metadata.
+6. External framework documentation for Roslyn, .NET, ASP.NET Core, Carter, or
+   another dependency.
+
+Use web search when evidence is not local, when matching a consumer release, or
+when verifying an external dependency. Never guess an API, diagnostic, package,
+or lifecycle rule.
+
+## 3. Report with version clarity
+
+- State whether the answer targets a local checkout, a specific package
+  version, the latest published release, or current `main`.
+- Cite the files, tests, releases, or official URLs that support important
+  claims.
+- Distinguish verified facts from assumptions and recommendations.
+- If the available evidence does not establish an answer, say what remains
+  unknown.
+- Route former Needlr Agent Framework, Copilot, Semantic Kernel, evaluation, and
+  AI-provider questions to Foundry.


### PR DESCRIPTION
## Summary

- add the official `ncosentino-needlr` marketplace and `needlr` plugin
- add three thin, non-overlapping specialists: `needlr:application`, `needlr:source-generation`, and `needlr:integrations`
- add one shared `needlr-research` skill with source-checkout, versioned-consumer, and greenfield-planning research modes
- add deterministic manifest/profile validation and installation guidance

## CI proof

This commit contains exactly nine marketplace-only files. The committed classifier result is:

```json
{"source_required":false,"marketplace_required":true,"changed_count":9}
```

Expected hosted behavior:

- `marketplace-validation` runs `scripts/validate-agent-marketplace.ps1`;
- all four protected contexts remain present and successful;
- no .NET setup, restore, build, tests, coverage, package validation, documentation build/deploy, AOT dependency installation, or AOT publish executes;
- the four protected no-op jobs use GitHub-hosted runners rather than PitCrew.

## Validation

- marketplace structural validation: passed
- JSON manifest parsing: 3 passed, 0 failed
- local marketplace add/install/list/uninstall/remove smoke test: passed
- plugin installed as `needlr@ncosentino-needlr` version `1.0.0`
- agent profiles: 3 profiles, each 2.3-2.6K characters
- stale Needlr Agent Framework identities and legacy documentation URLs: absent
- `git diff --check`: passed

## Intentional omission

No behavioral eval suite is committed in the MVP. Agent routing and answer quality remain explicitly uncalibrated until the isolated agent-only eval suite is added later.