### PR TITLE
ci: add trusted pull request merging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,13 +231,13 @@ jobs:
       run: python scripts/build-sitemap-index.py ./site
 
     - name: Add Coverage Report to Site
-      if: needs.changes.outputs.source_required == 'true' && github.ref == 'refs/heads/main' && github.event_name == 'push'
+      if: needs.changes.outputs.source_required == 'true' && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
       run: |
         mkdir -p site/coverage
         cp -r coverage/report/* site/coverage/
 
     - name: Restrict deploy to ci.yml-owned paths
-      if: needs.changes.outputs.source_required == 'true' && success() && github.ref == 'refs/heads/main' && github.event_name == 'push'
+      if: needs.changes.outputs.source_required == 'true' && success() && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
       run: |
         # ci.yml owns: /api/dev/*, /coverage/*, home, feature pages, assets.
         # release.yml owns: /api/stable/*, /api/v<version>/*.
@@ -254,7 +254,7 @@ jobs:
         echo "Restricted ./site/ to ci.yml-owned paths."
 
     - name: Deploy Documentation and Coverage
-      if: needs.changes.outputs.source_required == 'true' && success() && github.ref == 'refs/heads/main' && github.event_name == 'push'
+      if: needs.changes.outputs.source_required == 'true' && success() && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
       uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -266,7 +266,7 @@ jobs:
     # by keep_files above) -- check it out fresh and mirror that whole tree
     # to Cloudflare Pages, rather than deploying our own partial ./site/.
     - name: Checkout gh-pages for Cloudflare mirror
-      if: needs.changes.outputs.source_required == 'true' && success() && github.ref == 'refs/heads/main' && github.event_name == 'push'
+      if: needs.changes.outputs.source_required == 'true' && success() && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
       uses: actions/checkout@v4
       with:
         ref: gh-pages
@@ -277,17 +277,17 @@ jobs:
     # older archives stay in gh-pages history but are not published here.
     # Also removes the checkout's .git so it is not uploaded.
     - name: Trim mirror before Cloudflare deploy
-      if: needs.changes.outputs.source_required == 'true' && success() && github.ref == 'refs/heads/main' && github.event_name == 'push'
+      if: needs.changes.outputs.source_required == 'true' && success() && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
       run: python scripts/trim-cloudflare-mirror.py gh-pages-mirror --keep 20
 
     - name: Setup Node.js
-      if: needs.changes.outputs.source_required == 'true' && success() && github.ref == 'refs/heads/main' && github.event_name == 'push'
+      if: needs.changes.outputs.source_required == 'true' && success() && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
       uses: actions/setup-node@v4
       with:
         node-version: '24'
 
     - name: Deploy Documentation to Cloudflare Pages
-      if: needs.changes.outputs.source_required == 'true' && success() && github.ref == 'refs/heads/main' && github.event_name == 'push'
+      if: needs.changes.outputs.source_required == 'true' && success() && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
       uses: cloudflare/wrangler-action@v4
       with:
         apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,13 +36,13 @@ jobs:
                 repo: context.repo.repo,
                 workflow_id: 'ci.yml',
                 branch: 'main',
-                event: 'push',
                 per_page: 100
               });
               const run = data.workflow_runs
                 .filter(candidate =>
                   candidate.head_sha === context.sha &&
-                  candidate.head_branch === 'main')
+                  candidate.head_branch === 'main' &&
+                  ['push', 'workflow_dispatch'].includes(candidate.event))
                 .sort((left, right) =>
                   new Date(right.created_at) - new Date(left.created_at))[0];
 

--- a/.github/workflows/trusted-auto-merge.yml
+++ b/.github/workflows/trusted-auto-merge.yml
@@ -1,0 +1,89 @@
+name: Trusted pull request auto-merge
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+  schedule:
+    - cron: '*/5 * * * *'
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: trusted-pull-request-auto-merge
+  cancel-in-progress: false
+
+jobs:
+  merge:
+    if: vars.TRUSTED_AUTO_MERGE_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # This workflow runs only from the protected default branch. It must never
+      # check out or execute pull request code.
+      - name: Merge eligible trusted pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          OWNER: ${{ github.repository_owner }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          pull_requests="$(
+            gh api --paginate --slurp \
+              "repos/$GITHUB_REPOSITORY/pulls?state=open&base=main&per_page=100"
+          )"
+
+          while IFS= read -r pull_request; do
+            number="$(jq -r '.number' <<< "$pull_request")"
+            draft="$(jq -r '.draft' <<< "$pull_request")"
+            head_repo="$(jq -r '.head.repo.full_name // ""' <<< "$pull_request")"
+            head_sha="$(jq -r '.head.sha' <<< "$pull_request")"
+            author_login="$(jq -r '.user.login' <<< "$pull_request")"
+            author_id="$(jq -r '.user.id' <<< "$pull_request")"
+            author_type="$(jq -r '.user.type' <<< "$pull_request")"
+
+            if [[ "$draft" == "true" || "$head_repo" != "$GITHUB_REPOSITORY" ]]; then
+              continue
+            fi
+
+            if [[ "$author_login" == "$OWNER" ]]; then
+              # Owner-authored PRs are trusted by policy. Cloud agents must open
+              # their own PRs so the current-head approval requirement applies.
+              :
+            elif [[ "$author_id" == "198982749" && "$author_type" == "Bot" ]]; then
+              reviews="$(
+                gh api --paginate --slurp \
+                  "repos/$GITHUB_REPOSITORY/pulls/$number/reviews"
+              )"
+              latest_owner_review="$(
+                jq -r \
+                  --arg owner "$OWNER" \
+                  --arg head "$head_sha" \
+                  '[.[][] | select(
+                    .user.login == $owner and
+                    .commit_id == $head and
+                    (.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED")
+                  )] | last | .state // ""' \
+                  <<< "$reviews"
+              )"
+
+              if [[ "$latest_owner_review" != "APPROVED" ]]; then
+                continue
+              fi
+            else
+              continue
+            fi
+
+            if gh pr merge "$number" \
+              --repo "$GITHUB_REPOSITORY" \
+              --squash \
+              --match-head-commit "$head_sha"; then
+              gh workflow run ci.yml --repo "$GITHUB_REPOSITORY" --ref main
+              break
+            fi
+          done < <(jq -c '.[][]' <<< "$pull_requests")


### PR DESCRIPTION
## Summary

Add a protected-default-branch scheduler that merges eligible pull requests only after the existing required checks succeed.

- Draft and fork pull requests are never merged automatically.
- Same-repository pull requests authored by `ncosentino` are eligible after protected checks.
- Copilot coding-agent pull requests require an `APPROVED` review from `ncosentino` on the exact current head commit.
- Other authors and bots remain manual-review-only.
- Merges use exact-head squash semantics and process at most one pull request per scheduler run.
- Main CI is dispatched after an automated merge so documentation, coverage, deployment, and release evidence continue to run.

## Workflow compatibility

- Main-only documentation, coverage, and deployment steps now accept the trusted post-merge `workflow_dispatch` event in addition to `push`.
- Release verification accepts exact-main successful CI runs from either `push` or `workflow_dispatch` while retaining exact SHA, branch, completion, and success checks.

## Security boundary

The scheduler runs only from the default branch through `workflow_run`, `schedule`, or manual dispatch. It never checks out or executes pull-request code. External fork workflows require explicit approval through repository settings. Native GitHub auto-merge remains disabled.

## Rollout

`TRUSTED_AUTO_MERGE_ENABLED` is installed as `false`. This bootstrap pull request must merge manually; the variable is enabled only after the workflow exists on `main`.

## Validation

- 2,723 tests passed, 0 failed, 0 skipped.
- Release build completed with 3 pre-existing generated-example warnings and 0 errors.
- Changed workflow YAML parsed successfully.
- Scheduler Bash and release verification script syntax passed.