### PR TITLE
ci: migrate Needlr to Genesis PR-first delivery

### DIFF
--- a/.genesis/delivery/private-auto-merge.yml
+++ b/.genesis/delivery/private-auto-merge.yml
@@ -1,0 +1,246 @@
+name: Private PR auto-merge
+
+on:
+  workflow_run:
+    workflows:
+      # __GENESIS_WORKFLOW_NAMES__
+    types: [completed]
+
+permissions:
+  checks: read
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: private-auto-merge-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  merge:
+    name: Merge tested pull request
+    if: >-
+      vars.GENESIS_DELIVERY_MODEL == 'workflow-run' &&
+      (
+        github.event.workflow_run.event == 'pull_request' ||
+        (
+          github.event.workflow_run.path == '.github/workflows/pr-review-policy.yml' &&
+          (
+            github.event.workflow_run.event == 'pull_request_target' ||
+            github.event.workflow_run.event == 'pull_request_review'
+          )
+        )
+      ) &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      GH_PROMPT_DISABLED: '1'
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+      GIT_TERMINAL_PROMPT: '0'
+      REQUIRED_CHECK_APP_ID: '15368'
+      TRIGGER_DISPLAY_TITLE: ${{ github.event.workflow_run.display_title }}
+      TRIGGER_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+      TRIGGER_WORKFLOW_PATH: ${{ github.event.workflow_run.path }}
+    steps:
+      - name: Merge the exact tested pull request
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          tested_sha="$TRIGGER_HEAD_SHA"
+          trigger_pr_number=''
+          if [ "$TRIGGER_WORKFLOW_PATH" = '.github/workflows/pr-review-policy.yml' ]; then
+            if [[ "$TRIGGER_DISPLAY_TITLE" =~ ^Review\ policy\ for\ \#([0-9]+)\ at\ ([0-9a-f]{40})$ ]]; then
+              trigger_pr_number="${BASH_REMATCH[1]}"
+              tested_sha="${BASH_REMATCH[2]}"
+            else
+              echo "::error::Review policy run title does not identify an exact pull request SHA."
+              exit 1
+            fi
+          fi
+
+          repository="$(gh api "repos/$GH_REPO")"
+          default_branch="$(jq -r '.default_branch' <<<"$repository")"
+          repository_id="$(jq -r '.id' <<<"$repository")"
+          contract="$(
+            gh api \
+              -H 'Accept: application/vnd.github.raw+json' \
+              "repos/$GH_REPO/contents/.github/genesis-delivery.json?ref=$default_branch"
+          )"
+
+          pull_requests="$(
+            gh api "repos/$GH_REPO/commits/$tested_sha/pulls" |
+              jq --arg sha "$tested_sha" --arg repo "$GH_REPO" --arg base "$default_branch" '
+                [
+                  .[]
+                  | select(
+                      .state == "open"
+                      and .base.ref == $base
+                      and .head.sha == $sha
+                      and .head.repo.full_name == $repo
+                      and .draft == false
+                    )
+                ]
+              '
+          )"
+          pull_request_count="$(jq 'length' <<<"$pull_requests")"
+
+          if [ "$pull_request_count" -eq 0 ]; then
+            echo "No ready same-repository pull request targets $default_branch at $tested_sha."
+            exit 0
+          fi
+          if [ "$pull_request_count" -ne 1 ]; then
+            echo "::error::$pull_request_count pull requests match tested commit $tested_sha."
+            exit 1
+          fi
+
+          pull_request_number="$(jq -r '.[0].number' <<<"$pull_requests")"
+          if [ -n "$trigger_pr_number" ] && [ "$pull_request_number" != "$trigger_pr_number" ]; then
+            echo "::error::Review policy run identified pull request $trigger_pr_number, but commit lookup found $pull_request_number."
+            exit 1
+          fi
+          pull_request="$(gh api "repos/$GH_REPO/pulls/$pull_request_number")"
+          current_sha="$(jq -r '.head.sha' <<<"$pull_request")"
+          current_base="$(jq -r '.base.ref' <<<"$pull_request")"
+          current_repo="$(jq -r '.head.repo.full_name' <<<"$pull_request")"
+          head_ref="$(jq -r '.head.ref // empty' <<<"$pull_request")"
+          head_repo_id="$(jq -r '.head.repo.id // empty' <<<"$pull_request")"
+          base_repo_id="$(jq -r '.base.repo.id // empty' <<<"$pull_request")"
+          current_state="$(jq -r '.state' <<<"$pull_request")"
+          current_draft="$(jq -r '.draft' <<<"$pull_request")"
+          current_title="$(jq -r '.title' <<<"$pull_request")"
+
+          if [ "$current_state" != "open" ] ||
+             [ "$current_draft" != "false" ] ||
+             [ "$current_base" != "$default_branch" ] ||
+             [ "$current_repo" != "$GH_REPO" ] ||
+             [ "$current_sha" != "$tested_sha" ]; then
+            echo "Pull request $pull_request_number changed after validation; leaving it open."
+            exit 0
+          fi
+          if [ -z "$head_ref" ] ||
+             [ "$head_repo_id" != "$repository_id" ] ||
+             [ "$base_repo_id" != "$repository_id" ] ||
+             [ "$head_ref" = "$default_branch" ]; then
+            echo "::error::Pull request $pull_request_number does not have a deletable same-repository head branch."
+            exit 1
+          fi
+          full_ref="refs/heads/$head_ref"
+          git check-ref-format --branch "$head_ref" >/dev/null
+          git check-ref-format "$full_ref" >/dev/null
+
+          title_pattern="$(jq -r '.pullRequestTitle.pattern' <<<"$contract")"
+          title_max_length="$(jq -r '.pullRequestTitle.maxLength' <<<"$contract")"
+          if [[ "$current_title" == *$'\n'* || "$current_title" == *$'\r'* ]] ||
+             (( ${#current_title} > title_max_length )) ||
+             [[ ! "$current_title" =~ $title_pattern ]]; then
+            echo "::error::Pull request $pull_request_number has an invalid conventional title."
+            exit 1
+          fi
+
+          check_runs="$(
+            gh api \
+              --paginate \
+              --slurp \
+              "repos/$GH_REPO/commits/$tested_sha/check-runs?filter=latest&per_page=100" |
+              jq '{check_runs: [.[].check_runs[]]}'
+          )"
+          while IFS= read -r required_check; do
+            conclusion="$(
+              jq -r \
+                --arg name "$required_check" \
+                --argjson app_id "$REQUIRED_CHECK_APP_ID" '
+                [
+                  .check_runs[]
+                  | select(.name == $name and .app.id == $app_id)
+                ] | first | .conclusion // ""
+              ' <<<"$check_runs"
+            )"
+            if [ "$conclusion" != "success" ]; then
+              echo "Required check '$required_check' is '$conclusion'; leaving pull request open."
+              exit 0
+            fi
+          done < <(jq -r '.requiredChecks[]' <<<"$contract")
+
+          current_base_sha="$(gh api "repos/$GH_REPO/commits/$default_branch" --jq '.sha')"
+          comparison_status="$(
+            gh api "repos/$GH_REPO/compare/$current_base_sha...$tested_sha" --jq '.status'
+          )"
+          if [ "$comparison_status" != 'ahead' ] && [ "$comparison_status" != 'identical' ]; then
+            echo "Pull request $pull_request_number does not contain current $default_branch commit $current_base_sha; update the branch and rerun CI."
+            exit 0
+          fi
+
+          merge_response="$(
+            gh api \
+              --method PUT \
+              "repos/$GH_REPO/pulls/$pull_request_number/merge" \
+              -f merge_method=squash \
+              -f sha="$tested_sha"
+          )"
+          if [ "$(jq -r '.merged' <<<"$merge_response")" != "true" ]; then
+            message="$(jq -r '.message // "GitHub declined the merge."' <<<"$merge_response")"
+            echo "::error::Pull request $pull_request_number was not merged: $message"
+            exit 1
+          fi
+
+          merge_sha="$(jq -r '.sha' <<<"$merge_response")"
+          echo "Merged pull request $pull_request_number at $merge_sha."
+
+          cleanup_default="$(gh api "repos/$GH_REPO" --jq '.default_branch')"
+          if [ "$head_ref" = "$cleanup_default" ]; then
+            echo "::error::Refusing to delete the current default branch '$head_ref'."
+            exit 1
+          fi
+
+          control_repo="$(mktemp -d "${RUNNER_TEMP:?}/genesis-merge-control.XXXXXX")"
+          trap 'rm -rf "$control_repo"' EXIT
+          git init --quiet "$control_repo"
+          gh auth setup-git --hostname github.com --force
+          remote_url="https://github.com/${GH_REPO}.git"
+
+          set +e
+          push_output="$(
+            git -C "$control_repo" push --porcelain \
+              "--force-with-lease=${full_ref}:${tested_sha}" \
+              "$remote_url" \
+              ":${full_ref}" 2>&1
+          )"
+          push_status=$?
+          set -e
+          printf '%s\n' "$push_output"
+
+          if (( push_status == 0 )); then
+            echo "Deleted merged head branch '$head_ref' at $tested_sha."
+            exit 0
+          fi
+
+          set +e
+          remote_record="$(
+            git -C "$control_repo" ls-remote \
+              --quiet --exit-code --refs \
+              "$remote_url" "$full_ref" 2>&1
+          )"
+          lookup_status=$?
+          set -e
+
+          case "$lookup_status" in
+            2)
+              echo "Head branch '$head_ref' is already absent; cleanup succeeded."
+              ;;
+            0)
+              read -r remote_sha _ <<<"$remote_record"
+              if [ "$remote_sha" != "$tested_sha" ]; then
+                echo "::error::Head branch advanced to $remote_sha; refusing deletion."
+              else
+                echo "::error::Head branch remains at $tested_sha, but deletion was rejected."
+              fi
+              exit 1
+              ;;
+            *)
+              printf '%s\n' "$remote_record" >&2
+              echo "::error::Unable to determine branch state after deletion failure."
+              exit 1
+              ;;
+          esac

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,41 @@
+#!/bin/sh
+#
+# Allows initial default-branch creation only against an empty remote.
+# Every later default-branch update or deletion remains blocked.
+
+default_branch="$(git config --get genesis.defaultBranch)"
+if [ -z "$default_branch" ]; then
+    default_branch="main"
+fi
+protected_ref="refs/heads/$default_branch"
+zero_oid="0000000000000000000000000000000000000000"
+remote_url="$2"
+remote_heads_checked=false
+remote_heads=""
+
+while read local_ref local_oid remote_ref remote_oid; do
+    if [ "$remote_ref" != "$protected_ref" ]; then
+        continue
+    fi
+
+    if [ "$local_oid" != "$zero_oid" ] && [ "$remote_oid" = "$zero_oid" ]; then
+        if [ "$remote_heads_checked" = "false" ]; then
+            if ! remote_heads="$(git ls-remote --heads "$remote_url" 2>/dev/null)"; then
+                echo "Unable to inspect the remote before creating '$default_branch'." >&2
+                exit 1
+            fi
+            remote_heads_checked=true
+        fi
+        if [ -z "$remote_heads" ]; then
+            continue
+        fi
+    fi
+
+    echo ""
+    echo "Direct pushes to '$default_branch' are forbidden."
+    echo "Push a feature branch and deliver the change through a pull request."
+    echo ""
+    exit 1
+done
+
+exit 0

--- a/.github/genesis-delivery.json
+++ b/.github/genesis-delivery.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "./genesis-delivery.schema.json",
+  "schemaVersion": 1,
+  "template": "needlr",
+  "defaultBranch": "main",
+  "ciWorkflow": "CI",
+  "requiredChecks": [
+    "CI",
+    "PR title",
+    "Review policy"
+  ],
+  "draftValidation": {
+    "hostedDefault": "subset",
+    "pitcrewDefault": "subset",
+    "subsetJobs": [
+      "marketplace-validation",
+      "preflight"
+    ]
+  },
+  "runnerProfiles": [
+    {
+      "id": "linux-x64-general-purpose",
+      "source": "needlr-pitcrew",
+      "labels": [
+        "self-hosted",
+        "linux",
+        "x64",
+        "general-purpose"
+      ],
+      "jobs": [
+        "preflight",
+        "build-and-test",
+        "package-validation",
+        "aot-console-app",
+        "aot-web-app",
+        "deploy-documentation",
+        "release/publish",
+        "benchmarks/check-changes",
+        "benchmarks/run-benchmarks",
+        "ide-extensions/build-vscode",
+        "ide-extensions/release"
+      ]
+    }
+  ],
+  "componentWorkflows": [
+    {
+      "source": "needlr",
+      "path": ".github/workflows/maui-example.yml",
+      "roles": [
+        "draft-optional"
+      ],
+      "draftBehavior": "full",
+      "requiredChecks": []
+    },
+    {
+      "source": "needlr",
+      "path": ".github/workflows/benchmarks.yml",
+      "roles": [
+        "post-merge",
+        "release-deploy"
+      ],
+      "draftBehavior": "not-applicable",
+      "requiredChecks": []
+    },
+    {
+      "source": "needlr",
+      "path": ".github/workflows/ide-extensions.yml",
+      "roles": [
+        "release-deploy"
+      ],
+      "draftBehavior": "not-applicable",
+      "requiredChecks": []
+    },
+    {
+      "source": "needlr",
+      "path": ".github/workflows/release.yml",
+      "roles": [
+        "release-deploy"
+      ],
+      "draftBehavior": "not-applicable",
+      "requiredChecks": []
+    }
+  ],
+  "pullRequestTitle": {
+    "pattern": "^(feat|fix|docs|refactor|test|style|build|ci|chore|perf|revert)(\\([a-z0-9][a-z0-9._/-]*\\))?!?: .+$",
+    "maxLength": 72
+  },
+  "squashMerge": {
+    "method": "squash",
+    "title": "PR_TITLE",
+    "message": "PR_BODY"
+  }
+}

--- a/.github/genesis-delivery.schema.json
+++ b/.github/genesis-delivery.schema.json
@@ -1,0 +1,173 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://ncosentino.github.io/genesis/schemas/genesis-delivery.schema.json",
+  "title": "Genesis generated-project delivery contract",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "schemaVersion",
+    "template",
+    "defaultBranch",
+    "ciWorkflow",
+    "requiredChecks",
+    "draftValidation",
+    "runnerProfiles",
+    "componentWorkflows",
+    "pullRequestTitle",
+    "squashMerge"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "./genesis-delivery.schema.json"
+    },
+    "schemaVersion": {
+      "const": 1
+    },
+    "template": {
+      "type": "string",
+      "minLength": 1
+    },
+    "defaultBranch": {
+      "type": "string",
+      "minLength": 1
+    },
+    "ciWorkflow": {
+      "type": "string",
+      "minLength": 1
+    },
+    "requiredChecks": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "draftValidation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["hostedDefault", "pitcrewDefault", "subsetJobs"],
+      "properties": {
+        "hostedDefault": {
+          "enum": ["full", "subset", "ready-only"]
+        },
+        "pitcrewDefault": {
+          "enum": ["full", "subset", "ready-only"]
+        },
+        "subsetJobs": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "runnerProfiles": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "source", "labels", "jobs"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9-]*[a-z0-9]$|^[a-z]$"
+          },
+          "source": {
+            "type": "string",
+            "minLength": 1
+          },
+          "labels": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "jobs": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    },
+    "componentWorkflows": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["source", "path", "roles", "draftBehavior", "requiredChecks"],
+        "properties": {
+          "source": {
+            "type": "string",
+            "minLength": 1
+          },
+          "path": {
+            "type": "string",
+            "pattern": "^\\.github/workflows/.+\\.ya?ml$"
+          },
+          "roles": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "enum": ["merge-gate", "draft-optional", "post-merge", "release-deploy"]
+            }
+          },
+          "draftBehavior": {
+            "enum": ["full", "subset", "ready-only", "not-applicable"]
+          },
+          "requiredChecks": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    },
+    "pullRequestTitle": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["pattern", "maxLength"],
+      "properties": {
+        "pattern": {
+          "type": "string",
+          "minLength": 1
+        },
+        "maxLength": {
+          "const": 72
+        }
+      }
+    },
+    "squashMerge": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["method", "title", "message"],
+      "properties": {
+        "method": {
+          "const": "squash"
+        },
+        "title": {
+          "const": "PR_TITLE"
+        },
+        "message": {
+          "const": "PR_BODY"
+        }
+      }
+    }
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,18 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
   workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
@@ -13,8 +21,41 @@ env:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
 
 jobs:
+  validation-plan:
+    name: Validation plan
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      scope: ${{ steps.scope.outputs.scope }}
+
+    steps:
+    - name: Resolve validation scope
+      id: scope
+      shell: bash
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        IS_DRAFT: ${{ github.event.pull_request.draft || false }}
+        DRAFT_MODE: ${{ vars.CI_DRAFT_MODE || 'subset' }}
+      run: |
+        scope=full
+        if [ "$EVENT_NAME" = "pull_request" ] && [ "$IS_DRAFT" = "true" ]; then
+          scope="$DRAFT_MODE"
+        fi
+
+        case "$scope" in
+          full|subset|ready-only) ;;
+          *)
+            echo "::error::Unsupported validation scope '$scope'."
+            exit 1
+            ;;
+        esac
+
+        echo "scope=$scope" >> "$GITHUB_OUTPUT"
+        echo "Validation scope: $scope"
+
   changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
     outputs:
@@ -45,9 +86,10 @@ jobs:
         scripts/get-ci-scope.ps1 @arguments
 
   marketplace-validation:
-    needs: changes
-    if: needs.changes.outputs.marketplace_required == 'true'
+    needs: [validation-plan, changes]
+    if: needs.validation-plan.outputs.scope != 'ready-only' && needs.changes.outputs.marketplace_required == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
 
@@ -59,24 +101,113 @@ jobs:
       shell: pwsh
       run: scripts/validate-agent-marketplace.ps1
 
-  build-and-test:
-    needs: [changes, marketplace-validation]
-    if: always()
+  preflight:
+    name: Delivery preflight
+    needs: [validation-plan, changes, marketplace-validation]
+    if: always() && needs.validation-plan.outputs.scope != 'ready-only'
     # PitCrew default. Set CI_RUNNER=ubuntu-latest for the manual cloud fallback.
     # Untrusted fork pull requests always use GitHub-hosted infrastructure.
     # Marketplace-only changes use a lightweight hosted no-op rather than occupying PitCrew.
-    runs-on: ${{ needs.changes.outputs.source_required != 'true' && 'ubuntu-latest' || github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && 'ubuntu-latest' || vars.CI_RUNNER || fromJSON('["self-hosted","linux","x64","general-purpose"]') }}
-    permissions:
-      contents: write
-      pages: write
-      id-token: write
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || needs.changes.outputs.source_required != 'true' && 'ubuntu-latest' || vars.CI_RUNNER || fromJSON('["self-hosted","linux","x64","general-purpose"]') }}
+    timeout-minutes: 30
+
+    steps:
+    - name: Enforce preflight routing
+      shell: bash
+      run: |
+        if [[ "${{ needs.validation-plan.result }}" != "success" ]]; then
+          echo "::error::Validation planning did not succeed."
+          exit 1
+        fi
+        if [[ "${{ needs.changes.result }}" != "success" ]]; then
+          echo "::error::CI scope detection did not succeed."
+          exit 1
+        fi
+
+        marketplace_required="${{ needs.changes.outputs.marketplace_required }}"
+        marketplace_result="${{ needs.marketplace-validation.result }}"
+        if [[ "$marketplace_required" == "true" && "$marketplace_result" != "success" ]]; then
+          echo "::error::Required agent marketplace validation did not succeed."
+          exit 1
+        fi
+        if [[ "$marketplace_required" != "true" && "$marketplace_result" != "skipped" ]]; then
+          echo "::error::Agent marketplace validation ran unexpectedly."
+          exit 1
+        fi
+
+    - name: Source preflight not required
+      if: needs.changes.outputs.source_required != 'true'
+      run: echo "Marketplace-only change; source preflight is not applicable."
+
+    - name: Checkout
+      if: needs.changes.outputs.source_required == 'true'
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Configure writable .NET install directory
+      if: needs.changes.outputs.source_required == 'true'
+      shell: bash
+      run: |
+        echo "DOTNET_INSTALL_DIR=$RUNNER_TEMP/dotnet" >> "$GITHUB_ENV"
+        echo "$RUNNER_TEMP/dotnet" >> "$GITHUB_PATH"
+
+    - name: Setup .NET
+      if: needs.changes.outputs.source_required == 'true'
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 10.0.x
+
+    - name: Validate delivery contract
+      if: needs.changes.outputs.source_required == 'true'
+      shell: pwsh
+      run: |
+        $contract = Get-Content .github/genesis-delivery.json -Raw
+        if (-not ($contract | Test-Json -SchemaFile .github/genesis-delivery.schema.json)) {
+          throw 'The Genesis delivery contract does not satisfy its schema.'
+        }
+
+    - name: Validate CI scope classifier
+      if: needs.changes.outputs.source_required == 'true'
+      shell: pwsh
+      run: scripts/test-ci-scope.ps1
+
+    - name: Validate release finalization
+      if: needs.changes.outputs.source_required == 'true'
+      shell: pwsh
+      run: scripts/test-release.ps1
+
+    - name: Restore
+      if: needs.changes.outputs.source_required == 'true'
+      run: dotnet restore src/NexusLabs.Needlr.slnx
+
+    - name: Build (Release)
+      if: needs.changes.outputs.source_required == 'true'
+      run: dotnet build src/NexusLabs.Needlr.slnx --configuration Release --no-restore
+
+  build-and-test:
+    needs: [validation-plan, changes, marketplace-validation, preflight]
+    if: always() && needs.validation-plan.outputs.scope == 'full' && needs.preflight.result == 'success'
+    # PitCrew default. Set CI_RUNNER=ubuntu-latest for the manual cloud fallback.
+    # Untrusted fork pull requests always use GitHub-hosted infrastructure.
+    # Marketplace-only changes use a lightweight hosted no-op rather than occupying PitCrew.
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || needs.changes.outputs.source_required != 'true' && 'ubuntu-latest' || vars.CI_RUNNER || fromJSON('["self-hosted","linux","x64","general-purpose"]') }}
+    timeout-minutes: 90
 
     steps:
     - name: Enforce validation routing
       shell: bash
       run: |
+        if [[ "${{ needs.validation-plan.result }}" != "success" ]]; then
+          echo "::error::Validation planning did not succeed."
+          exit 1
+        fi
         if [[ "${{ needs.changes.result }}" != "success" ]]; then
           echo "::error::CI scope detection did not succeed."
+          exit 1
+        fi
+        if [[ "${{ needs.preflight.result }}" != "success" ]]; then
+          echo "::error::Delivery preflight did not succeed."
           exit 1
         fi
         marketplace_required="${{ needs.changes.outputs.marketplace_required }}"
@@ -86,9 +217,8 @@ jobs:
           exit 1
         fi
         if [[ "$marketplace_required" != "true" &&
-              "$marketplace_result" != "success" &&
               "$marketplace_result" != "skipped" ]]; then
-          echo "::error::Agent marketplace validation ended unexpectedly."
+          echo "::error::Agent marketplace validation ran unexpectedly."
           exit 1
         fi
 
@@ -253,59 +383,39 @@ jobs:
         rm -rf ./site/api/stable ./site/api/v*
         echo "Restricted ./site/ to ci.yml-owned paths."
 
-    - name: Deploy Documentation and Coverage
+    # Deployment credentials stay out of pull-request validation. The trusted
+    # push-only deploy job below consumes this exact validated site artifact.
+    - name: Upload documentation site artifact
       if: needs.changes.outputs.source_required == 'true' && success() && github.ref == 'refs/heads/main' && github.event_name == 'push'
-      uses: peaceiris/actions-gh-pages@v4
+      uses: actions/upload-artifact@v4
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./site
-        keep_files: true
-
-    # gh-pages now holds the complete merged site (this run's own paths plus
-    # whatever release.yml last wrote to /api/stable and /api/v*, preserved
-    # by keep_files above) -- check it out fresh and mirror that whole tree
-    # to Cloudflare Pages, rather than deploying our own partial ./site/.
-    - name: Checkout gh-pages for Cloudflare mirror
-      if: needs.changes.outputs.source_required == 'true' && success() && github.ref == 'refs/heads/main' && github.event_name == 'push'
-      uses: actions/checkout@v4
-      with:
-        ref: gh-pages
-        path: gh-pages-mirror
-
-    # Cloudflare Pages allows at most 20,000 files per deployment. Keep only
-    # the newest API version archives (and rewrite versions.json to match);
-    # older archives stay in gh-pages history but are not published here.
-    # Also removes the checkout's .git so it is not uploaded.
-    - name: Trim mirror before Cloudflare deploy
-      if: needs.changes.outputs.source_required == 'true' && success() && github.ref == 'refs/heads/main' && github.event_name == 'push'
-      run: python scripts/trim-cloudflare-mirror.py gh-pages-mirror --keep 20
-
-    - name: Setup Node.js
-      if: needs.changes.outputs.source_required == 'true' && success() && github.ref == 'refs/heads/main' && github.event_name == 'push'
-      uses: actions/setup-node@v4
-      with:
-        node-version: '24'
-
-    - name: Deploy Documentation to Cloudflare Pages
-      if: needs.changes.outputs.source_required == 'true' && success() && github.ref == 'refs/heads/main' && github.event_name == 'push'
-      uses: cloudflare/wrangler-action@v4
-      with:
-        apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        command: pages deploy gh-pages-mirror --project-name=needlr --branch=main --commit-dirty=true
+        name: documentation-site
+        path: site/
+        retention-days: 1
 
   package-validation:
-    needs: changes
-    if: always()
-    runs-on: ${{ needs.changes.outputs.source_required != 'true' && 'ubuntu-latest' || github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && 'ubuntu-latest' || vars.CI_RUNNER || fromJSON('["self-hosted","linux","x64","general-purpose"]') }}
+    needs: [validation-plan, changes, preflight]
+    if: always() && needs.validation-plan.outputs.scope == 'full' && needs.preflight.result == 'success'
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || needs.changes.outputs.source_required != 'true' && 'ubuntu-latest' || vars.CI_RUNNER || fromJSON('["self-hosted","linux","x64","general-purpose"]') }}
+    timeout-minutes: 60
     # Runs in parallel with the other source jobs after scope detection.
 
     steps:
     - name: Enforce validation routing
-      if: needs.changes.result != 'success'
+      shell: bash
       run: |
-        echo "::error::CI scope detection did not succeed."
-        exit 1
+        if [[ "${{ needs.validation-plan.result }}" != "success" ]]; then
+          echo "::error::Validation planning did not succeed."
+          exit 1
+        fi
+        if [[ "${{ needs.changes.result }}" != "success" ]]; then
+          echo "::error::CI scope detection did not succeed."
+          exit 1
+        fi
+        if [[ "${{ needs.preflight.result }}" != "success" ]]; then
+          echo "::error::Delivery preflight did not succeed."
+          exit 1
+        fi
 
     - name: Source package validation not required
       if: needs.changes.result == 'success' && needs.changes.outputs.source_required != 'true'
@@ -351,17 +461,28 @@ jobs:
       run: scripts/test-packages.ps1
 
   aot-console-app:
-    needs: changes
-    if: always()
-    runs-on: ${{ needs.changes.outputs.source_required != 'true' && 'ubuntu-latest' || github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && 'ubuntu-latest' || vars.CI_RUNNER || fromJSON('["self-hosted","linux","x64","general-purpose"]') }}
+    needs: [validation-plan, changes, preflight]
+    if: always() && needs.validation-plan.outputs.scope == 'full' && needs.preflight.result == 'success'
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || needs.changes.outputs.source_required != 'true' && 'ubuntu-latest' || vars.CI_RUNNER || fromJSON('["self-hosted","linux","x64","general-purpose"]') }}
+    timeout-minutes: 30
     # Runs in parallel with the other source jobs after scope detection.
 
     steps:
     - name: Enforce validation routing
-      if: needs.changes.result != 'success'
+      shell: bash
       run: |
-        echo "::error::CI scope detection did not succeed."
-        exit 1
+        if [[ "${{ needs.validation-plan.result }}" != "success" ]]; then
+          echo "::error::Validation planning did not succeed."
+          exit 1
+        fi
+        if [[ "${{ needs.changes.result }}" != "success" ]]; then
+          echo "::error::CI scope detection did not succeed."
+          exit 1
+        fi
+        if [[ "${{ needs.preflight.result }}" != "success" ]]; then
+          echo "::error::Delivery preflight did not succeed."
+          exit 1
+        fi
 
     - name: Source AOT console validation not required
       if: needs.changes.result == 'success' && needs.changes.outputs.source_required != 'true'
@@ -410,17 +531,28 @@ jobs:
       run: artifacts/console/AotSourceGenConsoleApp || echo "App executed (exit expected for demo)"
 
   aot-web-app:
-    needs: changes
-    if: always()
-    runs-on: ${{ needs.changes.outputs.source_required != 'true' && 'ubuntu-latest' || github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && 'ubuntu-latest' || vars.CI_RUNNER || fromJSON('["self-hosted","linux","x64","general-purpose"]') }}
+    needs: [validation-plan, changes, preflight]
+    if: always() && needs.validation-plan.outputs.scope == 'full' && needs.preflight.result == 'success'
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || needs.changes.outputs.source_required != 'true' && 'ubuntu-latest' || vars.CI_RUNNER || fromJSON('["self-hosted","linux","x64","general-purpose"]') }}
+    timeout-minutes: 30
     # Runs in parallel with the other source jobs after scope detection.
 
     steps:
     - name: Enforce validation routing
-      if: needs.changes.result != 'success'
+      shell: bash
       run: |
-        echo "::error::CI scope detection did not succeed."
-        exit 1
+        if [[ "${{ needs.validation-plan.result }}" != "success" ]]; then
+          echo "::error::Validation planning did not succeed."
+          exit 1
+        fi
+        if [[ "${{ needs.changes.result }}" != "success" ]]; then
+          echo "::error::CI scope detection did not succeed."
+          exit 1
+        fi
+        if [[ "${{ needs.preflight.result }}" != "success" ]]; then
+          echo "::error::Delivery preflight did not succeed."
+          exit 1
+        fi
 
     - name: Source AOT web validation not required
       if: needs.changes.result == 'success' && needs.changes.outputs.source_required != 'true'
@@ -463,3 +595,170 @@ jobs:
       run: |
         test -f artifacts/webapp/AotSourceGenApp
         file artifacts/webapp/AotSourceGenApp
+
+  ci:
+    name: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft && 'Draft CI' || 'CI' }}
+    needs:
+      - validation-plan
+      - changes
+      - marketplace-validation
+      - preflight
+      - build-and-test
+      - package-validation
+      - aot-console-app
+      - aot-web-app
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+    - name: Check validation results
+      shell: bash
+      env:
+        SCOPE: ${{ needs.validation-plan.outputs.scope }}
+        PLAN_RESULT: ${{ needs.validation-plan.result }}
+        CHANGES_RESULT: ${{ needs.changes.result }}
+        MARKETPLACE_REQUIRED: ${{ needs.changes.outputs.marketplace_required }}
+        MARKETPLACE_RESULT: ${{ needs.marketplace-validation.result }}
+        PREFLIGHT_RESULT: ${{ needs.preflight.result }}
+        BUILD_RESULT: ${{ needs.build-and-test.result }}
+        PACKAGE_RESULT: ${{ needs.package-validation.result }}
+        AOT_CONSOLE_RESULT: ${{ needs.aot-console-app.result }}
+        AOT_WEB_RESULT: ${{ needs.aot-web-app.result }}
+      run: |
+        fail() {
+          echo "::error::$1"
+          exit 1
+        }
+
+        expect_result() {
+          local job_name="$1"
+          local actual="$2"
+          local expected="$3"
+          if [ "$actual" != "$expected" ]; then
+            fail "$job_name was '$actual'; expected '$expected'."
+          fi
+        }
+
+        validate_marketplace() {
+          if [ "$MARKETPLACE_REQUIRED" = "true" ]; then
+            expect_result "marketplace-validation" "$MARKETPLACE_RESULT" "success"
+          else
+            expect_result "marketplace-validation" "$MARKETPLACE_RESULT" "skipped"
+          fi
+        }
+
+        expect_result "validation-plan" "$PLAN_RESULT" "success"
+        expect_result "changes" "$CHANGES_RESULT" "success"
+
+        case "$SCOPE" in
+          ready-only)
+            expect_result "marketplace-validation" "$MARKETPLACE_RESULT" "skipped"
+            expect_result "preflight" "$PREFLIGHT_RESULT" "skipped"
+            expect_result "build-and-test" "$BUILD_RESULT" "skipped"
+            expect_result "package-validation" "$PACKAGE_RESULT" "skipped"
+            expect_result "aot-console-app" "$AOT_CONSOLE_RESULT" "skipped"
+            expect_result "aot-web-app" "$AOT_WEB_RESULT" "skipped"
+            ;;
+          subset)
+            validate_marketplace
+            expect_result "preflight" "$PREFLIGHT_RESULT" "success"
+            expect_result "build-and-test" "$BUILD_RESULT" "skipped"
+            expect_result "package-validation" "$PACKAGE_RESULT" "skipped"
+            expect_result "aot-console-app" "$AOT_CONSOLE_RESULT" "skipped"
+            expect_result "aot-web-app" "$AOT_WEB_RESULT" "skipped"
+            ;;
+          full)
+            validate_marketplace
+            expect_result "preflight" "$PREFLIGHT_RESULT" "success"
+            expect_result "build-and-test" "$BUILD_RESULT" "success"
+            expect_result "package-validation" "$PACKAGE_RESULT" "success"
+            expect_result "aot-console-app" "$AOT_CONSOLE_RESULT" "success"
+            expect_result "aot-web-app" "$AOT_WEB_RESULT" "success"
+            ;;
+          *)
+            fail "Validation scope '$SCOPE' is unsupported."
+            ;;
+        esac
+
+  deploy-documentation:
+    name: Deploy documentation
+    needs:
+      - validation-plan
+      - changes
+      - build-and-test
+      - package-validation
+      - aot-console-app
+      - aot-web-app
+      - ci
+    if: >-
+      always() &&
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main' &&
+      needs.validation-plan.outputs.scope == 'full' &&
+      needs.changes.outputs.source_required == 'true' &&
+      needs.build-and-test.result == 'success' &&
+      needs.package-validation.result == 'success' &&
+      needs.aot-console-app.result == 'success' &&
+      needs.aot-web-app.result == 'success' &&
+      needs.ci.result == 'success'
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || vars.CI_RUNNER || fromJSON('["self-hosted","linux","x64","general-purpose"]') }}
+    timeout-minutes: 20
+    permissions:
+      actions: read
+      contents: write
+      pages: write
+      id-token: write
+
+    steps:
+    - name: Checkout repository deployment scripts
+      uses: actions/checkout@v4
+      with:
+        path: source
+
+    - name: Download validated documentation site
+      uses: actions/download-artifact@v4
+      with:
+        name: documentation-site
+        path: source/site
+
+    - name: Deploy Documentation and Coverage
+      uses: peaceiris/actions-gh-pages@v4
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./source/site
+        keep_files: true
+
+    # gh-pages now holds the complete merged site (this run's own paths plus
+    # whatever release.yml last wrote to /api/stable and /api/v*, preserved
+    # by keep_files above) -- check it out fresh and mirror that whole tree
+    # to Cloudflare Pages, rather than deploying our partial site artifact.
+    - name: Checkout gh-pages for Cloudflare mirror
+      uses: actions/checkout@v4
+      with:
+        ref: gh-pages
+        path: gh-pages-mirror
+
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+
+    # Cloudflare Pages allows at most 20,000 files per deployment. Keep only
+    # the newest API version archives (and rewrite versions.json to match);
+    # older archives stay in gh-pages history but are not published here.
+    # Also removes the checkout's .git so it is not uploaded.
+    - name: Trim mirror before Cloudflare deploy
+      run: python source/scripts/trim-cloudflare-mirror.py gh-pages-mirror --keep 20
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '24'
+
+    - name: Deploy Documentation to Cloudflare Pages
+      uses: cloudflare/wrangler-action@v4
+      with:
+        apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        command: pages deploy gh-pages-mirror --project-name=needlr --branch=main --commit-dirty=true

--- a/.github/workflows/pr-review-policy.yml
+++ b/.github/workflows/pr-review-policy.yml
@@ -1,0 +1,126 @@
+name: Review policy evaluator
+run-name: "Review policy for #${{ github.event.pull_request.number }} at ${{ github.event.pull_request.head.sha }}"
+
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
+  pull_request_review:
+    types: [submitted, dismissed]
+
+permissions:
+  checks: write
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: review-policy-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  evaluate:
+    name: Evaluate review policy
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      REVIEW_POLICY: ${{ vars.GENESIS_REVIEW_POLICY || 'none' }}
+    steps:
+      - name: Publish review policy check
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          pull_request="$(gh api "repos/$GH_REPO/pulls/$PR_NUMBER")"
+          head_sha="$(jq -r '.head.sha' <<<"$pull_request")"
+          author_login="$(jq -r '.user.login' <<<"$pull_request")"
+          author_type="$(jq -r '.user.type' <<<"$pull_request")"
+          is_draft="$(jq -r '.draft' <<<"$pull_request")"
+          conclusion=success
+          title='Review policy satisfied'
+          summary='No author-specific review is required.'
+
+          case "$REVIEW_POLICY" in
+            none)
+              ;;
+            copilot-one-approval)
+              if [ "$author_login" = 'Copilot' ] && [ "$author_type" = 'Bot' ]; then
+                if [ "$is_draft" = 'true' ]; then
+                  summary='Copilot review is enforced when this pull request becomes ready.'
+                else
+                  reviews="$(
+                    gh api \
+                      --paginate \
+                      --slurp \
+                      "repos/$GH_REPO/pulls/$PR_NUMBER/reviews?per_page=100" |
+                      jq '[.[][]]'
+                  )"
+                  approval_count="$(
+                    jq \
+                      --arg sha "$head_sha" '
+                        sort_by(.submitted_at // "")
+                        | reduce .[] as $review (
+                            {};
+                            .[$review.user.login] = $review
+                          )
+                        | [
+                            .[]
+                            | select(
+                                .state == "APPROVED"
+                                and .commit_id == $sha
+                                and .user.type == "User"
+                                and (
+                                  .author_association == "OWNER"
+                                  or .author_association == "MEMBER"
+                                  or .author_association == "COLLABORATOR"
+                                )
+                              )
+                          ]
+                        | length
+                      ' <<<"$reviews"
+                  )"
+                  if [ "$approval_count" -lt 1 ]; then
+                    conclusion=failure
+                    title='Human approval required'
+                    summary='Copilot-authored ready pull requests require an OWNER, MEMBER, or COLLABORATOR approval on the current head SHA.'
+                  else
+                    summary='A trusted human approved the current Copilot-authored head SHA.'
+                  fi
+                fi
+              fi
+              ;;
+            *)
+              conclusion=failure
+              title='Unsupported review policy'
+              summary="GENESIS_REVIEW_POLICY '$REVIEW_POLICY' is not supported."
+              ;;
+          esac
+
+          jq -n \
+            --arg name 'Review policy' \
+            --arg head_sha "$head_sha" \
+            --arg conclusion "$conclusion" \
+            --arg title "$title" \
+            --arg summary "$summary" '
+              {
+                name: $name,
+                head_sha: $head_sha,
+                status: "completed",
+                conclusion: $conclusion,
+                output: {
+                  title: $title,
+                  summary: $summary
+                }
+              }
+            ' |
+            gh api \
+              --method POST \
+              "repos/$GH_REPO/check-runs" \
+              --input - >/dev/null
+
+          if [ "$conclusion" != 'success' ]; then
+            echo "::error::$summary"
+            exit 1
+          fi

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,39 @@
+name: PR title
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  title:
+    name: PR title
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      PR_TITLE: ${{ github.event.pull_request.title }}
+      TITLE_MAX_LENGTH: '72'
+      TITLE_PATTERN: '^(feat|fix|docs|refactor|test|style|build|ci|chore|perf|revert)(\([a-z0-9][a-z0-9._/-]*\))?!?: .+$'
+    steps:
+      - name: Validate conventional title
+        shell: bash
+        run: |
+          if [[ "$PR_TITLE" == *$'\n'* || "$PR_TITLE" == *$'\r'* ]]; then
+            echo "::error::Pull request title must be a single line."
+            exit 1
+          fi
+
+          if (( ${#PR_TITLE} > TITLE_MAX_LENGTH )); then
+            echo "::error::Pull request title is ${#PR_TITLE} characters; maximum is $TITLE_MAX_LENGTH."
+            exit 1
+          fi
+
+          if [[ ! "$PR_TITLE" =~ $TITLE_PATTERN ]]; then
+            echo "::error::Use a conventional title such as 'feat(scope): description'."
+            exit 1
+          fi
+
+          echo "Conventional pull request title is valid."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,3 +75,23 @@ When adding a new source-generated feature, follow ALL layers of this pattern â€
 ## Glob-Targeted Instructions
 
 Pattern-specific rules live in `.github/instructions/*.instructions.md`. These activate automatically when you edit files matching their glob. See that directory for rules covering source generators, analyzers, CodeGen emission, attributes, integration tests, discovery helpers, models, docs, examples, and project files.
+
+## Pull Request Delivery
+
+- Deliver every change through a feature branch and pull request. Direct updates or
+  deletions of `main` are forbidden; local checkpoint commits on feature branches are
+  unrestricted.
+- "Open a draft PR" means keep the pull request in draft while the configured
+  `CI_DRAFT_MODE` validation runs. "Open" or "publish" a PR means make it ready for
+  review so a fresh full validation run publishes the stable `CI` check.
+- Use a conventional pull request title no longer than 72 characters. GitHub uses the
+  PR title as the squash commit subject and the PR body as the squash commit message.
+- `GENESIS_REVIEW_POLICY=copilot-one-approval` requires a ready pull request authored
+  by the Copilot bot to receive one trusted human approval on its current head SHA.
+  Pushing another commit invalidates that approval for delivery purposes.
+- An approval to run workflows from an external fork authorizes the entire proposed
+  workflow, including runner selection. Inspect workflow changes and confirm fork jobs
+  remain on GitHub-hosted runners before approving them.
+- Before marking a PR ready, report omitted behavior, implementation gaps, test
+  results, technical debt, missing coverage, weak assertions, and assumptions. Fix
+  every high-severity gap and discuss every medium-severity gap before delivery.

--- a/docs/adr/adr-0008-own-version-aware-agent-marketplace.md
+++ b/docs/adr/adr-0008-own-version-aware-agent-marketplace.md
@@ -161,6 +161,22 @@ agent-evaluation path.
 Behavioral quality, routing accuracy, latency, and token efficiency cannot be confirmed by
 the MVP repository checks. Those require the deferred calibrated evaluation suite.
 
+## Outcome Notes
+
+### 2026-07-28 — repository-wide PR delivery alignment
+
+Needlr's later repository-wide Genesis PR delivery contract replaces the four individual
+source job contexts as branch-protection requirements with one stable `CI` summary plus
+the `PR title` and `Review policy` governance checks. The marketplace decision remains
+unchanged: path classification still fails closed, marketplace validation still runs for
+agent-related changes, and irrelevant source, package, documentation, and AOT work still
+does not run for marketplace-only changes.
+
+Ready pull requests retain the existing source job identities during the migration and
+activation transition, including their hosted no-op behavior for marketplace-only changes.
+Draft pull requests instead publish `Draft CI` after the configured subset, so draft
+validation no longer has to manufacture every former branch-protection context.
+
 ## References
 
 - ADR-0004 records that Foundry, not Needlr, owns AI and agentic runtime, workflow,

--- a/docs/local-runners.md
+++ b/docs/local-runners.md
@@ -17,10 +17,18 @@ Provision repository-scoped capacity from a PitCrew checkout:
 
 The workflows use the `CI_RUNNER` repository variable as PitCrew's manual
 cloud fallback. Leave it unset for local ephemeral runners, or set it to
-`ubuntu-latest` to route Linux jobs to GitHub-hosted runners.
+`ubuntu-latest` to route trusted Linux jobs to GitHub-hosted runners.
 
-Pull requests from forks always use `ubuntu-latest`; untrusted code must never
-run on self-hosted infrastructure.
+Pull requests from external forks always force `ubuntu-24.04` before
+`CI_RUNNER` is considered; untrusted code must never run on self-hosted
+infrastructure. Approving a fork workflow run authorizes the complete proposed
+workflow, including runner selection, so inspect workflow changes before
+approval.
+
+Draft pull requests use `CI_DRAFT_MODE` (`subset` by default) and publish
+`Draft CI` after marketplace validation and the delivery preflight. Making the
+pull request ready starts fresh full validation and publishes the stable `CI`
+check.
 
 PitCrew workers are socketless Linux containers. Workloads requiring Docker,
 service containers, Testcontainers, Windows, or macOS remain on an appropriate

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -258,12 +258,18 @@ git push -u origin release/prepare-v0.0.3-alpha.3
 gh pr create
 ```
 
-Wait for all required checks:
+Make the pull request ready and wait for the stable required checks:
 
-- `build-and-test`;
-- `package-validation`;
-- `aot-console-app`;
-- `aot-web-app`.
+- `CI`, which summarizes `build-and-test`, `package-validation`,
+  `aot-console-app`, and `aot-web-app`;
+- `PR title`;
+- `Review policy`.
+
+A draft release-preparation pull request publishes `Draft CI`, which is not a
+substitute for the ready pull request's full `CI` validation. During the delivery
+migration transition, before GitHub branch protection is activated from
+`.github/genesis-delivery.json`, the four summarized source-job contexts may also
+remain temporarily required and must still pass.
 
 Resolve review conversations and squash-merge the pull request. The
 path-filtered `build-maui-example` workflow is not a required branch check;

--- a/scripts/delivery/Configure-GitHubDelivery.ps1
+++ b/scripts/delivery/Configure-GitHubDelivery.ps1
@@ -1,0 +1,452 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Plans or configures PR-first GitHub delivery for a generated project.
+
+.DESCRIPTION
+    Reads `.github/genesis-delivery.json`, probes repository settings and branch
+    protection capability, active default-branch rules, and existing protection,
+    then selects native protected auto-merge or the private exact-SHA
+    workflow-run lane.
+
+    The default is plan-only. `-Apply` is required for GitHub writes. This
+    script never commits, pushes, opens a pull request, or merges. Active
+    rulesets and incompatible existing protection require manual reconciliation.
+
+.PARAMETER ProjectRoot
+    Generated project root. Defaults to the current directory.
+
+.PARAMETER Repository
+    Optional `owner/repository`. Defaults to the current gh repository.
+
+.PARAMETER DeliveryMode
+    Auto, Native, or WorkflowRun. Auto selects Native whenever protection is
+    available and WorkflowRun only for the known private-plan denial.
+
+.PARAMETER CheckSha
+    Commit whose check runs establish the required GitHub check contexts.
+    Defaults to the remote default branch tip.
+
+.PARAMETER Apply
+    Apply the planned GitHub settings. Without this switch, no writes occur.
+
+.PARAMETER AllowUnprotectedPrivate
+    Required with `-Apply` when WorkflowRun is selected.
+
+.PARAMETER ReviewPolicy
+    None, or CopilotOneApproval. CopilotOneApproval requires one trusted human
+    approval on the current SHA before a ready Copilot-authored PR can merge.
+
+.PARAMETER SnapshotPath
+    Optional offline repository snapshot used by Genesis contract tests.
+
+.PARAMETER GhCommand
+    gh executable path. Defaults to `gh`.
+
+.EXAMPLE
+    ./scripts/delivery/Configure-GitHubDelivery.ps1
+
+.EXAMPLE
+    ./scripts/delivery/Configure-GitHubDelivery.ps1 -Apply
+#>
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [string]$ProjectRoot = (Get-Location).Path,
+    [string]$Repository,
+    [ValidateSet('Auto', 'Native', 'WorkflowRun')]
+    [string]$DeliveryMode = 'Auto',
+    [string]$CheckSha,
+    [switch]$Apply,
+    [switch]$AllowUnprotectedPrivate,
+    [ValidateSet('None', 'CopilotOneApproval')]
+    [string]$ReviewPolicy = 'None',
+    [string]$SnapshotPath,
+    [string]$GhCommand = 'gh'
+)
+
+$ErrorActionPreference = 'Stop'
+
+$ProjectRoot = (Resolve-Path $ProjectRoot).Path
+$contractPath = Join-Path $ProjectRoot '.github' 'genesis-delivery.json'
+$installerPath = Join-Path $ProjectRoot 'scripts' 'delivery' 'Install-PrivateAutoMerge.ps1'
+
+if (-not (Test-Path $contractPath)) {
+    Write-Error "Delivery contract not found at '$contractPath'."
+}
+
+$contract = Get-Content $contractPath -Raw | ConvertFrom-Json
+$requiredChecks = @($contract.requiredChecks | ForEach-Object { [string]$_ })
+$draftMode =
+    if (@($contract.runnerProfiles).Count -gt 0) {
+        [string]$contract.draftValidation.pitcrewDefault
+    } else {
+        [string]$contract.draftValidation.hostedDefault
+    }
+
+function Invoke-GhJson {
+    param(
+        [Parameter(Mandatory)]
+        [string[]]$Arguments
+    )
+
+    $output = & $GhCommand @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "gh $($Arguments -join ' ') failed with exit code $LASTEXITCODE."
+    }
+    if ([string]::IsNullOrWhiteSpace(($output -join "`n"))) {
+        return $null
+    }
+    return (($output -join "`n") | ConvertFrom-Json)
+}
+
+function Get-LiveSnapshot {
+    & $GhCommand auth status *> $null
+    if ($LASTEXITCODE -ne 0) {
+        throw 'GitHub CLI authentication is required. Run gh auth login.'
+    }
+
+    $resolvedRepository =
+        if ([string]::IsNullOrWhiteSpace($Repository)) {
+            $repoView = Invoke-GhJson -Arguments @(
+                'repo', 'view', '--json', 'nameWithOwner')
+            [string]$repoView.nameWithOwner
+        } else {
+            $Repository
+        }
+    if ($resolvedRepository -notmatch '^[^/]+/[^/]+$') {
+        throw "Repository '$resolvedRepository' must be owner/name."
+    }
+
+    $repositoryState = Invoke-GhJson -Arguments @(
+        'api', '-H', 'X-GitHub-Api-Version: 2026-03-10',
+        "repos/$resolvedRepository")
+    $defaultBranch = [string]$repositoryState.default_branch
+    $branchSha =
+        if ([string]::IsNullOrWhiteSpace($CheckSha)) {
+            $commit = Invoke-GhJson -Arguments @(
+                'api', '-H', 'X-GitHub-Api-Version: 2026-03-10',
+                "repos/$resolvedRepository/commits/$defaultBranch")
+            [string]$commit.sha
+        } else {
+            $CheckSha
+        }
+
+    $protectionStatus = 'unknown'
+    $protection = $null
+    $protectionOutput = & $GhCommand api `
+        -H 'X-GitHub-Api-Version: 2026-03-10' `
+        "repos/$resolvedRepository/branches/$defaultBranch/protection" 2>&1
+    if ($LASTEXITCODE -eq 0) {
+        $protectionStatus = 'protected'
+        $protection = ($protectionOutput -join "`n") | ConvertFrom-Json
+    } else {
+        $message = $protectionOutput -join "`n"
+        if ($message -match 'HTTP 404') {
+            $protectionStatus = 'available-unprotected'
+        } elseif (
+            [bool]$repositoryState.private -and
+            $message -match '(?i)upgrade.*pro|make this repository public') {
+            $protectionStatus = 'unavailable-private-plan'
+        } else {
+            throw "Unable to determine branch protection capability: $message"
+        }
+    }
+
+    $activeRulesStatus = 'available'
+    $activeRules = @()
+    $activeRulesOutput = & $GhCommand api --paginate --slurp `
+        -H 'X-GitHub-Api-Version: 2026-03-10' `
+        "repos/$resolvedRepository/rules/branches/${defaultBranch}?per_page=100" 2>&1
+    if ($LASTEXITCODE -eq 0) {
+        $activeRulePages = ($activeRulesOutput -join "`n") | ConvertFrom-Json
+        $activeRules = @(
+            foreach ($page in @($activeRulePages)) {
+                @($page)
+            }
+        )
+    } else {
+        $message = $activeRulesOutput -join "`n"
+        if (
+            [bool]$repositoryState.private -and
+            $message -match '(?i)upgrade.*pro|make this repository public'
+        ) {
+            $activeRulesStatus = 'unavailable-private-plan'
+        } else {
+            throw "Unable to inspect active default-branch rules: $message"
+        }
+    }
+
+    $checkRuns = Invoke-GhJson -Arguments @(
+        'api', '--paginate', '--slurp',
+        "repos/$resolvedRepository/commits/$branchSha/check-runs?filter=latest&per_page=100")
+    $flattenedChecks = @(
+        foreach ($page in @($checkRuns)) {
+            @($page.check_runs)
+        }
+    )
+
+    $privateWorkflowPresent = $false
+    $workflowOutput = & $GhCommand api `
+        -H 'X-GitHub-Api-Version: 2026-03-10' `
+        "repos/$resolvedRepository/contents/.github/workflows/private-auto-merge.yml?ref=$defaultBranch" 2>&1
+    if ($LASTEXITCODE -eq 0) {
+        $privateWorkflowPresent = $true
+    } elseif (($workflowOutput -join "`n") -notmatch 'HTTP 404') {
+        throw "Unable to inspect private auto-merge workflow: $($workflowOutput -join "`n")"
+    }
+
+    return [PSCustomObject]@{
+        repository             = $resolvedRepository
+        visibility             = [string]$repositoryState.visibility
+        private                = [bool]$repositoryState.private
+        defaultBranch          = $defaultBranch
+        checkSha               = $branchSha
+        protectionStatus       = $protectionStatus
+        protection             = $protection
+        activeRulesStatus      = $activeRulesStatus
+        activeRules            = @($activeRules)
+        checkRuns              = @($flattenedChecks)
+        privateWorkflowPresent = $privateWorkflowPresent
+    }
+}
+
+$snapshot =
+    if ([string]::IsNullOrWhiteSpace($SnapshotPath)) {
+        Get-LiveSnapshot
+    } else {
+        Get-Content (Resolve-Path $SnapshotPath) -Raw | ConvertFrom-Json
+    }
+
+if ([string]::IsNullOrWhiteSpace($Repository)) {
+    $Repository = [string]$snapshot.repository
+}
+
+$selectedMode =
+    if ($DeliveryMode -ne 'Auto') {
+        $DeliveryMode
+    } elseif ([string]$snapshot.protectionStatus -eq 'unavailable-private-plan') {
+        'WorkflowRun'
+    } else {
+        'Native'
+    }
+
+if ($selectedMode -eq 'WorkflowRun' -and -not [bool]$snapshot.private) {
+    throw 'WorkflowRun delivery is only supported for private repositories.'
+}
+if ($selectedMode -eq 'Native' -and [string]$snapshot.protectionStatus -eq 'unavailable-private-plan') {
+    throw 'Native delivery was requested but branch protection is unavailable for this private repository.'
+}
+
+$successfulCheckNames = @(
+    @($snapshot.checkRuns) |
+        Where-Object { [string]$_.conclusion -eq 'success' } |
+        ForEach-Object { [string]$_.name } |
+        Sort-Object -Unique
+)
+$missingChecks = @($requiredChecks | Where-Object { $_ -notin $successfulCheckNames })
+
+$operations = [System.Collections.Generic.List[string]]::new()
+$status = 'ready'
+$nextAction = $null
+$activeRules = @($snapshot.activeRules)
+
+if ($activeRules.Count -gt 0) {
+    $status = 'manual'
+    $nextAction = 'Active repository or inherited rulesets apply to the default branch. Reconcile them manually; Genesis will not mutate overlapping policy.'
+} elseif ($selectedMode -eq 'Native' -and $missingChecks.Count -gt 0) {
+    $status = 'deferred'
+    $nextAction = "Run the required workflows, then rerun with -CheckSha <sha>. Missing: $($missingChecks -join ', ')."
+} elseif ($selectedMode -eq 'WorkflowRun' -and -not [bool]$snapshot.privateWorkflowPresent) {
+    $status = 'deferred'
+    $nextAction = 'Install and merge .github/workflows/private-auto-merge.yml, then rerun.'
+    if (Test-Path $installerPath) {
+        if ($Apply) {
+            & $installerPath -ProjectRoot $ProjectRoot -Confirm:$false | Out-Null
+        } else {
+            & $installerPath -ProjectRoot $ProjectRoot -WhatIf | Out-Null
+        }
+    }
+}
+
+if ($status -eq 'ready') {
+    $reviewPolicyValue =
+        if ($ReviewPolicy -eq 'CopilotOneApproval') {
+            'copilot-one-approval'
+        } else {
+            'none'
+        }
+    $operations.Add('Configure squash-only repository merge settings') | Out-Null
+    $operations.Add('Set read-only Actions workflow permissions') | Out-Null
+    if (-not [bool]$snapshot.private) {
+        $operations.Add('Require workflow approval for all external contributors') | Out-Null
+    }
+    $operations.Add("Set CI_DRAFT_MODE=$draftMode") | Out-Null
+    $operations.Add("Set GENESIS_REVIEW_POLICY=$reviewPolicyValue") | Out-Null
+    if ($selectedMode -eq 'Native') {
+        if ([string]$snapshot.protectionStatus -eq 'protected') {
+            $existingChecks = @($snapshot.protection.required_status_checks.checks)
+            $missingProtectionChecks = @(
+                $requiredChecks |
+                    Where-Object {
+                        $requiredCheck = $_
+                        -not ($existingChecks | Where-Object {
+                            [string]$_.context -ceq $requiredCheck -and
+                            [int]$_.app_id -eq 15368
+                        })
+                    }
+            )
+            $reviewBypasses = $snapshot.protection.required_pull_request_reviews.bypass_pull_request_allowances
+            $reviewBypassActors = @(
+                if ($null -ne $reviewBypasses) {
+                    @($reviewBypasses.users) | Where-Object { $null -ne $_ }
+                    @($reviewBypasses.teams) | Where-Object { $null -ne $_ }
+                    @($reviewBypasses.apps) | Where-Object { $null -ne $_ }
+                }
+            )
+            $hasReviewBypasses = $reviewBypassActors.Count -gt 0
+            $compatibleProtection = (
+                $missingProtectionChecks.Count -eq 0 -and
+                [bool]$snapshot.protection.required_status_checks.strict -and
+                [bool]$snapshot.protection.enforce_admins.enabled -and
+                $null -ne $snapshot.protection.required_pull_request_reviews -and
+                -not $hasReviewBypasses -and
+                [bool]$snapshot.protection.required_conversation_resolution.enabled -and
+                -not [bool]$snapshot.protection.allow_force_pushes.enabled -and
+                -not [bool]$snapshot.protection.allow_deletions.enabled
+            )
+            if (-not $compatibleProtection) {
+                throw 'Existing branch protection differs from the Genesis safety contract; update it manually rather than allowing Genesis to overwrite it.'
+            }
+            $operations.Add('Keep existing compatible branch protection') | Out-Null
+        } else {
+            $operations.Add('Create strict default-branch protection with required checks') | Out-Null
+        }
+        $operations.Add('Enable native repository auto-merge') | Out-Null
+        $operations.Add('Set GENESIS_DELIVERY_MODEL=native') | Out-Null
+    } else {
+        $operations.Add('Set GENESIS_DELIVERY_MODEL=workflow-run') | Out-Null
+    }
+}
+
+$result = [ordered]@{
+    schemaVersion    = 1
+    repository       = [string]$snapshot.repository
+    defaultBranch    = [string]$snapshot.defaultBranch
+    visibility       = [string]$snapshot.visibility
+    selectedMode     = $selectedMode
+    status           = $status
+    requiredChecks   = @($requiredChecks)
+    missingChecks    = @($missingChecks)
+    operations       = @($operations)
+    draftMode        = $draftMode
+    reviewPolicy     = $ReviewPolicy
+    activeRulesStatus = [string]$snapshot.activeRulesStatus
+    activeRules      = @($activeRules)
+    nextAction       = $nextAction
+}
+
+if (-not $Apply -or $status -ne 'ready') {
+    [PSCustomObject]$result
+    return
+}
+if ($selectedMode -eq 'WorkflowRun' -and -not $AllowUnprotectedPrivate) {
+    throw '-AllowUnprotectedPrivate is required to apply workflow-run delivery.'
+}
+if (-not $PSCmdlet.ShouldProcess(
+    $Repository,
+    "Apply Genesis $selectedMode delivery settings, variables, and local default-branch configuration"
+)) {
+    $result.status = if ($WhatIfPreference) { 'what-if' } else { 'cancelled' }
+    [PSCustomObject]$result
+    return
+}
+
+Write-Host "[1/3] Applying squash-only repository settings"
+$autoMergeValue = if ($selectedMode -eq 'Native') { 'true' } else { 'false' }
+& $GhCommand api --method PATCH `
+    -H 'X-GitHub-Api-Version: 2026-03-10' `
+    "repos/$Repository" `
+    -F allow_squash_merge=true `
+    -F allow_merge_commit=false `
+    -F allow_rebase_merge=false `
+    -F "allow_auto_merge=$autoMergeValue" `
+    -F delete_branch_on_merge=true `
+    -f squash_merge_commit_title=PR_TITLE `
+    -f squash_merge_commit_message=PR_BODY *> $null
+if ($LASTEXITCODE -ne 0) { throw 'Failed to configure repository merge settings.' }
+
+Write-Host "[2/3] Applying delivery model '$selectedMode'"
+if ($selectedMode -eq 'Native' -and [string]$snapshot.protectionStatus -ne 'protected') {
+    $checks = @(
+        $requiredChecks | ForEach-Object {
+            [ordered]@{ context = $_; app_id = 15368 }
+        }
+    )
+    $protectionBody = [ordered]@{
+        required_status_checks = [ordered]@{ strict = $true; checks = $checks }
+        enforce_admins = $true
+        required_pull_request_reviews = [ordered]@{
+            dismiss_stale_reviews = $false
+            require_code_owner_reviews = $false
+            required_approving_review_count = 0
+            require_last_push_approval = $false
+        }
+        restrictions = $null
+        required_linear_history = $false
+        allow_force_pushes = $false
+        allow_deletions = $false
+        block_creations = $false
+        required_conversation_resolution = $true
+        lock_branch = $false
+        allow_fork_syncing = $false
+    }
+    $protectionBody | ConvertTo-Json -Depth 8 -Compress |
+        & $GhCommand api --method PUT `
+            -H 'X-GitHub-Api-Version: 2026-03-10' `
+            "repos/$Repository/branches/$($snapshot.defaultBranch)/protection" `
+            --input - *> $null
+    if ($LASTEXITCODE -ne 0) { throw 'Failed to configure branch protection.' }
+}
+
+$workflowPermissionsBody = [ordered]@{
+    default_workflow_permissions = 'read'
+    can_approve_pull_request_reviews = $false
+}
+$workflowPermissionsBody | ConvertTo-Json -Compress |
+    & $GhCommand api --method PUT `
+        -H 'X-GitHub-Api-Version: 2026-03-10' `
+        "repos/$Repository/actions/permissions/workflow" `
+        --input - *> $null
+if ($LASTEXITCODE -ne 0) { throw 'Failed to configure Actions workflow permissions.' }
+
+if (-not [bool]$snapshot.private) {
+    [ordered]@{ approval_policy = 'all_external_contributors' } |
+        ConvertTo-Json -Compress |
+        & $GhCommand api --method PUT `
+            -H 'X-GitHub-Api-Version: 2026-03-10' `
+            "repos/$Repository/actions/permissions/fork-pr-contributor-approval" `
+            --input - *> $null
+    if ($LASTEXITCODE -ne 0) { throw 'Failed to configure public fork workflow approval.' }
+}
+
+$modelValue = if ($selectedMode -eq 'Native') { 'native' } else { 'workflow-run' }
+& $GhCommand variable set GENESIS_DELIVERY_MODEL `
+    --repo $Repository `
+    --body $modelValue *> $null
+if ($LASTEXITCODE -ne 0) { throw 'Failed to set GENESIS_DELIVERY_MODEL.' }
+
+& $GhCommand variable set GENESIS_REVIEW_POLICY `
+    --repo $Repository `
+    --body $reviewPolicyValue *> $null
+if ($LASTEXITCODE -ne 0) { throw 'Failed to set GENESIS_REVIEW_POLICY.' }
+
+& $GhCommand variable set CI_DRAFT_MODE `
+    --repo $Repository `
+    --body $draftMode *> $null
+if ($LASTEXITCODE -ne 0) { throw 'Failed to set CI_DRAFT_MODE.' }
+
+Write-Host "[3/3] Recording default branch locally"
+git -C $ProjectRoot config genesis.defaultBranch ([string]$snapshot.defaultBranch)
+
+$result.status = 'applied'
+[PSCustomObject]$result

--- a/scripts/delivery/Install-PrivateAutoMerge.ps1
+++ b/scripts/delivery/Install-PrivateAutoMerge.ps1
@@ -1,0 +1,132 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Installs the generated private-repository exact-SHA auto-merge workflow.
+
+.DESCRIPTION
+    Reads `.github/genesis-delivery.json`, discovers the workflow display names
+    that own required merge gates, renders the inactive Genesis workflow template,
+    and writes `.github/workflows/private-auto-merge.yml`.
+
+    This script only edits the local working tree. It never commits, pushes,
+    opens a pull request, changes GitHub settings, or merges.
+
+.PARAMETER ProjectRoot
+    Generated project root. Defaults to the current directory.
+
+.PARAMETER Force
+    Replace an existing different workflow. Without this switch, a differing
+    target is treated as an error.
+
+.EXAMPLE
+    ./scripts/delivery/Install-PrivateAutoMerge.ps1
+
+.EXAMPLE
+    ./scripts/delivery/Install-PrivateAutoMerge.ps1 -WhatIf
+#>
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [string]$ProjectRoot = (Get-Location).Path,
+    [switch]$Force
+)
+
+$ErrorActionPreference = 'Stop'
+
+$ProjectRoot = (Resolve-Path $ProjectRoot).Path
+$contractPath = Join-Path $ProjectRoot '.github' 'genesis-delivery.json'
+$templatePath = Join-Path $ProjectRoot '.genesis' 'delivery' 'private-auto-merge.yml'
+$targetPath = Join-Path $ProjectRoot '.github' 'workflows' 'private-auto-merge.yml'
+
+if (-not (Test-Path $contractPath)) {
+    Write-Error "Delivery contract not found at '$contractPath'."
+}
+if (-not (Test-Path $templatePath)) {
+    Write-Error "Private auto-merge template not found at '$templatePath'."
+}
+
+Write-Host "[1/3] Reading delivery contract"
+$contract = Get-Content $contractPath -Raw | ConvertFrom-Json
+$workflowNames = [System.Collections.Generic.List[string]]::new()
+$seen = [System.Collections.Generic.HashSet[string]]::new(
+    [System.StringComparer]::Ordinal)
+
+function Add-WorkflowName {
+    param([string]$Name)
+    if ([string]::IsNullOrWhiteSpace($Name)) {
+        Write-Error 'A required workflow has an empty display name.'
+    }
+    if ($seen.Add($Name)) {
+        $workflowNames.Add($Name) | Out-Null
+    }
+}
+
+Add-WorkflowName ([string]$contract.ciWorkflow)
+Add-WorkflowName 'PR title'
+Add-WorkflowName 'Review policy evaluator'
+
+foreach ($workflow in @($contract.componentWorkflows)) {
+    if (@($workflow.roles) -notcontains 'merge-gate') {
+        continue
+    }
+
+    $workflowPath = Join-Path $ProjectRoot ([string]$workflow.path)
+    if (-not (Test-Path $workflowPath)) {
+        Write-Error "Required component workflow not found at '$workflowPath'."
+    }
+    $workflowText = Get-Content $workflowPath -Raw
+    $nameMatch = [regex]::Match($workflowText, '(?m)^name:\s*(.+?)\r?$')
+    if (-not $nameMatch.Success) {
+        Write-Error "Required component workflow '$workflowPath' has no top-level name."
+    }
+    Add-WorkflowName ($nameMatch.Groups[1].Value.Trim().Trim('"', "'"))
+}
+
+Write-Host "[2/3] Rendering workflow listeners: $($workflowNames -join ', ')"
+$template = Get-Content $templatePath -Raw
+$marker = '      # __GENESIS_WORKFLOW_NAMES__'
+if (-not $template.Contains($marker)) {
+    Write-Error "Workflow template marker is missing from '$templatePath'."
+}
+$renderedNames = @(
+    $workflowNames |
+        ForEach-Object {
+            $escapedName = $_.Replace("'", "''")
+            "      - '$escapedName'"
+        }
+) -join "`n"
+$rendered = $template.Replace($marker, $renderedNames)
+
+if (Test-Path $targetPath) {
+    $current = Get-Content $targetPath -Raw
+    if ($current -ceq $rendered) {
+        Write-Host "[3/3] Workflow already current: $targetPath"
+        return [PSCustomObject]@{
+            Path      = $targetPath
+            Changed   = $false
+            Workflows = @($workflowNames)
+        }
+    }
+    if (-not $Force) {
+        Write-Error "A different workflow already exists at '$targetPath'. Re-run with -Force to replace it."
+    }
+}
+
+$changed = $false
+if ($PSCmdlet.ShouldProcess($targetPath, 'Install private exact-SHA auto-merge workflow')) {
+    $targetDir = Split-Path $targetPath -Parent
+    if (-not (Test-Path $targetDir)) {
+        New-Item -ItemType Directory -Path $targetDir -Force | Out-Null
+    }
+    [IO.File]::WriteAllText(
+        $targetPath,
+        $rendered,
+        [Text.UTF8Encoding]::new($false))
+    Write-Host "[3/3] Installed workflow: $targetPath"
+    $changed = $true
+}
+
+[PSCustomObject]@{
+    Path      = $targetPath
+    Changed   = $changed
+    Workflows = @($workflowNames)
+}


### PR DESCRIPTION
## Summary

- add the current bundled Genesis delivery schema, contract, governance workflows, inactive private fallback template, delivery configurator, installer, and protected pre-push hook
- introduce `Draft CI` for draft subset validation and stable `CI` for ready/full validation while retaining the existing `build-and-test`, `package-validation`, `aot-console-app`, and `aot-web-app` job identities during activation
- force external fork pull requests onto `ubuntu-24.04` before repository runner variables are considered; trusted Linux work retains the exact PitCrew `self-hosted, linux, x64, general-purpose` profile
- move GitHub Pages and Cloudflare credentials into a trusted main-push deployment job that consumes the validated documentation artifact
- document PR-first delivery, current-SHA Copilot approval, external-fork approval risk, runner routing, release checks, and the ADR-0008 delivery-mechanism outcome

## Preserved behavior

- existing build, test, coverage, package-validation, release dry-run, and Native AOT commands
- marketplace-only fail-closed classification and hosted no-op legacy contexts for ready pull requests
- tag-only release workflow, release environment, NuGet/GitHub package publishing, GitHub Releases, versioned API documentation, GitHub Pages, and Cloudflare mirroring
- path-filtered hosted MAUI validation
- manual IDE-extension release and scheduled/manual benchmark workflows

## Audit findings

- repository: public `ncosentino/needlr`, default branch `main`, native protected delivery available
- existing protection: strict, four app-bound checks, PR required with zero approvals, admin enforcement, conversation resolution, no force pushes/deletion
- active rulesets: none
- Actions defaults: read-only token, Actions cannot approve reviews, all external fork contributors require workflow approval
- trusted same-repository jobs were observed on the exact PitCrew labels; no current usable external-fork PR exists for live route observation
- repository settings still have native auto-merge disabled and pre-Genesis squash title/body defaults; these are intentionally unchanged in this PR

## Validation

- Genesis delivery alignment: 51 checks, 0 errors, 0 warnings
- solution tests: 2,777 passed, 0 failed, 0 skipped
- Release solution build: 0 errors, 3 existing generated-example CS0162 warnings
- package validation: passed, including 40 example builds and four example test projects
- Native AOT: console and web executables produced locally for `win-x64`; hosted CI will rerun the preserved required `linux-x64` publishes
- CI scope and release finalization scripts: passed
- delivery contract schema and all workflow YAML: parsed successfully
- strict MkDocs build: passed
- pre-push proof: empty-remote main creation and feature pushes allowed; later main update/deletion blocked
- exact-SHA cleanup proof: exact head deleted, absent head accepted, advanced head retained, denied deletion surfaced
- lifecycle truth table: draft subset, ready-only, full-ready, failed-preflight, missing marketplace validation, and unexpected skips behaved as required

## Activation and evidence still pending

This PR intentionally performs no GitHub settings writes. After merge, the local and GitHub audits must be rerun, the new check contexts must be observed on a real SHA, and the existing classic protection check set must be manually reconciled because the Genesis configurator refuses to overwrite existing protection. A separate explicit approval is required before applying native auto-merge, canonical squash title/body settings, required `CI`/`PR title`/`Review policy` checks, and Genesis variables.

Live `Draft CI`, external-fork routing, and Copilot-authored current-SHA approval remain unobserved because no suitable existing scenarios are available and this PR was requested ready. The GitHub UI setting for Copilot-authored workflow approval remains manual and undocumented for automation.