### PR TITLE
ci: publish pinned Needlr runner image

### DIFF
--- a/.github/genesis-delivery.json
+++ b/.github/genesis-delivery.json
@@ -49,6 +49,16 @@
   "componentWorkflows": [
     {
       "source": "needlr",
+      "path": ".github/workflows/runner-image.yml",
+      "roles": [
+        "draft-optional",
+        "post-merge"
+      ],
+      "draftBehavior": "full",
+      "requiredChecks": []
+    },
+    {
+      "source": "needlr",
       "path": ".github/workflows/maui-example.yml",
       "roles": [
         "draft-optional"

--- a/.github/runner-images/needlr-ci/Dockerfile
+++ b/.github/runner-images/needlr-ci/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1.7
+
+FROM --platform=linux/amd64 mcr.microsoft.com/dotnet/sdk:10.0.302-noble@sha256:ed034a8bf0b24ded0cbbac07e17825d8e9ebfe21e308191d0f7421eaf5ad4664 AS dotnet
+
+FROM --platform=linux/amd64 myoung34/github-runner:ubuntu-noble@sha256:43afb5b81ac1981351b46d9054e14b3bdb15742d7aef28165b5be1a840bddbae
+
+LABEL org.opencontainers.image.source="https://github.com/ncosentino/needlr"
+LABEL org.opencontainers.image.description="Needlr CI runner with the pinned .NET SDK and Native AOT prerequisites"
+
+COPY --from=dotnet /usr/share/dotnet /usr/share/dotnet
+
+ENV DOTNET_ROOT=/usr/share/dotnet
+ENV PATH="/usr/share/dotnet:${PATH}"
+ENV DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+ENV DOTNET_NOLOGO=true
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        clang \
+        file \
+        zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN test -x /actions-runner/bin/Runner.Listener \
+    && dotnet --list-sdks | grep -F '10.0.302' \
+    && pwsh --version \
+    && git --version \
+    && gh --version \
+    && clang --version \
+    && file --version

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 10.0.x
+          global-json-file: global.json
 
       - name: Restore
         run: dotnet restore src/NexusLabs.Needlr.Benchmarks/NexusLabs.Needlr.Benchmarks.csproj

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
       if: needs.changes.outputs.source_required == 'true'
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 10.0.x
+        global-json-file: global.json
 
     - name: Validate delivery contract
       if: needs.changes.outputs.source_required == 'true'
@@ -181,6 +181,11 @@ jobs:
       if: needs.changes.outputs.source_required == 'true'
       shell: pwsh
       run: scripts/test-release-artifacts.ps1
+
+    - name: Validate runner image contract
+      if: needs.changes.outputs.source_required == 'true'
+      shell: pwsh
+      run: scripts/test-runner-image.ps1
 
     - name: Restore
       if: needs.changes.outputs.source_required == 'true'
@@ -248,8 +253,7 @@ jobs:
       if: needs.changes.outputs.source_required == 'true'
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: |
-          10.0.x
+        global-json-file: global.json
 
     - name: Add .NET global tools to PATH
       if: needs.changes.outputs.source_required == 'true'
@@ -443,8 +447,7 @@ jobs:
       if: needs.changes.outputs.source_required == 'true'
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: |
-          10.0.x
+        global-json-file: global.json
 
     - name: Validate CI scope classifier
       if: needs.changes.outputs.source_required == 'true'
@@ -510,7 +513,7 @@ jobs:
       if: needs.changes.outputs.source_required == 'true'
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 10.0.x
+        global-json-file: global.json
 
     - name: Install AOT dependencies
       if: needs.changes.outputs.source_required == 'true'
@@ -580,7 +583,7 @@ jobs:
       if: needs.changes.outputs.source_required == 'true'
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 10.0.x
+        global-json-file: global.json
 
     - name: Install AOT dependencies
       if: needs.changes.outputs.source_required == 'true'

--- a/.github/workflows/ide-extensions.yml
+++ b/.github/workflows/ide-extensions.yml
@@ -14,7 +14,6 @@ on:
         default: true
 
 env:
-  DOTNET_VERSION: '9.0.x'
   NODE_VERSION: '20'
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   DOTNET_NOLOGO: true
@@ -66,7 +65,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          global-json-file: ide-extensions/global.json
 
       - name: Update version in csproj
         shell: pwsh
@@ -77,10 +76,12 @@ jobs:
           Set-Content $csproj $content
 
       - name: Restore
-        run: dotnet restore ide-extensions/visualstudio/NeedlrCodeLens/NeedlrCodeLens.csproj
+        working-directory: ide-extensions
+        run: dotnet restore visualstudio/NeedlrCodeLens/NeedlrCodeLens.csproj
 
       - name: Build
-        run: dotnet build ide-extensions/visualstudio/NeedlrCodeLens/NeedlrCodeLens.csproj --configuration Release --no-restore
+        working-directory: ide-extensions
+        run: dotnet build visualstudio/NeedlrCodeLens/NeedlrCodeLens.csproj --configuration Release --no-restore
 
       - name: Rename VSIX with version
         shell: pwsh
@@ -105,7 +106,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          global-json-file: ide-extensions/global.json
 
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v2
@@ -119,10 +120,12 @@ jobs:
           Set-Content $manifest $content
 
       - name: Restore
-        run: dotnet restore ide-extensions/visualstudio/NeedlrToolsExtension/NeedlrToolsExtension.csproj
+        working-directory: ide-extensions
+        run: dotnet restore visualstudio/NeedlrToolsExtension/NeedlrToolsExtension.csproj
 
       - name: Build with MSBuild
-        run: msbuild ide-extensions/visualstudio/NeedlrToolsExtension/NeedlrToolsExtension.csproj /p:Configuration=Release /p:DeployExtension=false
+        working-directory: ide-extensions
+        run: msbuild visualstudio/NeedlrToolsExtension/NeedlrToolsExtension.csproj /p:Configuration=Release /p:DeployExtension=false
 
       - name: Rename VSIX with version
         shell: pwsh

--- a/.github/workflows/maui-example.yml
+++ b/.github/workflows/maui-example.yml
@@ -17,6 +17,7 @@ on:
       - 'src/Examples/Maui/**'
       - 'src/NexusLabs.Needlr.Generators/**'
       - 'src/NexusLabs.Needlr.Roslyn.Shared/**'
+      - 'global.json'
       - '.github/workflows/maui-example.yml'
       - 'scripts/build-maui-example.ps1'
   pull_request:
@@ -27,6 +28,7 @@ on:
       - 'src/Examples/Maui/**'
       - 'src/NexusLabs.Needlr.Generators/**'
       - 'src/NexusLabs.Needlr.Roslyn.Shared/**'
+      - 'global.json'
       - '.github/workflows/maui-example.yml'
       - 'scripts/build-maui-example.ps1'
 
@@ -48,8 +50,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: |
-            10.0.x
+          global-json-file: global.json
 
       - name: Install MAUI workloads
         run: dotnet workload install maui-android maui-windows

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,6 @@ on:
 # never restore, build, or test: retrying a failed destination replays only that
 # destination against the artifacts prepared earlier in this run.
 env:
-  DOTNET_VERSION: '10.0.x'
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
@@ -106,7 +105,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: ${{ env.DOTNET_VERSION }}
+        global-json-file: global.json
 
     - name: Add .NET global tools to PATH
       run: echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
@@ -334,7 +333,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: ${{ env.DOTNET_VERSION }}
+        global-json-file: global.json
 
     - name: Download prepared packages
       uses: actions/download-artifact@v4
@@ -392,7 +391,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: ${{ env.DOTNET_VERSION }}
+        global-json-file: global.json
 
     - name: Download prepared packages
       uses: actions/download-artifact@v4

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -1,0 +1,146 @@
+name: Runner image
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - global.json
+      - .github/runner-images/needlr-ci/**
+      - .github/workflows/runner-image.yml
+      - scripts/test-runner-image.ps1
+  push:
+    branches: [main]
+    paths:
+      - global.json
+      - .github/runner-images/needlr-ci/**
+      - .github/workflows/runner-image.yml
+      - scripts/test-runner-image.ps1
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: runner-image-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  IMAGE_NAME: ghcr.io/ncosentino/needlr-runner
+  LOCAL_IMAGE: needlr-runner:validation
+
+jobs:
+  validate:
+    name: Validate runner image
+    if: github.event_name != 'push'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Validate image contract
+      shell: pwsh
+      run: scripts/test-runner-image.ps1
+
+    - name: Setup Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build validation image
+      uses: docker/build-push-action@v6
+      with:
+        context: .github/runner-images/needlr-ci
+        file: .github/runner-images/needlr-ci/Dockerfile
+        platforms: linux/amd64
+        load: true
+        push: false
+        tags: ${{ env.LOCAL_IMAGE }}
+
+    - name: Verify built image
+      run: |
+        docker run --rm --entrypoint /bin/sh "$LOCAL_IMAGE" -c '
+          test -x /actions-runner/bin/Runner.Listener
+          dotnet --list-sdks | grep -F "10.0.302"
+          clang --version
+          pwsh --version
+        '
+
+  publish:
+    name: Publish runner image
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Validate image contract
+      shell: pwsh
+      run: scripts/test-runner-image.ps1
+
+    - name: Setup Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Authenticate to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and publish immutable image
+      id: image
+      uses: docker/build-push-action@v6
+      with:
+        context: .github/runner-images/needlr-ci
+        file: .github/runner-images/needlr-ci/Dockerfile
+        platforms: linux/amd64
+        push: true
+        provenance: mode=max
+        sbom: true
+        tags: ${{ env.IMAGE_NAME }}:sha-${{ github.sha }}
+        labels: |
+          org.opencontainers.image.source=https://github.com/${{ github.repository }}
+          org.opencontainers.image.revision=${{ github.sha }}
+
+    - name: Verify published image
+      env:
+        IMAGE_DIGEST: ${{ steps.image.outputs.digest }}
+      run: docker buildx imagetools inspect "$IMAGE_NAME@$IMAGE_DIGEST"
+
+    - name: Record immutable publication
+      env:
+        IMAGE_DIGEST: ${{ steps.image.outputs.digest }}
+      run: |
+        mkdir -p runner-image-publication
+        jq -n \
+          --arg image "$IMAGE_NAME" \
+          --arg tag "sha-${GITHUB_SHA}" \
+          --arg digest "$IMAGE_DIGEST" \
+          --arg sourceSha "$GITHUB_SHA" \
+          '{
+            schemaVersion: 1,
+            image: $image,
+            tag: $tag,
+            digest: $digest,
+            sourceSha: $sourceSha
+          }' > runner-image-publication/publication.json
+        {
+          echo "## Needlr runner image"
+          echo
+          echo "\`$IMAGE_NAME@$IMAGE_DIGEST\`"
+          echo
+          echo "After the first publication, a repository owner must make the GHCR package public before the digest is committed to the PitCrew profile."
+        } >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Upload publication record
+      uses: actions/upload-artifact@v4
+      with:
+        name: needlr-runner-publication
+        path: runner-image-publication/publication.json
+        if-no-files-found: error
+        retention-days: 30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Changed
 
 - Release publication is now staged. `release.yml` verifies the same-commit `main` CI run, prepares a release candidate once, and hands digest-verified artifacts to separate NuGet.org, GitHub Packages, documentation, and GitHub Release jobs. Publication jobs never restore, build, or test, so retrying a failed destination replays only that destination instead of repeating validation that already passed for the exact commit. Every packaged file is bound to its source commit and validating CI run by `release-manifest.json`, and each publication job re-verifies that manifest before its irreversible step. See ADR-0009 and `docs/releasing.md`.
+- Needlr now pins .NET SDK `10.0.302` and validates a digest-pinned, repository-owned Linux runner image on pull requests. Trusted `main` publishes commit-tagged images to `ghcr.io/ncosentino/needlr-runner` and records the immutable manifest digest for a separately reviewed PitCrew profile rollout. Existing hosted and general-purpose runner routes remain unchanged until that profile is activated.
 
 ## [0.0.3-alpha.3] - 2026-07-28
 

--- a/docs/adr/adr-0010-own-repository-runner-image.md
+++ b/docs/adr/adr-0010-own-repository-runner-image.md
@@ -1,0 +1,151 @@
+---
+title: "ADR-0010: Own a repository runner image"
+status: "Accepted"
+date: "2026-07-29"
+authors: ["Nick Cosentino"]
+tags: ["architecture", "decision", "ci", "containers", "runners"]
+supersedes: ""
+superseded_by: ""
+---
+
+## Context and scope
+
+Needlr's trusted Linux validation and release jobs use ephemeral PitCrew workers. Those
+jobs repeatedly acquire the .NET SDK and install Native AOT prerequisites even though
+the required toolchain changes much less frequently than the workers.
+
+Release `v0.0.3-alpha.3` demonstrated the operational cost. Its publication worker spent
+about twenty minutes in SDK setup before any release preparation could begin. Staged
+release publication now makes downstream retries cheaper, but it does not make worker
+startup deterministic.
+
+Needlr already selects trusted Linux runners through `CI_RUNNER`, preserves a
+general-purpose PitCrew fallback, and forces external forks onto GitHub-hosted workers.
+PitCrew supports operator-approved external OCI profiles with immutable image identity,
+verification commands, rolling worker replacement, and rollback.
+
+This decision governs the toolchain image, publication boundary, profile identity, and
+workflow routing for Needlr's trusted Linux jobs. It does not let repository workflows
+mutate PitCrew, change host capacity, or select arbitrary images at runtime.
+
+## Decision drivers
+
+- Ephemeral workers should start with the exact supported .NET SDK already installed.
+- Runner configuration must remain reproducible and rollback-safe.
+- Pull requests must validate image changes without publishing deployable images.
+- Only trusted `main` may publish the image.
+- External forks must never reach self-hosted infrastructure.
+- GitHub-hosted and general-purpose PitCrew fallbacks must remain available.
+- No source, generated output, or credentials may enter an image layer.
+- Host capacity and image activation remain operator-owned.
+
+## Decision
+
+Needlr will publish a public Linux amd64 runner image at
+`ghcr.io/ncosentino/needlr-runner`.
+
+GHCR creates the package as private on its first push. A repository owner performs a
+one-time visibility change after trusted `main` publishes the initial image and verifies
+anonymous digest access before the profile PR is opened. Later image revisions retain the
+package's public visibility.
+
+`global.json` is the source of truth for the exact .NET SDK. The runner Dockerfile uses
+the same SDK version, pins every base image by SHA-256 digest, copies only the .NET
+installation from the SDK stage, and installs the stable Native AOT OS prerequisites.
+Python and Node.js remain workflow-managed until the repository defines exact versions
+for them.
+
+Pull requests build and execute the image on GitHub-hosted Ubuntu without publishing it.
+Trusted `main` publishes a commit-tagged image and records the immutable manifest digest.
+No pull-request event receives package publication capability.
+
+Activation uses a separately reviewed `.pitcrew/runner-profile.json` named `needlr-ci`.
+The profile references the immutable GHCR digest, disables GitHub default labels, and
+verifies the runner listener, SDK, and advertised native tools. PitCrew automatically
+adds `needlr-ci` as the routing label.
+
+Bootstrap and updates use two repository changes: the image contract first, then the
+published digest and routing contract. A workflow cannot safely commit the digest of an
+image that trusted `main` has not published yet.
+
+The host operator applies the profile with Needlr's existing capacity, confirms the
+specialized runner is online, and only then sets `CI_RUNNER=needlr-ci`. Repository
+workflows detect the exact SDK before invoking setup, so the specialized profile avoids
+the download while hosted fallback remains functional.
+
+## Alternatives considered
+
+### Continue runtime SDK installation
+
+This keeps workflows portable and avoids image ownership. It was rejected because every
+ephemeral worker repeats slow external acquisition and can stall before useful work
+begins.
+
+### Put the toolchain in PitCrew's default image
+
+This centralizes image maintenance. It was rejected because PitCrew is a runner
+orchestrator, not an ecosystem toolchain catalog. Needlr owns its SDK and native build
+requirements.
+
+### Publish and activate a mutable tag
+
+This simplifies updates because the profile never changes. It was rejected because the
+same profile document could resolve to different bytes, weakening auditability and
+rollback.
+
+### Publish from pull requests
+
+This would make the image digest available before merge. It was rejected because
+untrusted or unreviewed code must not publish deployable runner images.
+
+### Include Python and Node.js in the initial contract
+
+The base runner already supplies those tools and workflows currently request floating
+versions. Adding them without exact repository version contracts would create an
+appearance of determinism without providing it. They remain workflow-managed.
+
+## Consequences
+
+### Positive
+
+- The exact .NET SDK and Native AOT prerequisites are prepared once per image revision.
+- Image changes are reviewed, validated, digest-pinned, and independently rollbackable.
+- Hosted fallback and external-fork isolation remain intact.
+- Needlr owns its toolchain lifecycle without expanding PitCrew's responsibilities.
+
+### Negative
+
+- Image publication and digest activation require two pull requests.
+- Needlr assumes GHCR image maintenance and storage.
+- The operator must apply the profile on each approved host before changing routing.
+- SDK servicing requires coordinated changes to `global.json`, the image, and profile
+  digest.
+
+### Neutral
+
+- Python and Node.js setup remain unchanged.
+- Existing general-purpose PitCrew capacity remains available during rollout and
+  rollback.
+- Busy stale workers may continue until their current job finishes.
+
+## Confirmation
+
+Repository tests validate the SDK pin, base-image digests, absence of source or
+credential-bearing Dockerfile inputs, trusted publication trigger, commit tag, and digest
+capture.
+
+The pull-request image workflow builds and executes the candidate. The trusted-main run
+must publish a digest before the profile PR can be created.
+
+Activation is confirmed by a live `needlr-ci` runner, representative source validation,
+both Native AOT jobs, documentation generation, and a non-publishing release dry run.
+PitCrew rollout evidence must report the approved target image and preserve the existing
+Needlr capacity.
+
+## References
+
+- ADR-0009 records the staged release publication model whose preparation job benefits
+  from deterministic worker startup.
+- Needlr issue 119 defines the repository-owned image and portable routing requirements.
+- PitCrew's repository-owned image guide defines the operator/repository ownership
+  boundary and digest-pinned external profile lifecycle.

--- a/docs/local-runners.md
+++ b/docs/local-runners.md
@@ -34,3 +34,8 @@ PitCrew workers are socketless Linux containers. Workloads requiring Docker,
 service containers, Testcontainers, Windows, or macOS remain on an appropriate
 hosted or isolated runner profile. Needlr's Windows and MAUI jobs therefore
 continue using native GitHub-hosted runners.
+
+Needlr also publishes a repository-owned `needlr-ci` image profile with the exact
+.NET SDK and Native AOT prerequisites. See
+[Repository-Owned Runner Image](runner-image.md) for publication, activation, update,
+hosted fallback, and rollback.

--- a/docs/runner-image.md
+++ b/docs/runner-image.md
@@ -1,0 +1,103 @@
+---
+description: Build, publish, activate, update, and roll back Needlr's repository-owned PitCrew runner image.
+---
+
+# Repository-Owned Runner Image
+
+Needlr owns a Linux amd64 GitHub Actions runner image containing the exact .NET
+SDK and Native AOT prerequisites used by source validation and release preparation.
+PitCrew remains responsible for runner registration, capacity, and worker lifecycle.
+
+The image contains no repository source, generated output, registration token, package
+credential, or deployment credential.
+
+## Pinned Toolchain
+
+`global.json` pins .NET SDK `10.0.302` with roll-forward disabled. The runner
+Dockerfile uses the same SDK and pins both of its base images by immutable SHA-256
+digest.
+
+The image also includes the Linux packages required by Needlr's Native AOT jobs:
+
+- `clang`;
+- `file`;
+- `zlib1g-dev`.
+
+Python and Node.js remain workflow-managed. Their current workflow inputs are not exact
+version contracts, and they were not the cause of repeated SDK acquisition.
+
+## Publication
+
+`.github/workflows/runner-image.yml` uses GitHub-hosted Ubuntu workers because image
+validation requires Docker:
+
+- pull requests build and run the candidate without publishing it;
+- `main` publishes `ghcr.io/ncosentino/needlr-runner:sha-<commit>`;
+- the workflow captures the immutable registry manifest digest and uploads a
+  `needlr-runner-publication` record.
+
+GHCR creates a new container package as private. After the first trusted publication, a
+repository owner must make `needlr-runner` public once in GitHub package settings (or
+through the package API) and verify an unauthenticated digest pull. Workflows and PitCrew
+profiles then deploy by digest, never by a mutable tag.
+
+## Bootstrap Sequence
+
+Image publication and profile activation require two reviewed repository changes:
+
+1. Merge the Dockerfile, SDK pin, tests, and publication workflow.
+2. Read the immutable digest from the trusted `main` publication run.
+3. Make the new GHCR package public and verify anonymous access to that digest.
+4. Commit `.pitcrew/runner-profile.json` with that digest.
+5. Merge the profile and portable workflow-routing changes.
+6. Apply the approved external profile on the runner host.
+7. Set `CI_RUNNER=needlr-ci` only after the specialized runner is online.
+
+The digest cannot be safely committed before trusted `main` publishes the image, so the
+two-PR sequence is intentional.
+
+## Host Activation
+
+PitCrew automatically adds the profile name as a routing label. A profile named
+`needlr-ci` therefore satisfies jobs whose `runs-on` value is `needlr-ci`, even when
+GitHub default labels are disabled.
+
+The activation command must replay the existing Needlr capacity rather than guessing it.
+The exact command is documented with the digest-pinning PR after reading the host's
+non-secret PitCrew state.
+
+Repository workflows never choose an OCI image or mutate PitCrew. Image activation is an
+operator-approved host operation.
+
+## Updating the Image
+
+1. Change the Dockerfile or SDK pin through a pull request.
+2. Let trusted `main` publish a new immutable digest.
+3. Update the profile digest through a second pull request.
+4. Apply the profile on one host with `pitcrew-profile-rollout`.
+5. Verify the target image identity, current workers, stale workers, and rollout state.
+6. Update other approved hosts after the first host is healthy.
+
+`update.status: rolling` is successful partial convergence while busy ephemeral workers
+finish naturally.
+
+## Rollback
+
+Restore the previous profile digest in a reviewed change and replay the complete external
+profile command. Do not restart Docker, tear down the profile broadly, or use a mutable
+image tag as a rollback target.
+
+## Hosted Fallback
+
+The existing `CI_RUNNER` contract remains portable:
+
+- `needlr-ci` selects the specialized profile;
+- `ubuntu-latest` selects GitHub-hosted Linux workers;
+- an unset variable uses the existing general-purpose PitCrew fallback;
+- external fork pull requests always route to `ubuntu-24.04` before the variable is
+  considered.
+
+## See Also
+
+- [Local CI Runners](local-runners.md)
+- [ADR-0010: Own a Repository Runner Image](adr/adr-0010-own-repository-runner-image.md)

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "10.0.302",
+    "rollForward": "disable",
+    "allowPrerelease": false
+  }
+}

--- a/ide-extensions/global.json
+++ b/ide-extensions/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "9.0.316",
+    "rollForward": "disable",
+    "allowPrerelease": false
+  }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,6 +85,7 @@ nav:
     - Cross-Generator Plugins: cross-generator-plugins.md
     - IDE Extensions: ide-extensions.md
     - Local CI Runners: local-runners.md
+    - Repository-Owned Runner Image: runner-image.md
     - Releasing Needlr: releasing.md
   - Benchmarks: benchmarks.md
   - Analyzers:
@@ -186,6 +187,7 @@ nav:
     - ADR-0007 Own Graph Source Locations Per Project: adr/adr-0007-own-graph-source-locations-per-project.md
     - ADR-0008 Own a Version-Aware Agent Marketplace: adr/adr-0008-own-version-aware-agent-marketplace.md
     - ADR-0009 Stage Release Publication: adr/adr-0009-stage-release-publication.md
+    - ADR-0010 Own a Repository Runner Image: adr/adr-0010-own-repository-runner-image.md
 
 plugins:
   - search

--- a/scripts/test-runner-image.ps1
+++ b/scripts/test-runner-image.ps1
@@ -1,0 +1,105 @@
+<#
+.SYNOPSIS
+    Validates the repository-owned Needlr runner image contract.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$globalJsonPath = Join-Path $repoRoot 'global.json'
+$dockerfilePath = Join-Path $repoRoot '.github\runner-images\needlr-ci\Dockerfile'
+$workflowPath = Join-Path $repoRoot '.github\workflows\runner-image.yml'
+$expectedSdkVersion = '10.0.302'
+
+function Assert-Condition {
+    param(
+        [Parameter(Mandatory)]
+        [bool]$Condition,
+
+        [Parameter(Mandatory)]
+        [string]$Message)
+
+    if (-not $Condition) {
+        throw $Message
+    }
+}
+
+$globalJson = Get-Content -LiteralPath $globalJsonPath -Raw | ConvertFrom-Json
+Assert-Condition `
+    -Condition ([string]$globalJson.sdk.version -ceq $expectedSdkVersion) `
+    -Message "global.json must pin .NET SDK $expectedSdkVersion."
+Assert-Condition `
+    -Condition ([string]$globalJson.sdk.rollForward -ceq 'disable') `
+    -Message 'global.json must disable SDK roll-forward.'
+Assert-Condition `
+    -Condition (-not [bool]$globalJson.sdk.allowPrerelease) `
+    -Message 'global.json must reject prerelease SDKs.'
+
+$dockerfile = Get-Content -LiteralPath $dockerfilePath -Raw
+$pinnedFromLines = @(
+    $dockerfile -split '\r?\n' |
+        Where-Object { $_ -match '^FROM .+@sha256:[0-9a-f]{64}(?:\s+AS\s+\w+)?$' })
+Assert-Condition `
+    -Condition ($pinnedFromLines.Count -eq 2) `
+    -Message 'The runner Dockerfile must pin both base images by SHA-256 digest.'
+Assert-Condition `
+    -Condition ($dockerfile -match [regex]::Escape("dotnet/sdk:$expectedSdkVersion-noble@sha256:")) `
+    -Message "The runner image must install the SDK pinned by global.json."
+Assert-Condition `
+    -Condition ($dockerfile -match '/actions-runner/bin/Runner\.Listener') `
+    -Message 'The runner image must verify Runner.Listener.'
+Assert-Condition `
+    -Condition ($dockerfile -match 'clang' -and $dockerfile -match 'zlib1g-dev') `
+    -Message 'The runner image must include Needlr Native AOT prerequisites.'
+Assert-Condition `
+    -Condition ($dockerfile -notmatch '(?im)^\s*(COPY|ADD)\s+\.\s') `
+    -Message 'The runner image must not copy repository source into an image layer.'
+Assert-Condition `
+    -Condition ($dockerfile -notmatch '(?i)(api[_-]?key|access[_-]?token|password|credential|private[_-]?key)') `
+    -Message 'The runner Dockerfile must not contain credential-bearing inputs.'
+
+$workflow = Get-Content -LiteralPath $workflowPath -Raw
+Assert-Condition `
+    -Condition ($workflow -notmatch 'pull_request_target') `
+    -Message 'Runner image validation must never use pull_request_target.'
+Assert-Condition `
+    -Condition ($workflow -match "(?m)^  pull_request:\r?$") `
+    -Message 'Pull requests must validate the runner image.'
+Assert-Condition `
+    -Condition ($workflow -match "(?m)^  push:\r?$" -and $workflow -match "branches: \[main\]") `
+    -Message 'Trusted main pushes must publish the runner image.'
+Assert-Condition `
+    -Condition ($workflow -match "github\.event_name == 'push'.*refs/heads/main") `
+    -Message 'Image publication must be restricted to trusted main pushes.'
+Assert-Condition `
+    -Condition ($workflow -match '(?m)^\s+packages: write\r?$') `
+    -Message 'The publication job must request packages: write.'
+Assert-Condition `
+    -Condition ($workflow -match 'ghcr\.io/ncosentino/needlr-runner') `
+    -Message 'The publication workflow must target the Needlr GHCR package.'
+Assert-Condition `
+    -Condition ($workflow -match 'sha-\$\{\{ github\.sha \}\}') `
+    -Message 'Published images must carry an immutable commit tag.'
+Assert-Condition `
+    -Condition ($workflow -match 'steps\.image\.outputs\.digest') `
+    -Message 'The publication workflow must capture the registry manifest digest.'
+
+$allWorkflowText = @(
+    Get-ChildItem -LiteralPath (Join-Path $repoRoot '.github\workflows') -Filter '*.yml' |
+        ForEach-Object { Get-Content -LiteralPath $_.FullName -Raw }) -join "`n"
+$setupDotnetCount = (
+    [regex]::Matches(
+        $allWorkflowText,
+        'uses:\s*actions/setup-dotnet@')).Count
+$globalJsonCount = (
+    [regex]::Matches(
+        $allWorkflowText,
+        'global-json-file:\s*(?:[A-Za-z0-9._/-]+/)?global\.json')).Count
+Assert-Condition `
+    -Condition ($allWorkflowText -notmatch '(?m)^\s+dotnet-version:') `
+    -Message 'Workflows must not bypass the exact SDK pin with dotnet-version.'
+Assert-Condition `
+    -Condition ($setupDotnetCount -eq $globalJsonCount) `
+    -Message 'Every actions/setup-dotnet step must use an exact global.json contract.'
+
+Write-Host 'Runner image contract validation passed.' -ForegroundColor Green


### PR DESCRIPTION
## Summary

- pin Needlr source, CI, release, benchmark, and MAUI builds to .NET SDK `10.0.302`; preserve the legacy Visual Studio extension SDK with `ide-extensions/global.json` at `9.0.316`
- add a Linux amd64 runner Dockerfile with digest-pinned .NET and GitHub runner bases, the exact SDK, and Native AOT prerequisites
- validate candidate images on pull requests and publish immutable commit-tagged images only from trusted `main` to `ghcr.io/ncosentino/needlr-runner`
- emit the published manifest digest as a workflow summary and retained publication record
- add static image/workflow contract tests, CI preflight integration, ADR-0010, and lifecycle documentation
- preserve all existing runner routing; this PR does not change `CI_RUNNER` or any PitCrew host

## Base image identities

- `mcr.microsoft.com/dotnet/sdk:10.0.302-noble@sha256:ed034a8bf0b24ded0cbbac07e17825d8e9ebfe21e308191d0f7421eaf5ad4664`
- `myoung34/github-runner:ubuntu-noble@sha256:43afb5b81ac1981351b46d9054e14b3bdb15742d7aef28165b5be1a840bddbae`

## Validation

- exact-SDK Release build: 0 errors, 3 existing generated-example CS0162 warnings
- complete solution tests under SDK 10.0.302: 2,807 passed, 0 failed, 0 skipped
- package validation: passed, including 40 example builds and four example test projects
- runner image static contract, CI scope, release artifact, and tag-only release tests: passed
- CodeLens VSIX build under SDK 9.0.316: 0 warnings, 0 errors
- VS Tool Window build under SDK 9.0.316: 0 errors, 17 existing analyzer warnings
- delivery contract and all workflow YAML: parsed successfully
- strict MkDocs build: passed

The executable Docker build is intentionally performed by the path-filtered GitHub-hosted `Validate runner image` job because the local Docker daemon is unavailable.

## Bootstrap after merge

Trusted `main` will publish the initial image. GHCR creates a new package as private, so a repository owner will make `needlr-runner` public once and verify anonymous digest access. A second PR will then pin that immutable digest in `.pitcrew/runner-profile.json`, add conditional SDK setup and routing tests, and provide the exact Zephyr rollout/rollback commands.

Closes no issue; this is PR 1 of #119.
