### PR TITLE
ci: pin Needlr runner profile

### DIFF
--- a/.github/actions/setup-dotnet/action.yml
+++ b/.github/actions/setup-dotnet/action.yml
@@ -1,0 +1,83 @@
+name: Setup pinned .NET SDK
+description: Uses an installed exact SDK when available and otherwise installs the repository's global.json version.
+
+inputs:
+  global-json-file:
+    description: Repository-relative global.json path.
+    required: false
+    default: global.json
+
+outputs:
+  setup-performed:
+    description: Whether actions/setup-dotnet installed the SDK.
+    value: ${{ steps.detect.outputs.setup-required }}
+  required-version:
+    description: Exact SDK version required by the selected global.json.
+    value: ${{ steps.detect.outputs.required-version }}
+
+runs:
+  using: composite
+  steps:
+  - name: Detect exact SDK
+    id: detect
+    shell: pwsh
+    env:
+      GLOBAL_JSON_FILE: ${{ inputs.global-json-file }}
+    run: |
+      $globalJsonPath = Join-Path $env:GITHUB_WORKSPACE $env:GLOBAL_JSON_FILE
+      if (-not (Test-Path -LiteralPath $globalJsonPath -PathType Leaf)) {
+        throw "global.json was not found at '$globalJsonPath'."
+      }
+
+      $globalJson = Get-Content -LiteralPath $globalJsonPath -Raw |
+        ConvertFrom-Json
+      $requiredVersion = [string]$globalJson.sdk.version
+      if ($requiredVersion -notmatch '^\d+\.\d+\.\d+$') {
+        throw "global.json must declare an exact SDK version; actual '$requiredVersion'."
+      }
+
+      $installedVersions = @()
+      $dotnet = Get-Command dotnet -ErrorAction SilentlyContinue
+      if ($null -ne $dotnet) {
+        $sdkOutput = & dotnet --list-sdks 2>&1
+        if ($LASTEXITCODE -ne 0) {
+          throw "The installed dotnet command could not enumerate SDKs.`n$($sdkOutput | Out-String)"
+        }
+        $installedVersions = @(
+          $sdkOutput |
+            ForEach-Object { ($_ -split '\s+', 2)[0] } |
+            Where-Object { $_ })
+      }
+
+      $setupRequired = $requiredVersion -notin $installedVersions
+      "required-version=$requiredVersion" |
+        Out-File $env:GITHUB_OUTPUT -Append
+      "setup-required=$($setupRequired.ToString().ToLowerInvariant())" |
+        Out-File $env:GITHUB_OUTPUT -Append
+
+      if ($setupRequired) {
+        Write-Host "SDK $requiredVersion is not installed; setup is required."
+      } else {
+        Write-Host "SDK $requiredVersion is already installed; setup is skipped."
+      }
+
+  - name: Configure writable install directory
+    if: steps.detect.outputs.setup-required == 'true'
+    shell: pwsh
+    run: |
+      $installDirectory =
+        if ($env:RUNNER_OS -eq 'Windows') {
+          Join-Path $env:RUNNER_TEMP 'dotnet'
+        } else {
+          Join-Path $env:RUNNER_TEMP 'dotnet'
+        }
+      "DOTNET_INSTALL_DIR=$installDirectory" |
+        Out-File $env:GITHUB_ENV -Append
+      $installDirectory |
+        Out-File $env:GITHUB_PATH -Append
+
+  - name: Install exact SDK
+    if: steps.detect.outputs.setup-required == 'true'
+    uses: actions/setup-dotnet@v4
+    with:
+      global-json-file: ${{ inputs.global-json-file }}

--- a/.github/genesis-delivery.json
+++ b/.github/genesis-delivery.json
@@ -44,6 +44,30 @@
         "ide-extensions/build-vscode",
         "ide-extensions/release"
       ]
+    },
+    {
+      "id": "needlr-ci",
+      "source": "ghcr.io/ncosentino/needlr-runner@sha256:233a06905fc35312fe73099d12e93bf496ac1b98dd19a0482be000c12d7b4461",
+      "labels": [
+        "needlr-ci"
+      ],
+      "jobs": [
+        "preflight",
+        "build-and-test",
+        "package-validation",
+        "aot-console-app",
+        "aot-web-app",
+        "deploy-documentation",
+        "release/prepare",
+        "release/publish-nuget",
+        "release/publish-github-packages",
+        "release/deploy-documentation",
+        "release/create-release",
+        "benchmarks/check-changes",
+        "benchmarks/run-benchmarks",
+        "ide-extensions/build-vscode",
+        "ide-extensions/release"
+      ]
     }
   ],
   "componentWorkflows": [

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -66,7 +66,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: ./.github/actions/setup-dotnet
         with:
           global-json-file: global.json
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,16 +145,9 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Configure writable .NET install directory
-      if: needs.changes.outputs.source_required == 'true'
-      shell: bash
-      run: |
-        echo "DOTNET_INSTALL_DIR=$RUNNER_TEMP/dotnet" >> "$GITHUB_ENV"
-        echo "$RUNNER_TEMP/dotnet" >> "$GITHUB_PATH"
-
     - name: Setup .NET
       if: needs.changes.outputs.source_required == 'true'
-      uses: actions/setup-dotnet@v4
+      uses: ./.github/actions/setup-dotnet
       with:
         global-json-file: global.json
 
@@ -186,6 +179,11 @@ jobs:
       if: needs.changes.outputs.source_required == 'true'
       shell: pwsh
       run: scripts/test-runner-image.ps1
+
+    - name: Validate runner profile contract
+      if: needs.changes.outputs.source_required == 'true'
+      shell: pwsh
+      run: scripts/test-runner-profile.ps1
 
     - name: Restore
       if: needs.changes.outputs.source_required == 'true'
@@ -242,16 +240,9 @@ jobs:
       with:
         fetch-depth: 0 # Needed for NBGV / SourceLink / deterministic builds
 
-    - name: Configure writable .NET install directory
-      if: needs.changes.outputs.source_required == 'true'
-      shell: bash
-      run: |
-        echo "DOTNET_INSTALL_DIR=$RUNNER_TEMP/dotnet" >> "$GITHUB_ENV"
-        echo "$RUNNER_TEMP/dotnet" >> "$GITHUB_PATH"
-
     - name: Setup .NET
       if: needs.changes.outputs.source_required == 'true'
-      uses: actions/setup-dotnet@v4
+      uses: ./.github/actions/setup-dotnet
       with:
         global-json-file: global.json
 
@@ -436,16 +427,9 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Configure writable .NET install directory
-      if: needs.changes.outputs.source_required == 'true'
-      shell: bash
-      run: |
-        echo "DOTNET_INSTALL_DIR=$RUNNER_TEMP/dotnet" >> "$GITHUB_ENV"
-        echo "$RUNNER_TEMP/dotnet" >> "$GITHUB_PATH"
-
     - name: Setup .NET
       if: needs.changes.outputs.source_required == 'true'
-      uses: actions/setup-dotnet@v4
+      uses: ./.github/actions/setup-dotnet
       with:
         global-json-file: global.json
 
@@ -502,16 +486,9 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Configure writable .NET install directory
-      if: needs.changes.outputs.source_required == 'true'
-      shell: bash
-      run: |
-        echo "DOTNET_INSTALL_DIR=$RUNNER_TEMP/dotnet" >> "$GITHUB_ENV"
-        echo "$RUNNER_TEMP/dotnet" >> "$GITHUB_PATH"
-
     - name: Setup .NET 10
       if: needs.changes.outputs.source_required == 'true'
-      uses: actions/setup-dotnet@v4
+      uses: ./.github/actions/setup-dotnet
       with:
         global-json-file: global.json
 
@@ -572,16 +549,9 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Configure writable .NET install directory
-      if: needs.changes.outputs.source_required == 'true'
-      shell: bash
-      run: |
-        echo "DOTNET_INSTALL_DIR=$RUNNER_TEMP/dotnet" >> "$GITHUB_ENV"
-        echo "$RUNNER_TEMP/dotnet" >> "$GITHUB_PATH"
-
     - name: Setup .NET 10
       if: needs.changes.outputs.source_required == 'true'
-      uses: actions/setup-dotnet@v4
+      uses: ./.github/actions/setup-dotnet
       with:
         global-json-file: global.json
 

--- a/.github/workflows/ide-extensions.yml
+++ b/.github/workflows/ide-extensions.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: ./.github/actions/setup-dotnet
         with:
           global-json-file: ide-extensions/global.json
 
@@ -104,7 +104,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: ./.github/actions/setup-dotnet
         with:
           global-json-file: ide-extensions/global.json
 

--- a/.github/workflows/maui-example.yml
+++ b/.github/workflows/maui-example.yml
@@ -48,7 +48,7 @@ jobs:
           fetch-depth: 0 # Needed for NBGV / SourceLink on the referenced library projects
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: ./.github/actions/setup-dotnet
         with:
           global-json-file: global.json
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
         fetch-tags: true    # ensure tags are available locally
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: ./.github/actions/setup-dotnet
       with:
         global-json-file: global.json
 
@@ -331,7 +331,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: ./.github/actions/setup-dotnet
       with:
         global-json-file: global.json
 
@@ -389,7 +389,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: ./.github/actions/setup-dotnet
       with:
         global-json-file: global.json
 

--- a/.pitcrew/runner-profile.json
+++ b/.pitcrew/runner-profile.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://raw.githubusercontent.com/ncosentino/pitcrew/87162e6fad6a961b9bc2f026639f2fa7df0795ba/runner-profile.schema.json",
+  "schemaVersion": 1,
+  "name": "needlr-ci",
+  "description": "Needlr repository CI workers with the pinned .NET SDK and Native AOT prerequisites.",
+  "image": "ghcr.io/ncosentino/needlr-runner@sha256:233a06905fc35312fe73099d12e93bf496ac1b98dd19a0482be000c12d7b4461",
+  "labels": [
+    "needlr"
+  ],
+  "replicas": 1,
+  "pullImage": true,
+  "disableDefaultLabels": true,
+  "verificationCommands": [
+    "test -x /actions-runner/bin/Runner.Listener",
+    "dotnet --list-sdks | grep -F '10.0.302'",
+    "clang --version",
+    "pwsh --version"
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Release publication is now staged. `release.yml` verifies the same-commit `main` CI run, prepares a release candidate once, and hands digest-verified artifacts to separate NuGet.org, GitHub Packages, documentation, and GitHub Release jobs. Publication jobs never restore, build, or test, so retrying a failed destination replays only that destination instead of repeating validation that already passed for the exact commit. Every packaged file is bound to its source commit and validating CI run by `release-manifest.json`, and each publication job re-verifies that manifest before its irreversible step. See ADR-0009 and `docs/releasing.md`.
 - Needlr now pins .NET SDK `10.0.302` and validates a digest-pinned, repository-owned Linux runner image on pull requests. Trusted `main` publishes commit-tagged images to `ghcr.io/ncosentino/needlr-runner` and records the immutable manifest digest for a separately reviewed PitCrew profile rollout. Existing hosted and general-purpose runner routes remain unchanged until that profile is activated.
+- The published runner image is pinned in a `needlr-ci` PitCrew profile, and every workflow now uses a conditional local setup action that skips SDK download when the exact version is already installed while preserving writable hosted/general-purpose fallback installation. Repository routing remains unchanged until the operator applies the profile and sets `CI_RUNNER=needlr-ci`.
 
 ## [0.0.3-alpha.3] - 2026-07-28
 

--- a/docs/adr/adr-0010-own-repository-runner-image.md
+++ b/docs/adr/adr-0010-own-repository-runner-image.md
@@ -142,6 +142,20 @@ both Native AOT jobs, documentation generation, and a non-publishing release dry
 PitCrew rollout evidence must report the approved target image and preserve the existing
 Needlr capacity.
 
+## Outcome Notes
+
+### 2026-07-29 - initial image publication
+
+Trusted `main` published the initial Linux amd64 image at:
+
+```text
+ghcr.io/ncosentino/needlr-runner@sha256:233a06905fc35312fe73099d12e93bf496ac1b98dd19a0482be000c12d7b4461
+```
+
+The package permits anonymous digest retrieval. The separately reviewed
+`.pitcrew/runner-profile.json` pins that identity and preserves Needlr's existing
+one-worker capacity.
+
 ## References
 
 - ADR-0009 records the staged release publication model whose preparation job benefits

--- a/docs/local-runners.md
+++ b/docs/local-runners.md
@@ -12,7 +12,7 @@ Provision repository-scoped capacity from a PitCrew checkout:
 
 ```powershell
 .\Setup-Runner.ps1 `
-    -Repos https://github.com/ncosentino/needlr=2
+    -Repos https://github.com/ncosentino/needlr=1
 ```
 
 The workflows use the `CI_RUNNER` repository variable as PitCrew's manual
@@ -38,4 +38,5 @@ continue using native GitHub-hosted runners.
 Needlr also publishes a repository-owned `needlr-ci` image profile with the exact
 .NET SDK and Native AOT prerequisites. See
 [Repository-Owned Runner Image](runner-image.md) for publication, activation, update,
-hosted fallback, and rollback.
+hosted fallback, and rollback. The committed profile pins the public GHCR digest and
+preserves Needlr's existing capacity of one worker.

--- a/docs/runner-image.md
+++ b/docs/runner-image.md
@@ -36,10 +36,14 @@ validation requires Docker:
 - the workflow captures the immutable registry manifest digest and uploads a
   `needlr-runner-publication` record.
 
-GHCR creates a new container package as private. After the first trusted publication, a
-repository owner must make `needlr-runner` public once in GitHub package settings (or
-through the package API) and verify an unauthenticated digest pull. Workflows and PitCrew
-profiles then deploy by digest, never by a mutable tag.
+The initial trusted publication produced:
+
+```text
+ghcr.io/ncosentino/needlr-runner@sha256:233a06905fc35312fe73099d12e93bf496ac1b98dd19a0482be000c12d7b4461
+```
+
+Anonymous manifest retrieval succeeds for that digest. Workflows and PitCrew profiles
+deploy by digest, never by a mutable tag.
 
 ## Bootstrap Sequence
 
@@ -62,9 +66,40 @@ PitCrew automatically adds the profile name as a routing label. A profile named
 `needlr-ci` therefore satisfies jobs whose `runs-on` value is `needlr-ci`, even when
 GitHub default labels are disabled.
 
-The activation command must replay the existing Needlr capacity rather than guessing it.
-The exact command is documented with the digest-pinning PR after reading the host's
-non-secret PitCrew state.
+Needlr's existing capacity is one worker. On the Zephyr host, run from the PitCrew
+checkout:
+
+```powershell
+.\Setup-Runner.ps1 `
+    -ProfilePath <needlr-checkout>\.pitcrew\runner-profile.json `
+    -Repos https://github.com/ncosentino/needlr=1
+```
+
+This creates a separate `needlr-ci` manager and does not change the existing
+general-purpose profile or Foundry capacity.
+
+Confirm the specialized runner is online before changing repository routing:
+
+```powershell
+gh api repos/ncosentino/needlr/actions/runners `
+    --jq '.runners[] | select(.labels[].name == "needlr-ci")'
+```
+
+Then route trusted Linux jobs:
+
+```powershell
+gh variable set CI_RUNNER `
+    --repo ncosentino/needlr `
+    --body needlr-ci
+```
+
+Run a full CI workflow and confirm `preflight`, build/test, package validation, both AOT
+jobs, and documentation use a runner carrying the `needlr-ci` label. The conditional
+setup action must report that SDK `10.0.302` is already installed.
+
+Only after the specialized route is proven should the old default profile stop providing
+Needlr capacity. Replay that profile with its existing non-Needlr repositories and
+counts; do not change Foundry capacity.
 
 Repository workflows never choose an OCI image or mutate PitCrew. Image activation is an
 operator-approved host operation.

--- a/scripts/test-runner-image.ps1
+++ b/scripts/test-runner-image.ps1
@@ -90,7 +90,7 @@ $allWorkflowText = @(
 $setupDotnetCount = (
     [regex]::Matches(
         $allWorkflowText,
-        'uses:\s*actions/setup-dotnet@')).Count
+        'uses:\s*(?:actions/setup-dotnet@|\./\.github/actions/setup-dotnet)')).Count
 $globalJsonCount = (
     [regex]::Matches(
         $allWorkflowText,
@@ -100,6 +100,6 @@ Assert-Condition `
     -Message 'Workflows must not bypass the exact SDK pin with dotnet-version.'
 Assert-Condition `
     -Condition ($setupDotnetCount -eq $globalJsonCount) `
-    -Message 'Every actions/setup-dotnet step must use an exact global.json contract.'
+    -Message 'Every .NET setup step must use an exact global.json contract.'
 
 Write-Host 'Runner image contract validation passed.' -ForegroundColor Green

--- a/scripts/test-runner-profile.ps1
+++ b/scripts/test-runner-profile.ps1
@@ -1,0 +1,113 @@
+<#
+.SYNOPSIS
+    Validates Needlr's digest-pinned PitCrew profile and portable SDK setup.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$profilePath = Join-Path $repoRoot '.pitcrew\runner-profile.json'
+$actionPath = Join-Path $repoRoot '.github\actions\setup-dotnet\action.yml'
+$deliveryPath = Join-Path $repoRoot '.github\genesis-delivery.json'
+$expectedImage = 'ghcr.io/ncosentino/needlr-runner@sha256:233a06905fc35312fe73099d12e93bf496ac1b98dd19a0482be000c12d7b4461'
+
+function Assert-Condition {
+    param(
+        [Parameter(Mandatory)]
+        [bool]$Condition,
+
+        [Parameter(Mandatory)]
+        [string]$Message)
+
+    if (-not $Condition) {
+        throw $Message
+    }
+}
+
+$profile = Get-Content -LiteralPath $profilePath -Raw | ConvertFrom-Json
+Assert-Condition `
+    -Condition ([string]$profile.'$schema' -ceq 'https://raw.githubusercontent.com/ncosentino/pitcrew/87162e6fad6a961b9bc2f026639f2fa7df0795ba/runner-profile.schema.json') `
+    -Message 'The PitCrew profile schema must be pinned to the reviewed upstream contract.'
+Assert-Condition `
+    -Condition ([string]$profile.name -ceq 'needlr-ci') `
+    -Message "The PitCrew profile name must be 'needlr-ci'."
+Assert-Condition `
+    -Condition ([string]$profile.image -ceq $expectedImage) `
+    -Message 'The PitCrew profile must pin the approved immutable GHCR digest.'
+Assert-Condition `
+    -Condition ([int]$profile.replicas -eq 1) `
+    -Message 'The committed profile must preserve Needlr capacity at one worker.'
+Assert-Condition `
+    -Condition ([bool]$profile.pullImage) `
+    -Message 'The external profile must pull the approved GHCR image.'
+Assert-Condition `
+    -Condition ([bool]$profile.disableDefaultLabels) `
+    -Message 'The specialized profile must disable GitHub default labels.'
+Assert-Condition `
+    -Condition (@($profile.labels) -contains 'needlr') `
+    -Message "The specialized profile must advertise the 'needlr' capability."
+Assert-Condition `
+    -Condition (@($profile.labels) -notcontains 'self-hosted') `
+    -Message 'The specialized profile must not expose the broad self-hosted label.'
+
+$verification = @($profile.verificationCommands) -join "`n"
+Assert-Condition `
+    -Condition ($verification -match '/actions-runner/bin/Runner\.Listener') `
+    -Message 'The profile must verify Runner.Listener.'
+Assert-Condition `
+    -Condition ($verification -match '10\.0\.302') `
+    -Message 'The profile must verify the exact Needlr SDK.'
+Assert-Condition `
+    -Condition ($verification -match 'clang --version') `
+    -Message 'The profile must verify the Native AOT compiler.'
+
+$action = Get-Content -LiteralPath $actionPath -Raw
+Assert-Condition `
+    -Condition ($action -match 'dotnet --list-sdks') `
+    -Message 'The setup action must inspect installed SDKs.'
+Assert-Condition `
+    -Condition ($action -match "setup-required == 'true'") `
+    -Message 'The setup action must install only when the exact SDK is absent.'
+Assert-Condition `
+    -Condition ($action -match 'uses: actions/setup-dotnet@v4') `
+    -Message 'Hosted fallback must retain actions/setup-dotnet.'
+Assert-Condition `
+    -Condition ($action -match 'DOTNET_INSTALL_DIR') `
+    -Message 'Fallback installation must use a writable directory.'
+
+$workflowText = @(
+    Get-ChildItem -LiteralPath (Join-Path $repoRoot '.github\workflows') -Filter '*.yml' |
+        ForEach-Object { Get-Content -LiteralPath $_.FullName -Raw }) -join "`n"
+$localSetupCount = (
+    [regex]::Matches(
+        $workflowText,
+        'uses:\s*\./\.github/actions/setup-dotnet')).Count
+$globalJsonCount = (
+    [regex]::Matches(
+        $workflowText,
+        'global-json-file:\s*(?:[A-Za-z0-9._/-]+/)?global\.json')).Count
+Assert-Condition `
+    -Condition ($workflowText -notmatch 'uses:\s*actions/setup-dotnet@') `
+    -Message 'Workflows must use the conditional local setup action.'
+Assert-Condition `
+    -Condition ($localSetupCount -eq $globalJsonCount -and $localSetupCount -gt 0) `
+    -Message 'Every local setup action usage must select an exact global.json.'
+Assert-Condition `
+    -Condition ($workflowText -notmatch 'DOTNET_INSTALL_DIR=\$RUNNER_TEMP') `
+    -Message 'Workflows must not overwrite the preinstalled profile SDK path.'
+Assert-Condition `
+    -Condition ($workflowText -match 'head\.repo\.full_name != github\.repository') `
+    -Message 'External fork routing must remain ahead of CI_RUNNER.'
+
+$delivery = Get-Content -LiteralPath $deliveryPath -Raw | ConvertFrom-Json
+$runnerProfile = @($delivery.runnerProfiles) |
+    Where-Object { $_.id -eq 'needlr-ci' } |
+    Select-Object -First 1
+Assert-Condition `
+    -Condition ($null -ne $runnerProfile) `
+    -Message 'The Genesis delivery contract must declare the needlr-ci profile.'
+Assert-Condition `
+    -Condition ((@($runnerProfile.labels) -join ',') -ceq 'needlr-ci') `
+    -Message 'The Genesis delivery contract must use the profile routing label.'
+
+Write-Host 'Runner profile contract validation passed.' -ForegroundColor Green


### PR DESCRIPTION
## Summary

- pin the public initial image digest in `.pitcrew/runner-profile.json` as the isolated `needlr-ci` profile at Needlr's existing capacity of one worker
- verify `Runner.Listener`, .NET SDK `10.0.302`, clang, and PowerShell before PitCrew activates the candidate
- add a conditional composite .NET setup action that skips downloads when the exact SDK is present and otherwise installs through `actions/setup-dotnet` into a writable temporary directory
- move every CI, release, benchmark, MAUI, and IDE-extension .NET setup call through that portable action while preserving root SDK 10.0.302 and IDE SDK 9.0.316
- preserve all existing `CI_RUNNER` and external-fork routing; this PR does not change repository variables or any PitCrew host
- add profile/routing contract tests and exact Zephyr activation, validation, convergence, fallback, and rollback guidance

## Pinned image

```text
ghcr.io/ncosentino/needlr-runner@sha256:233a06905fc35312fe73099d12e93bf496ac1b98dd19a0482be000c12d7b4461
```

Anonymous manifest retrieval returns HTTP 200 for this digest.

## Validation

- runner image contract: passed
- runner profile/routing contract: passed
- CI scope, release artifact, and tag-only release tests: passed
- profile JSON validates against the pinned PitCrew schema from commit `87162e6f`
- Genesis delivery contract validates against its schema
- all workflow and composite-action YAML parses successfully
- strict MkDocs build: passed
- code review: no high-confidence findings

No source code changed in this PR. PR #120 already validated SDK 10.0.302 with a Release build (0 errors, 3 existing warnings), 2,807 tests (0 failed/skipped), package/example validation, MAUI, both VSIX builds, and a hosted Docker build/run.

## Operator rollout after merge

This PR intentionally does not mutate PitCrew or `CI_RUNNER`. After merge, run the documented Zephyr command from that host's PitCrew checkout with Needlr capacity `1`, verify the `needlr-ci` runner, set `CI_RUNNER=needlr-ci`, run representative CI/AOT/docs/release-dry-run validation, and only then remove Needlr capacity from the old general-purpose profile while preserving Foundry.

Closes #119 after the documented operator rollout is completed.
