### PR TITLE
fix: generate valid factory dependency identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Fixed
+
+- **`NexusLabs.Needlr.Generators` — `[GenerateFactory]` no longer emits invalid identifiers for generic constructor parameter types.** The generated backing field, constructor parameter, and construction argument for an injectable dependency are now derived from the original constructor parameter name (escaped when it is a C# keyword) instead of the dependency's simple type name, so a generic injected dependency such as `ILogger<T>` no longer produces a dangling `>` in the generated identifier. This also prevents two distinct injectable dependencies whose type arguments coincidentally share a simple name (e.g. `ILogger<Report>` and `IOptions<Report>`) from colliding on the same generated field name.
+
 ### Changed
 
 - Release publication is now staged. `release.yml` verifies the same-commit `main` CI run, prepares a release candidate once, and hands digest-verified artifacts to separate NuGet.org, GitHub Packages, documentation, and GitHub Release jobs. Publication jobs never restore, build, or test, so retrying a failed destination replays only that destination instead of repeating validation that already passed for the exact commit. Every packaged file is bound to its source commit and validating CI run by `release-manifest.json`, and each publication job re-verifies that manifest before its irreversible step. See ADR-0009 and `docs/releasing.md`.

--- a/src/NexusLabs.Needlr.Generators.Tests/FactoryGeneratorTests.cs
+++ b/src/NexusLabs.Needlr.Generators.Tests/FactoryGeneratorTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.Extensions.DependencyInjection;
 
 using Xunit;
 
@@ -267,10 +268,8 @@ namespace TestApp
 
         var generatedCode = RunGenerator(source);
 
-        // Should generate implementation class
         Assert.Contains("internal sealed class MyServiceFactory : IMyServiceFactory", generatedCode);
-        // Implementation should have injectable deps as constructor params (uses type-derived name)
-        Assert.Contains("public MyServiceFactory(global::TestApp.IDependency dependency)", generatedCode);
+        Assert.Contains("public MyServiceFactory(global::TestApp.IDependency dep)", generatedCode);
     }
 
     [Fact]
@@ -596,6 +595,198 @@ namespace TestApp
         // Should preserve XML escaping
         Assert.Contains(@"<param name=""filter"">Filter expression using &lt;T&gt; syntax.</param>", generatedCode);
     }
+
+    /// <summary>
+    /// Verifies generic injectable types use the constructor parameter name for generated identifiers.
+    /// </summary>
+    [Fact]
+    public void Generator_WithGenericInjectableDependency_GeneratesValidIdentifiers()
+    {
+        var source = @"
+using NexusLabs.Needlr;
+using NexusLabs.Needlr.Generators;
+
+[assembly: GenerateTypeRegistry]
+
+namespace TestApp
+{
+    public interface IReportLogger<T> { }
+
+    [GenerateFactory]
+    public sealed class Report
+    {
+        public Report(IReportLogger<Report> logger, string title) { }
+    }
+}";
+
+        var runner = GeneratorTestRunner.ForFactory().WithReference<IServiceCollection>().WithSource(source);
+        var generatedCode = runner.RunTypeRegistryGenerator();
+
+        Assert.Contains(
+            "private readonly global::TestApp.IReportLogger<global::TestApp.Report> _logger;",
+            generatedCode);
+        Assert.Contains(
+            "public ReportFactory(global::TestApp.IReportLogger<global::TestApp.Report> logger)",
+            generatedCode);
+        Assert.Contains("logger: _logger", generatedCode);
+        AssertGeneratedFactoriesCompile(runner);
+    }
+
+    /// <summary>
+    /// Verifies repeated injectable types share one field while retaining both constructor argument names.
+    /// </summary>
+    [Fact]
+    public void Generator_WithTwoSameTypedConstructorParameters_GeneratesValidNonCollidingCode()
+    {
+        var source = @"
+using NexusLabs.Needlr;
+using NexusLabs.Needlr.Generators;
+
+[assembly: GenerateTypeRegistry]
+
+namespace TestApp
+{
+    public interface IDependency { }
+
+    [GenerateFactory]
+    public class MyService
+    {
+        public MyService(IDependency primary, IDependency secondary, string title) { }
+    }
+}";
+
+        var runner = GeneratorTestRunner.ForFactory().WithReference<IServiceCollection>().WithSource(source);
+        var generatedCode = runner.RunTypeRegistryGenerator();
+
+        Assert.Contains(
+            "public MyServiceFactory(global::TestApp.IDependency primary)",
+            generatedCode);
+        Assert.Contains(
+            "primary: _primary, secondary: _primary, title: title",
+            generatedCode);
+        Assert.DoesNotContain("_secondary", generatedCode);
+        AssertGeneratedFactoriesCompile(runner);
+    }
+
+    /// <summary>
+    /// Verifies different generic dependencies with the same type argument receive distinct fields.
+    /// </summary>
+    [Fact]
+    public void Generator_WithDistinctGenericDependenciesSharingTypeArgument_GeneratesDistinctFields()
+    {
+        var source = @"
+using NexusLabs.Needlr;
+using NexusLabs.Needlr.Generators;
+
+[assembly: GenerateTypeRegistry]
+
+namespace TestApp
+{
+    public interface IReportLogger<T> { }
+
+    public interface IReportOptions<T> { }
+
+    [GenerateFactory]
+    public sealed class Report
+    {
+        public Report(IReportLogger<Report> logger, IReportOptions<Report> options, string title) { }
+    }
+}";
+
+        var runner = GeneratorTestRunner.ForFactory().WithReference<IServiceCollection>().WithSource(source);
+        var generatedCode = runner.RunTypeRegistryGenerator();
+
+        Assert.Contains(
+            "private readonly global::TestApp.IReportLogger<global::TestApp.Report> _logger;",
+            generatedCode);
+        Assert.Contains(
+            "private readonly global::TestApp.IReportOptions<global::TestApp.Report> _options;",
+            generatedCode);
+        Assert.Contains("logger: _logger, options: _options, title: title", generatedCode);
+        AssertGeneratedFactoriesCompile(runner);
+    }
+
+    /// <summary>
+    /// Verifies injectable names remain unique when constructor overloads reuse a parameter name.
+    /// </summary>
+    [Fact]
+    public void Generator_WithOverloadsReusingInjectableParameterName_GeneratesUniqueFields()
+    {
+        var source = @"
+using NexusLabs.Needlr;
+using NexusLabs.Needlr.Generators;
+
+[assembly: GenerateTypeRegistry]
+
+namespace TestApp
+{
+    public interface IPrimaryDependency { }
+    public interface ISecondaryDependency { }
+
+    [GenerateFactory]
+    public sealed class MyService
+    {
+        public MyService(IPrimaryDependency dependency, string name) { }
+        public MyService(ISecondaryDependency dependency, int id) { }
+    }
+}";
+
+        var runner = GeneratorTestRunner.ForFactory().WithReference<IServiceCollection>().WithSource(source);
+        var generatedCode = runner.RunTypeRegistryGenerator();
+
+        Assert.Contains(
+            "private readonly global::TestApp.IPrimaryDependency _dependency;",
+            generatedCode);
+        Assert.Contains(
+            "private readonly global::TestApp.ISecondaryDependency _dependency2;",
+            generatedCode);
+        Assert.Contains("dependency: _dependency, name: name", generatedCode);
+        Assert.Contains("dependency: _dependency2, id: id", generatedCode);
+        AssertGeneratedFactoriesCompile(runner);
+    }
+
+    /// <summary>
+    /// Verifies escaped constructor parameter names remain valid in generated code.
+    /// </summary>
+    [Fact]
+    public void Generator_WithKeywordNamedConstructorParameter_EscapesGeneratedIdentifier()
+    {
+        var source = @"
+using NexusLabs.Needlr;
+using NexusLabs.Needlr.Generators;
+
+[assembly: GenerateTypeRegistry]
+
+namespace TestApp
+{
+    public interface IDependency { }
+
+    [GenerateFactory]
+    public class MyService
+    {
+        public MyService(IDependency @class, string title) { }
+    }
+}";
+
+        var runner = GeneratorTestRunner.ForFactory().WithReference<IServiceCollection>().WithSource(source);
+        var generatedCode = runner.RunTypeRegistryGenerator();
+
+        Assert.Contains("private readonly global::TestApp.IDependency _class;", generatedCode);
+        Assert.Contains("public MyServiceFactory(global::TestApp.IDependency @class)", generatedCode);
+        Assert.Contains("@class: _class, title: title", generatedCode);
+        AssertGeneratedFactoriesCompile(runner);
+    }
+
+    private static void AssertGeneratedFactoriesCompile(GeneratorTestRunner runner)
+    {
+        var errors = runner
+            .RunGeneratorCompilationErrors(new TypeRegistryGenerator())
+            .Where(e => e.Location.SourceTree?.FilePath.EndsWith("Factories.g.cs") == true)
+            .ToList();
+
+        Assert.Empty(errors);
+    }
+
     private static string RunGenerator(string source)
     {
         return GeneratorTestRunner.ForFactory()

--- a/src/NexusLabs.Needlr.Generators/CodeGen/FactoryCodeGenerator.cs
+++ b/src/NexusLabs.Needlr.Generators/CodeGen/FactoryCodeGenerator.cs
@@ -15,6 +15,46 @@ namespace NexusLabs.Needlr.Generators.CodeGen;
 /// </summary>
 internal static class FactoryCodeGenerator
 {
+    private static string GetParameterBaseName(TypeDiscoveryHelper.ConstructorParameterInfo parameter)
+    {
+        if (!string.IsNullOrWhiteSpace(parameter.ParameterName))
+            return parameter.ParameterName!;
+
+        var typeName = GeneratorHelpers.GetShortTypeName(parameter.TypeName);
+        var genericStart = typeName.IndexOf('<');
+        if (genericStart >= 0)
+            typeName = typeName.Substring(0, genericStart);
+
+        return GeneratorHelpers.ToCamelCase(typeName);
+    }
+
+    private static string GetParameterIdentifierName(TypeDiscoveryHelper.ConstructorParameterInfo parameter)
+    {
+        return GeneratorHelpers.EscapeIdentifier(GetParameterBaseName(parameter));
+    }
+
+    private static Dictionary<string, string> GetInjectableNamesByType(
+        IEnumerable<TypeDiscoveryHelper.ConstructorParameterInfo> parameters)
+    {
+        var namesByType = new Dictionary<string, string>(StringComparer.Ordinal);
+        var usedNames = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var parameter in parameters)
+        {
+            if (namesByType.ContainsKey(parameter.TypeName))
+                continue;
+
+            var baseName = GetParameterBaseName(parameter);
+            var uniqueName = baseName;
+            for (var suffix = 2; !usedNames.Add(uniqueName); suffix++)
+                uniqueName = baseName + suffix;
+
+            namesByType.Add(parameter.TypeName, uniqueName);
+        }
+
+        return namesByType;
+    }
+
     internal static void GenerateFactoryInterface(StringBuilder builder, DiscoveredFactory factory, BreadcrumbWriter breadcrumbs, string? projectDirectory)
     {
         var factoryName = $"I{factory.SimpleTypeName}Factory";
@@ -29,11 +69,8 @@ internal static class FactoryCodeGenerator
         // Generate Create method for each constructor
         foreach (var ctor in factory.Constructors)
         {
-            var runtimeParamList = string.Join(", ", ctor.RuntimeParameters.Select(p => 
-            {
-                var simpleTypeName = GeneratorHelpers.GetSimpleTypeName(p.TypeName);
-                return $"{p.TypeName} {p.ParameterName ?? GeneratorHelpers.ToCamelCase(simpleTypeName)}";
-            }));
+            var runtimeParamList = string.Join(", ", ctor.RuntimeParameters.Select(p =>
+                $"{p.TypeName} {GetParameterIdentifierName(p)}"));
 
             builder.AppendLine($"    /// <summary>Creates a new instance of {factory.SimpleTypeName}.</summary>");
             
@@ -42,7 +79,7 @@ internal static class FactoryCodeGenerator
             {
                 if (!string.IsNullOrWhiteSpace(param.DocumentationComment))
                 {
-                    var paramName = param.ParameterName ?? GeneratorHelpers.ToCamelCase(GeneratorHelpers.GetSimpleTypeName(param.TypeName));
+                    var paramName = GetParameterBaseName(param);
                     var escapedDoc = GeneratorHelpers.EscapeXmlContent(param.DocumentationComment!);
                     builder.AppendLine($"    /// <param name=\"{paramName}\">{escapedDoc}</param>");
                 }
@@ -59,12 +96,12 @@ internal static class FactoryCodeGenerator
         var factoryInterfaceName = $"I{factory.SimpleTypeName}Factory";
         var factoryImplName = $"{factory.SimpleTypeName}Factory";
 
-        // Collect all unique injectable parameters across all constructors
         var allInjectableParams = factory.Constructors
             .SelectMany(c => c.InjectableParameters)
             .GroupBy(p => p.TypeName)
             .Select(g => g.First())
             .ToList();
+        var injectableNamesByType = GetInjectableNamesByType(allInjectableParams);
 
         builder.AppendLine("/// <summary>");
         builder.AppendLine($"/// Factory implementation for creating instances of <see cref=\"{factory.TypeName}\"/>.");
@@ -76,20 +113,24 @@ internal static class FactoryCodeGenerator
         // Fields for injectable dependencies
         foreach (var param in allInjectableParams)
         {
-            var fieldName = "_" + GeneratorHelpers.ToCamelCase(GeneratorHelpers.GetSimpleTypeName(param.TypeName));
+            var fieldName = "_" + injectableNamesByType[param.TypeName];
             builder.AppendLine($"    private readonly {param.TypeName} {fieldName};");
         }
 
         builder.AppendLine();
 
         // Constructor
-        var ctorParams = string.Join(", ", allInjectableParams.Select(p => $"{p.TypeName} {GeneratorHelpers.ToCamelCase(GeneratorHelpers.GetSimpleTypeName(p.TypeName))}"));
+        var ctorParams = string.Join(
+            ", ",
+            allInjectableParams.Select(p =>
+                $"{p.TypeName} {GeneratorHelpers.EscapeIdentifier(injectableNamesByType[p.TypeName])}"));
         builder.AppendLine($"    public {factoryImplName}({ctorParams})");
         builder.AppendLine("    {");
         foreach (var param in allInjectableParams)
         {
-            var fieldName = "_" + GeneratorHelpers.ToCamelCase(GeneratorHelpers.GetSimpleTypeName(param.TypeName));
-            var paramName = GeneratorHelpers.ToCamelCase(GeneratorHelpers.GetSimpleTypeName(param.TypeName));
+            var parameterName = injectableNamesByType[param.TypeName];
+            var fieldName = "_" + parameterName;
+            var paramName = GeneratorHelpers.EscapeIdentifier(parameterName);
             builder.AppendLine($"        {fieldName} = {paramName};");
         }
         builder.AppendLine("    }");
@@ -98,11 +139,8 @@ internal static class FactoryCodeGenerator
         // Create methods for each constructor
         foreach (var ctor in factory.Constructors)
         {
-            var runtimeParamList = string.Join(", ", ctor.RuntimeParameters.Select(p => 
-            {
-                var paramName = p.ParameterName ?? GeneratorHelpers.ToCamelCase(GeneratorHelpers.GetSimpleTypeName(p.TypeName));
-                return $"{p.TypeName} {paramName}";
-            }));
+            var runtimeParamList = string.Join(", ", ctor.RuntimeParameters.Select(p =>
+                $"{p.TypeName} {GetParameterIdentifierName(p)}"));
 
             builder.AppendLine($"    public {factory.ReturnTypeName} Create({runtimeParamList})");
             builder.AppendLine("    {");
@@ -116,13 +154,13 @@ internal static class FactoryCodeGenerator
             var allArgs = new List<string>();
             foreach (var inj in ctor.InjectableParameters)
             {
-                var fieldName = "_" + GeneratorHelpers.ToCamelCase(GeneratorHelpers.GetSimpleTypeName(inj.TypeName));
-                var argName = inj.ParameterName ?? GeneratorHelpers.ToCamelCase(GeneratorHelpers.GetSimpleTypeName(inj.TypeName));
+                var fieldName = "_" + injectableNamesByType[inj.TypeName];
+                var argName = GetParameterIdentifierName(inj);
                 allArgs.Add($"{argName}: {fieldName}");
             }
             foreach (var rt in ctor.RuntimeParameters)
             {
-                var paramName = rt.ParameterName ?? GeneratorHelpers.ToCamelCase(GeneratorHelpers.GetSimpleTypeName(rt.TypeName));
+                var paramName = GetParameterIdentifierName(rt);
                 allArgs.Add($"{paramName}: {paramName}");
             }
 
@@ -141,8 +179,7 @@ internal static class FactoryCodeGenerator
         var funcType = $"Func<{runtimeTypes}, {factory.ReturnTypeName}>";
 
         // Build the lambda
-        var runtimeParams = string.Join(", ", ctor.RuntimeParameters.Select(p => 
-            p.ParameterName ?? GeneratorHelpers.ToCamelCase(GeneratorHelpers.GetSimpleTypeName(p.TypeName))));
+        var runtimeParams = string.Join(", ", ctor.RuntimeParameters.Select(GetParameterIdentifierName));
 
         builder.AppendLine($"{indent}services.AddSingleton<{funcType}>(sp =>");
         builder.AppendLine($"{indent}    ({runtimeParams}) => new {factory.TypeName}(");
@@ -153,7 +190,7 @@ internal static class FactoryCodeGenerator
         var allArgs = new List<string>();
         foreach (var inj in ctor.InjectableParameters)
         {
-            var argName = inj.ParameterName ?? GeneratorHelpers.ToCamelCase(GeneratorHelpers.GetSimpleTypeName(inj.TypeName));
+            var argName = GetParameterIdentifierName(inj);
             if (inj.IsKeyed)
             {
                 allArgs.Add($"{argName}: sp.GetRequiredKeyedService<{inj.TypeName}>(\"{GeneratorHelpers.EscapeStringLiteral(inj.ServiceKey!)}\")");
@@ -165,7 +202,7 @@ internal static class FactoryCodeGenerator
         }
         foreach (var rt in ctor.RuntimeParameters)
         {
-            var paramName = rt.ParameterName ?? GeneratorHelpers.ToCamelCase(GeneratorHelpers.GetSimpleTypeName(rt.TypeName));
+            var paramName = GetParameterIdentifierName(rt);
             allArgs.Add($"{paramName}: {paramName}");
         }
 
@@ -256,4 +293,3 @@ internal static class FactoryCodeGenerator
         return builder.ToString();
     }
 }
-


### PR DESCRIPTION
## Summary

- derive generated factory dependency identifiers from the original constructor
  parameter names instead of dependency type names
- assign deterministic numeric suffixes when different injectable types reuse a
  parameter name across constructor overloads
- preserve the existing one-field-per-exact-service-type behavior while using
  each target constructor's real parameter name for named arguments
- escape keyword parameter names and add compile-time regression coverage

## Report verification

- Reproduced the reported generic dependency failure: a type-derived name for
  `ILogger<Report>` retained the closing `>` and produced invalid generated C#.
- Refuted the literal secondary assumption: two parameters of the exact same
  injectable type did not create duplicate fields because the generator already
  deduplicates exact service types. The generated constructor call intentionally
  passes the shared injected instance to both named arguments.
- Confirmed a related collision: different generic dependency types sharing the
  same type argument could derive the same malformed identifier.
- Confirmed the existing factory generator tests covered only non-generic
  injectable dependencies.

## Design

Parsing only the outer generic type would be the smallest change, but it would
retain collisions between dependencies with the same simple type name. Using
constructor parameter names handles generic and namespace collisions naturally.
A per-factory name map adds stable suffixes for the remaining cross-overload case,
where parameter names are individually valid but not unique across constructors.

## Validation

- .NET SDK `10.0.302` solution build: 0 errors, 3 pre-existing generated-example
  CS0162 warnings
- generator tests: 1,070 passed, 0 failed, 0 skipped
- factory integration tests: 44 passed, 0 failed, 0 skipped
- focused factory generator tests: 26 passed, 0 failed, 0 skipped
- independent code review: no high-confidence findings

## Readiness assessment

- Omitted behavior: none
- Implementation gaps: none
- Technical debt introduced: none
- Missing coverage: none identified; the failure is generated-code compilation,
  directly covered through Roslyn compilation, while the existing runtime
  factory integration suite verifies DI and factory behavior
- Weak assertions: none identified; regressions assert exact emitted identifiers
  and zero generated-file compilation errors
- Remaining assumptions: none; both assumptions in the report were checked
  against current source and generated output

Closes #122
