### PR TITLE
chore: prepare v0.0.3-alpha.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,16 @@
 ## [Unreleased]
 
-### Fixed
-
-- **`NexusLabs.Needlr.Generators` — `[GenerateFactory]` no longer emits invalid identifiers for generic constructor parameter types.** The generated backing field, constructor parameter, and construction argument for an injectable dependency are now derived from the original constructor parameter name (escaped when it is a C# keyword) instead of the dependency's simple type name, so a generic injected dependency such as `ILogger<T>` no longer produces a dangling `>` in the generated identifier. This also prevents two distinct injectable dependencies whose type arguments coincidentally share a simple name (e.g. `ILogger<Report>` and `IOptions<Report>`) from colliding on the same generated field name.
+## [0.0.3-alpha.4] - 2026-07-30
 
 ### Changed
 
 - Release publication is now staged. `release.yml` verifies the same-commit `main` CI run, prepares a release candidate once, and hands digest-verified artifacts to separate NuGet.org, GitHub Packages, documentation, and GitHub Release jobs. Publication jobs never restore, build, or test, so retrying a failed destination replays only that destination instead of repeating validation that already passed for the exact commit. Every packaged file is bound to its source commit and validating CI run by `release-manifest.json`, and each publication job re-verifies that manifest before its irreversible step. See ADR-0009 and `docs/releasing.md`.
 - Needlr now pins .NET SDK `10.0.302` and validates a digest-pinned, repository-owned Linux runner image on pull requests. Trusted `main` publishes commit-tagged images to `ghcr.io/ncosentino/needlr-runner` and records the immutable manifest digest for a separately reviewed PitCrew profile rollout. Existing hosted and general-purpose runner routes remain unchanged until that profile is activated.
 - The published runner image is pinned in a `needlr-ci` PitCrew profile, and every workflow now uses a conditional local setup action that skips SDK download when the exact version is already installed while preserving writable hosted/general-purpose fallback installation. Repository routing remains unchanged until the operator applies the profile and sets `CI_RUNNER=needlr-ci`.
+
+### Fixed
+
+- **`NexusLabs.Needlr.Generators` — `[GenerateFactory]` no longer emits invalid identifiers for generic constructor parameter types.** The generated backing field, constructor parameter, and construction argument for an injectable dependency are now derived from the original constructor parameter name (escaped when it is a C# keyword) instead of the dependency's simple type name, so a generic injected dependency such as `ILogger<T>` no longer produces a dangling `>` in the generated identifier. This also prevents two distinct injectable dependencies whose type arguments coincidentally share a simple name (e.g. `ILogger<Report>` and `IOptions<Report>`) from colliding on the same generated field name.
 
 ## [0.0.3-alpha.3] - 2026-07-28
 

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.0.3-alpha.3",
+  "version": "0.0.3-alpha.4",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release/v\\d+\\.\\d+",


### PR DESCRIPTION
## Summary

- advance Needlr from `0.0.3-alpha.3` to `0.0.3-alpha.4`
- publish the staged/restartable release workflow and repository-owned runner
  delivery changes merged since alpha.3
- publish the `[GenerateFactory]` generic dependency identifier fix from #123
- move the reviewed Unreleased notes into the dated alpha.4 section

## Release contents

### Changed

- release publication now prepares one digest-bound candidate and isolates
  NuGet.org, GitHub Packages, documentation, and GitHub Release publication
- trusted CI now uses the digest-pinned `needlr-ci` runner profile with portable
  exact-SDK fallback
- Needlr owns and publishes its immutable Linux CI runner image

### Fixed

- `[GenerateFactory]` now emits valid, collision-safe identifiers for generic
  injectable constructor parameters

## Validation

- release finalization contract: passed
- strict MkDocs build: passed
- .NET SDK `10.0.302` solution build: 0 errors, 2 existing generated-example
  CS0162 warnings
- package validation: passed
  - NuGet package contract assertions passed
  - 40 example projects built
  - four example test projects passed
- no unshipped analyzer rule rows remain
- `v0.0.3-alpha.4` is unused locally and on `origin`

## Readiness assessment

- Omitted behavior: none
- Implementation gaps: none
- Technical debt introduced: none
- Missing coverage: none identified
- Weak assertions: none identified
- Assumptions: the release date uses the maintainer host date, `2026-07-30`

After squash merge, the tag-only finalizer will run from synchronized `main`
after successful same-commit CI.
