### PR TITLE
fix(sourcegen): retain empty registry assemblies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Fixed
+
+- Source-generated plugin assembly options now include every generated `TypeRegistry` participant, including contract or abstractions assemblies whose registries contain no injectable types or plugins. Generated module initializers carry their registry identity through `NeedlrSourceGenBootstrap`, and `GeneratedAssemblyProvider` appends marker-only assemblies without synthetic registrations, `AppDomain` scanning, duplicates, or changes to existing metadata-derived ordering.
+
 ## [0.0.3-alpha.4] - 2026-07-30
 
 ### Changed

--- a/docs/solution-wide-source-generation.md
+++ b/docs/solution-wide-source-generation.md
@@ -81,18 +81,19 @@ ship the same target as defense-in-depth.
 
 ## Multi-Assembly TypeRegistry Composition
 
-When multiple projects in your solution each have `[assembly: GenerateTypeRegistry]`, Needlr generates a `TypeRegistry` in each of them. At runtime, each assembly's `[ModuleInitializer]` calls `NeedlrSourceGenBootstrap.Register()`, which accumulates all registered providers.
+When multiple projects in your solution each have `[assembly: GenerateTypeRegistry]`, Needlr generates a `TypeRegistry` in each of them. At runtime, each assembly's `[ModuleInitializer]` calls `NeedlrSourceGenBootstrap.Register()`, which accumulates the registry identity together with its generated providers.
 
-When you call `new Syringe().UsingSourceGen()`, it calls `TryGetProviders()`, which combines and deduplicates all registered providers from all loaded assemblies. This means:
+When you call `new Syringe().UsingSourceGen()`, it calls `TryGetProviders()`, which combines and deduplicates all registered providers and registry participants from all loaded assemblies. This means:
 
 - An entry-point project referencing a Bootstrap project (which references feature projects) gets all types from all of them
 - Test projects that reference any of those get full service resolution without needing their own TypeRegistry
+- Plugin assembly options include every generated registry participant, even when a participant contributes no injectable or plugin metadata, when runtime assembly metadata is available
 
 ### Participants With No Registerable Types
 
 A project can carry `[assembly: GenerateTypeRegistry]` (for example because `NeedlrAutoGenerate=true` is set solution-wide) yet contain nothing to register — a domain, contracts, or abstractions library made up only of `record`, `enum`, and `interface` types is the common case.
 
-Such a project still emits a **minimal** `TypeRegistry` (empty `GetInjectableTypes()` / `GetPluginTypes()` providers and a module initializer). This matters because any project that references it force-loads `typeof(<Assembly>.Generated.TypeRegistry)` to run that module initializer; if the registry were omitted, the referencing project would fail to compile with `CS0234`. Emitting the minimal registry keeps the producer and consumer in agreement, so adding a type-less participant never breaks an aggregator build.
+Such a project still emits a **minimal** `TypeRegistry` (empty `GetInjectableTypes()` / `GetPluginTypes()` providers and a module initializer). This matters because any project that references it force-loads `typeof(<Assembly>.Generated.TypeRegistry)` to run that module initializer; if the registry were omitted, the referencing project would fail to compile with `CS0234`. The generated registry type also preserves the participant's assembly identity, so `ServiceCollectionPluginOptions.Assemblies` includes it without a synthetic service, a synthetic plugin, or runtime assembly scanning.
 
 The minimal registry depends only on the attributes package (`NexusLabs.Needlr.Generators.Attributes`) — never on the injection packages. A project must already reference the attributes package to use `[GenerateTypeRegistry]`, so the registry always compiles, **even for a project that references no Needlr injection packages** (a pure contracts or documentation library). It does not register a `ServiceCatalog` or apply decorators, because there is nothing to register.
 

--- a/src/Examples/MultiProjectApp/MultiProjectApp.Integration.Tests/AssemblyOptionsCapturePlugin.cs
+++ b/src/Examples/MultiProjectApp/MultiProjectApp.Integration.Tests/AssemblyOptionsCapturePlugin.cs
@@ -1,0 +1,19 @@
+using System.Reflection;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using NexusLabs.Needlr;
+
+namespace MultiProjectApp.Integration.Tests;
+
+/// <summary>
+/// Captures the candidate assemblies supplied to service collection plugins for integration tests.
+/// </summary>
+internal sealed class AssemblyOptionsCapturePlugin : IServiceCollectionPlugin
+{
+    /// <inheritdoc />
+    public void Configure(ServiceCollectionPluginOptions options)
+    {
+        options.Services.AddSingleton<IReadOnlyList<Assembly>>(options.Assemblies);
+    }
+}

--- a/src/Examples/MultiProjectApp/MultiProjectApp.Integration.Tests/SourceGenIntegrationTests.cs
+++ b/src/Examples/MultiProjectApp/MultiProjectApp.Integration.Tests/SourceGenIntegrationTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using MultiProjectApp.Contracts;
 using MultiProjectApp.Features.Notifications;
 using MultiProjectApp.Features.Reporting;
 using NexusLabs.Needlr.Injection;
@@ -54,5 +55,21 @@ public sealed class SourceGenIntegrationTests
         Assert.Single(capture.Sent);
         Assert.Equal("alice@example.com", capture.Sent[0].Recipient);
         Assert.Equal("Hello from test", capture.Sent[0].Message);
+    }
+
+    [Fact]
+    public void PluginAssemblyOptions_IncludeEmptyAndNonEmptyRegistryParticipantsExactlyOnce()
+    {
+        var provider = new Syringe()
+            .UsingSourceGen()
+            .BuildServiceProvider();
+
+        var assemblies = provider.GetRequiredService<IReadOnlyList<System.Reflection.Assembly>>();
+        var contractAssembly = typeof(ReportRequest).Assembly;
+        var reportingAssembly = typeof(IReportService).Assembly;
+
+        Assert.Equal(1, assemblies.Count(assembly => assembly == contractAssembly));
+        Assert.Equal(1, assemblies.Count(assembly => assembly == reportingAssembly));
+        Assert.Equal(assemblies.Count, assemblies.Distinct().Count());
     }
 }

--- a/src/NexusLabs.Needlr.AspNet/WebApplicationBuilderPluginOptions.cs
+++ b/src/NexusLabs.Needlr.AspNet/WebApplicationBuilderPluginOptions.cs
@@ -10,7 +10,10 @@ namespace NexusLabs.Needlr.AspNet;
 /// Contains the web application builder, discovered assemblies, logger, and plugin factory.
 /// </summary>
 /// <param name="Builder">The web application builder being configured.</param>
-/// <param name="Assemblies">The list of assemblies discovered by Needlr.</param>
+/// <param name="Assemblies">
+/// The candidate assemblies selected by Needlr. Source-generated discovery includes every
+/// generated TypeRegistry participant, including empty registries, when assembly metadata is available.
+/// </param>
 /// <param name="Logger">Logger for diagnostic output during plugin execution.</param>
 /// <param name="PluginFactory">Factory for creating additional plugin instances.</param>
 public sealed record WebApplicationBuilderPluginOptions(

--- a/src/NexusLabs.Needlr.AspNet/WebApplicationPluginOptions.cs
+++ b/src/NexusLabs.Needlr.AspNet/WebApplicationPluginOptions.cs
@@ -9,7 +9,10 @@ namespace NexusLabs.Needlr.AspNet;
 /// Contains the built web application, discovered assemblies, and plugin factory.
 /// </summary>
 /// <param name="WebApplication">The built web application to configure.</param>
-/// <param name="Assemblies">The list of assemblies discovered by Needlr.</param>
+/// <param name="Assemblies">
+/// The candidate assemblies selected by Needlr. Source-generated discovery includes every
+/// generated TypeRegistry participant, including empty registries, when assembly metadata is available.
+/// </param>
 /// <param name="PluginFactory">Factory for creating additional plugin instances.</param>
 public sealed record WebApplicationPluginOptions(
     WebApplication WebApplication,

--- a/src/NexusLabs.Needlr.Generators.Attributes/NeedlrSourceGenBootstrap.cs
+++ b/src/NexusLabs.Needlr.Generators.Attributes/NeedlrSourceGenBootstrap.cs
@@ -10,7 +10,7 @@ namespace NexusLabs.Needlr.Generators;
 /// </summary>
 /// <remarks>
 /// The source generator emits a module initializer in the host assembly that calls
-/// one of the Register overloads with the generated TypeRegistry providers.
+/// one of the Register overloads with the generated TypeRegistry identity and providers.
 /// Needlr runtime can then discover generated registries without any runtime reflection.
 /// </remarks>
 public static class NeedlrSourceGenBootstrap
@@ -20,17 +20,22 @@ public static class NeedlrSourceGenBootstrap
         public Registration(
             Func<IReadOnlyList<InjectableTypeInfo>> injectableTypeProvider,
             Func<IReadOnlyList<PluginTypeInfo>> pluginTypeProvider,
+            IReadOnlyList<Type>? registryParticipantTypes = null,
             Action<object>? decoratorApplier = null,
             Action<object, object>? optionsRegistrar = null)
         {
             InjectableTypeProvider = injectableTypeProvider;
             PluginTypeProvider = pluginTypeProvider;
+            RegistryParticipantTypes = registryParticipantTypes is null
+                ? Array.Empty<Type>()
+                : registryParticipantTypes.ToArray();
             DecoratorApplier = decoratorApplier;
             OptionsRegistrar = optionsRegistrar;
         }
 
         public Func<IReadOnlyList<InjectableTypeInfo>> InjectableTypeProvider { get; }
         public Func<IReadOnlyList<PluginTypeInfo>> PluginTypeProvider { get; }
+        public IReadOnlyList<Type> RegistryParticipantTypes { get; }
         public Action<object>? DecoratorApplier { get; }
         public Action<object, object>? OptionsRegistrar { get; }
     }
@@ -131,12 +136,113 @@ public static class NeedlrSourceGenBootstrap
         Action<object>? decoratorApplier,
         Action<object, object>? optionsRegistrar)
     {
+        RegisterCore(
+            injectableTypeProvider,
+            pluginTypeProvider,
+            Array.Empty<Type>(),
+            decoratorApplier,
+            optionsRegistrar);
+    }
+
+    /// <summary>
+    /// Registers the generated registry identity and its type and plugin providers.
+    /// </summary>
+    /// <param name="registryParticipantType">
+    /// A generated type whose assembly identifies the registry participant.
+    /// </param>
+    /// <param name="injectableTypeProvider">Provider for injectable types.</param>
+    /// <param name="pluginTypeProvider">Provider for plugin types.</param>
+    /// <remarks>
+    /// The generated <c>TypeRegistry</c> type is carried separately from injectable and plugin
+    /// metadata so assemblies with empty registries remain visible to Needlr plugins.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// NeedlrSourceGenBootstrap.Register(
+    ///     typeof(MyApp.Generated.TypeRegistry),
+    ///     MyApp.Generated.TypeRegistry.GetInjectableTypes,
+    ///     MyApp.Generated.TypeRegistry.GetPluginTypes);
+    /// </code>
+    /// </example>
+    public static void Register(
+        Type registryParticipantType,
+        Func<IReadOnlyList<InjectableTypeInfo>> injectableTypeProvider,
+        Func<IReadOnlyList<PluginTypeInfo>> pluginTypeProvider)
+    {
+        Register(
+            registryParticipantType,
+            injectableTypeProvider,
+            pluginTypeProvider,
+            null,
+            null);
+    }
+
+    /// <summary>
+    /// Registers the generated registry identity and its type, plugin, decorator, and options providers.
+    /// </summary>
+    /// <param name="registryParticipantType">
+    /// A generated type whose assembly identifies the registry participant.
+    /// </param>
+    /// <param name="injectableTypeProvider">Provider for injectable types.</param>
+    /// <param name="pluginTypeProvider">Provider for plugin types.</param>
+    /// <param name="decoratorApplier">
+    /// Action that applies decorators to the service collection.
+    /// The parameter is an IServiceCollection, but typed as object to avoid dependency on Microsoft.Extensions.DependencyInjection in this assembly.
+    /// </param>
+    /// <param name="optionsRegistrar">
+    /// Action that registers options with the service collection and configuration.
+    /// Parameters are (IServiceCollection, IConfiguration), typed as object to avoid dependencies.
+    /// </param>
+    /// <remarks>
+    /// Generated module initializers use this overload so the runtime can retain assembly identity
+    /// even when both metadata providers return empty collections.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// NeedlrSourceGenBootstrap.Register(
+    ///     typeof(MyApp.Generated.TypeRegistry),
+    ///     MyApp.Generated.TypeRegistry.GetInjectableTypes,
+    ///     MyApp.Generated.TypeRegistry.GetPluginTypes,
+    ///     null,
+    ///     null);
+    /// </code>
+    /// </example>
+    public static void Register(
+        Type registryParticipantType,
+        Func<IReadOnlyList<InjectableTypeInfo>> injectableTypeProvider,
+        Func<IReadOnlyList<PluginTypeInfo>> pluginTypeProvider,
+        Action<object>? decoratorApplier,
+        Action<object, object>? optionsRegistrar)
+    {
+        if (registryParticipantType is null) throw new ArgumentNullException(nameof(registryParticipantType));
+
+        RegisterCore(
+            injectableTypeProvider,
+            pluginTypeProvider,
+            new[] { registryParticipantType },
+            decoratorApplier,
+            optionsRegistrar);
+    }
+
+    private static void RegisterCore(
+        Func<IReadOnlyList<InjectableTypeInfo>> injectableTypeProvider,
+        Func<IReadOnlyList<PluginTypeInfo>> pluginTypeProvider,
+        IReadOnlyList<Type> registryParticipantTypes,
+        Action<object>? decoratorApplier,
+        Action<object, object>? optionsRegistrar)
+    {
         if (injectableTypeProvider is null) throw new ArgumentNullException(nameof(injectableTypeProvider));
         if (pluginTypeProvider is null) throw new ArgumentNullException(nameof(pluginTypeProvider));
+        if (registryParticipantTypes is null) throw new ArgumentNullException(nameof(registryParticipantTypes));
 
         lock (_gate)
         {
-            _registrations.Add(new Registration(injectableTypeProvider, pluginTypeProvider, decoratorApplier, optionsRegistrar));
+            _registrations.Add(new Registration(
+                injectableTypeProvider,
+                pluginTypeProvider,
+                registryParticipantTypes,
+                decoratorApplier,
+                optionsRegistrar));
             _cachedCombined = null;
         }
     }
@@ -182,11 +288,50 @@ public static class NeedlrSourceGenBootstrap
         out Func<IReadOnlyList<InjectableTypeInfo>> injectableTypeProvider,
         out Func<IReadOnlyList<PluginTypeInfo>> pluginTypeProvider)
     {
+        return TryGetProviders(
+            out injectableTypeProvider,
+            out pluginTypeProvider,
+            out _);
+    }
+
+    /// <summary>
+    /// Gets the registered providers and generated registry participant types, if any.
+    /// </summary>
+    /// <param name="injectableTypeProvider">The combined injectable type provider.</param>
+    /// <param name="pluginTypeProvider">The combined plugin type provider.</param>
+    /// <param name="registryParticipantTypes">
+    /// Generated types whose assemblies identify every registered TypeRegistry participant.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> when at least one source-generated registration exists; otherwise,
+    /// <see langword="false"/>.
+    /// </returns>
+    /// <remarks>
+    /// Participant types are returned in registration order and deduplicated by type. Consumers
+    /// can derive assembly identity from them without scanning the current <c>AppDomain</c>.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// if (NeedlrSourceGenBootstrap.TryGetProviders(
+    ///     out var injectableTypes,
+    ///     out var pluginTypes,
+    ///     out var registryParticipants))
+    /// {
+    ///     // Configure the source-generated runtime from the returned metadata.
+    /// }
+    /// </code>
+    /// </example>
+    public static bool TryGetProviders(
+        out Func<IReadOnlyList<InjectableTypeInfo>> injectableTypeProvider,
+        out Func<IReadOnlyList<PluginTypeInfo>> pluginTypeProvider,
+        out IReadOnlyList<Type> registryParticipantTypes)
+    {
         var local = _asyncLocalOverride.Value;
         if (local is not null)
         {
             injectableTypeProvider = local.InjectableTypeProvider;
             pluginTypeProvider = local.PluginTypeProvider;
+            registryParticipantTypes = local.RegistryParticipantTypes;
             return true;
         }
 
@@ -196,6 +341,7 @@ public static class NeedlrSourceGenBootstrap
             {
                 injectableTypeProvider = null!;
                 pluginTypeProvider = null!;
+                registryParticipantTypes = null!;
                 return false;
             }
 
@@ -206,6 +352,7 @@ public static class NeedlrSourceGenBootstrap
 
             injectableTypeProvider = _cachedCombined.InjectableTypeProvider;
             pluginTypeProvider = _cachedCombined.PluginTypeProvider;
+            registryParticipantTypes = _cachedCombined.RegistryParticipantTypes;
             return true;
         }
     }
@@ -297,7 +444,7 @@ public static class NeedlrSourceGenBootstrap
     /// <returns>True if any extension registrars are registered.</returns>
     /// <remarks>
     /// The returned action invokes every registrar in registration order. Unlike
-    /// <see cref="TryGetProviders"/>, extension registrars are not affected by test scopes.
+    /// <c>TryGetProviders</c>, extension registrars are not affected by test scopes.
     /// </remarks>
     public static bool TryGetExtensionRegistrar(out Action<object, object>? extensionRegistrar)
     {
@@ -339,11 +486,26 @@ public static class NeedlrSourceGenBootstrap
         Func<IReadOnlyList<InjectableTypeInfo>> injectableTypeProvider,
         Func<IReadOnlyList<PluginTypeInfo>> pluginTypeProvider)
     {
+        return BeginTestScope(
+            injectableTypeProvider,
+            pluginTypeProvider,
+            Array.Empty<Type>());
+    }
+
+    internal static IDisposable BeginTestScope(
+        Func<IReadOnlyList<InjectableTypeInfo>> injectableTypeProvider,
+        Func<IReadOnlyList<PluginTypeInfo>> pluginTypeProvider,
+        IReadOnlyList<Type> registryParticipantTypes)
+    {
         if (injectableTypeProvider is null) throw new ArgumentNullException(nameof(injectableTypeProvider));
         if (pluginTypeProvider is null) throw new ArgumentNullException(nameof(pluginTypeProvider));
+        if (registryParticipantTypes is null) throw new ArgumentNullException(nameof(registryParticipantTypes));
 
         var prior = _asyncLocalOverride.Value;
-        _asyncLocalOverride.Value = new Registration(injectableTypeProvider, pluginTypeProvider);
+        _asyncLocalOverride.Value = new Registration(
+            injectableTypeProvider,
+            pluginTypeProvider,
+            registryParticipantTypes);
         return new Scope(prior);
     }
 
@@ -369,6 +531,19 @@ public static class NeedlrSourceGenBootstrap
         var pluginProviders = registrations.Select(r => r.PluginTypeProvider).ToArray();
         var decoratorAppliers = registrations.Where(r => r.DecoratorApplier is not null).Select(r => r.DecoratorApplier!).ToArray();
         var optionsRegistrars = registrations.Where(r => r.OptionsRegistrar is not null).Select(r => r.OptionsRegistrar!).ToArray();
+        var registryParticipantTypes = new List<Type>();
+        var seenRegistryParticipantTypes = new HashSet<Type>();
+
+        foreach (var registration in registrations)
+        {
+            foreach (var registryParticipantType in registration.RegistryParticipantTypes)
+            {
+                if (seenRegistryParticipantTypes.Add(registryParticipantType))
+                {
+                    registryParticipantTypes.Add(registryParticipantType);
+                }
+            }
+        }
 
         IReadOnlyList<InjectableTypeInfo> GetInjectableTypes()
         {
@@ -428,6 +603,11 @@ public static class NeedlrSourceGenBootstrap
             }
             : null;
 
-        return new Registration(GetInjectableTypes, GetPluginTypes, combinedDecoratorApplier, combinedOptionsRegistrar);
+        return new Registration(
+            GetInjectableTypes,
+            GetPluginTypes,
+            registryParticipantTypes,
+            combinedDecoratorApplier,
+            combinedOptionsRegistrar);
     }
 }

--- a/src/NexusLabs.Needlr.Generators.Tests/BootstrapCodeGeneratorRuntimeTests.cs
+++ b/src/NexusLabs.Needlr.Generators.Tests/BootstrapCodeGeneratorRuntimeTests.cs
@@ -90,6 +90,7 @@ public sealed class BootstrapCodeGeneratorRuntimeTests
                 public static class NeedlrSourceGenBootstrap
                 {
                     public static void Register(
+                        Type registryParticipantType,
                         Func<IReadOnlyList<InjectableTypeInfo>> injectableTypeProvider,
                         Func<IReadOnlyList<PluginTypeInfo>> pluginTypeProvider,
                         Action<object> decoratorApplier,

--- a/src/NexusLabs.Needlr.Generators.Tests/GeneratorTestRunner.cs
+++ b/src/NexusLabs.Needlr.Generators.Tests/GeneratorTestRunner.cs
@@ -684,9 +684,11 @@ public sealed class GeneratorTestRunner
             public static class NeedlrSourceGenBootstrap
             {
                 public static void Register(
+                    System.Type registryParticipantType,
                     System.Func<System.Collections.Generic.IReadOnlyList<InjectableTypeInfo>> injectableTypeProvider,
                     System.Func<System.Collections.Generic.IReadOnlyList<PluginTypeInfo>> pluginTypeProvider,
-                    System.Action<object>? decoratorApplier = null)
+                    System.Action<object>? decoratorApplier = null,
+                    System.Action<object, object>? optionsRegistrar = null)
                 {
                 }
             }
@@ -810,9 +812,11 @@ public sealed class GeneratorTestRunner
             public static class NeedlrSourceGenBootstrap
             {
                 public static void Register(
+                    System.Type registryParticipantType,
                     System.Func<System.Collections.Generic.IReadOnlyList<InjectableTypeInfo>> injectableTypeProvider,
                     System.Func<System.Collections.Generic.IReadOnlyList<PluginTypeInfo>> pluginTypeProvider,
-                    System.Action<object>? decoratorApplier = null)
+                    System.Action<object>? decoratorApplier = null,
+                    System.Action<object, object>? optionsRegistrar = null)
                 {
                 }
             }

--- a/src/NexusLabs.Needlr.Generators.Tests/InaccessibleInternalTypeDiagnosticTests.cs
+++ b/src/NexusLabs.Needlr.Generators.Tests/InaccessibleInternalTypeDiagnosticTests.cs
@@ -376,8 +376,11 @@ namespace NexusLabs.Needlr.Generators
     public static class NeedlrSourceGenBootstrap
     {
         public static void Register(
+            System.Type registryParticipantType,
             System.Func<System.Collections.Generic.IReadOnlyList<InjectableTypeInfo>> injectableTypeProvider,
-            System.Func<System.Collections.Generic.IReadOnlyList<PluginTypeInfo>> pluginTypeProvider)
+            System.Func<System.Collections.Generic.IReadOnlyList<PluginTypeInfo>> pluginTypeProvider,
+            System.Action<object>? decoratorApplier = null,
+            System.Action<object, object>? optionsRegistrar = null)
         {
         }
     }

--- a/src/NexusLabs.Needlr.Generators.Tests/MissingTypeRegistryDiagnosticTests.cs
+++ b/src/NexusLabs.Needlr.Generators.Tests/MissingTypeRegistryDiagnosticTests.cs
@@ -373,8 +373,11 @@ namespace NexusLabs.Needlr.Generators
     public static class NeedlrSourceGenBootstrap
     {
         public static void Register(
+            System.Type registryParticipantType,
             System.Func<System.Collections.Generic.IReadOnlyList<InjectableTypeInfo>> injectableTypeProvider,
-            System.Func<System.Collections.Generic.IReadOnlyList<PluginTypeInfo>> pluginTypeProvider)
+            System.Func<System.Collections.Generic.IReadOnlyList<PluginTypeInfo>> pluginTypeProvider,
+            System.Action<object>? decoratorApplier = null,
+            System.Action<object, object>? optionsRegistrar = null)
         {
         }
     }

--- a/src/NexusLabs.Needlr.Generators.Tests/TypeRegistryGeneratorTests.cs
+++ b/src/NexusLabs.Needlr.Generators.Tests/TypeRegistryGeneratorTests.cs
@@ -785,8 +785,11 @@ namespace NexusLabs.Needlr.Generators
     public static class NeedlrSourceGenBootstrap
     {
         public static void Register(
+            System.Type registryParticipantType,
             System.Func<System.Collections.Generic.IReadOnlyList<InjectableTypeInfo>> injectableTypeProvider,
-            System.Func<System.Collections.Generic.IReadOnlyList<PluginTypeInfo>> pluginTypeProvider)
+            System.Func<System.Collections.Generic.IReadOnlyList<PluginTypeInfo>> pluginTypeProvider,
+            System.Action<object>? decoratorApplier = null,
+            System.Action<object, object>? optionsRegistrar = null)
         {
         }
     }
@@ -869,6 +872,9 @@ namespace MainApp
 
         var (_, mainGeneratedCode) = RunGeneratorWithReferencedAssembly(referencedAssemblySource, mainAssemblySource);
 
+        Assert.Contains(
+            "typeof(global::MainApp.Generated.TypeRegistry),",
+            mainGeneratedCode);
         // Should generate ForceLoadReferencedAssemblies method
         Assert.Contains("ForceLoadReferencedAssemblies", mainGeneratedCode);
         Assert.Contains(
@@ -1098,8 +1104,11 @@ namespace NexusLabs.Needlr.Generators
     public static class NeedlrSourceGenBootstrap
     {
         public static void Register(
+            System.Type registryParticipantType,
             System.Func<System.Collections.Generic.IReadOnlyList<InjectableTypeInfo>> injectableTypeProvider,
-            System.Func<System.Collections.Generic.IReadOnlyList<PluginTypeInfo>> pluginTypeProvider)
+            System.Func<System.Collections.Generic.IReadOnlyList<PluginTypeInfo>> pluginTypeProvider,
+            System.Action<object>? decoratorApplier = null,
+            System.Action<object, object>? optionsRegistrar = null)
         {
         }
     }
@@ -1155,6 +1164,7 @@ namespace DomainOnly
         var bootstrap = files.FirstOrDefault(f => f.FilePath.EndsWith("NeedlrSourceGenBootstrap.g.cs"));
         Assert.NotNull(bootstrap);
         Assert.Contains("NeedlrSourceGenBootstrap.Register(", bootstrap!.Content);
+        Assert.Contains("typeof(global::DomainOnly.Generated.TypeRegistry),", bootstrap.Content);
         Assert.DoesNotContain("IServiceCollection", bootstrap.Content);
 
         // No ServiceCatalog is emitted for an assembly with nothing to catalog.

--- a/src/NexusLabs.Needlr.Generators/CodeGen/BootstrapCodeGenerator.cs
+++ b/src/NexusLabs.Needlr.Generators/CodeGen/BootstrapCodeGenerator.cs
@@ -13,7 +13,7 @@ internal static class BootstrapCodeGenerator
 {
     /// <summary>
     /// Emits the module-initializer bootstrap source that registers TypeRegistry
-    /// callbacks and runs referenced TypeRegistry module constructors.
+    /// identity and callbacks and runs referenced TypeRegistry module constructors.
     /// </summary>
     internal static string GenerateModuleInitializerBootstrapSource(string assemblyName, IReadOnlyList<string> referencedAssemblies, BreadcrumbWriter breadcrumbs, bool hasFactories, bool hasOptions, bool hasProviders)
     {
@@ -43,6 +43,7 @@ internal static class BootstrapCodeGenerator
         }
 
         builder.AppendLine("        global::NexusLabs.Needlr.Generators.NeedlrSourceGenBootstrap.Register(");
+        builder.AppendLine($"            typeof(global::{safeAssemblyName}.Generated.TypeRegistry),");
         builder.AppendLine($"            global::{safeAssemblyName}.Generated.TypeRegistry.GetInjectableTypes,");
         builder.AppendLine($"            global::{safeAssemblyName}.Generated.TypeRegistry.GetPluginTypes,");
 

--- a/src/NexusLabs.Needlr.Generators/CodeGen/EmptyTypeRegistryCodeGenerator.cs
+++ b/src/NexusLabs.Needlr.Generators/CodeGen/EmptyTypeRegistryCodeGenerator.cs
@@ -67,7 +67,7 @@ internal static class EmptyTypeRegistryCodeGenerator
     /// <param name="breadcrumbs">The breadcrumb writer supplied by the orchestration method.</param>
     /// <returns>The generated C# source for the module-initializer bootstrap.</returns>
     /// <remarks>
-    /// Uses the two-argument <c>Register</c> overload (no decorator applier, no options registrar),
+    /// Uses the registry-identity <c>Register</c> overload (no decorator applier, no options registrar),
     /// which takes no <c>IServiceCollection</c>/<c>IConfiguration</c> parameters and therefore keeps
     /// the emitted code free of any Microsoft.Extensions.DependencyInjection dependency.
     /// </remarks>
@@ -87,6 +87,7 @@ internal static class EmptyTypeRegistryCodeGenerator
         builder.AppendLine("    internal static void Initialize()");
         builder.AppendLine("    {");
         builder.AppendLine("        global::NexusLabs.Needlr.Generators.NeedlrSourceGenBootstrap.Register(");
+        builder.AppendLine($"            typeof(global::{safeAssemblyName}.Generated.TypeRegistry),");
         builder.AppendLine($"            global::{safeAssemblyName}.Generated.TypeRegistry.GetInjectableTypes,");
         builder.AppendLine($"            global::{safeAssemblyName}.Generated.TypeRegistry.GetPluginTypes);");
         builder.AppendLine("    }");

--- a/src/NexusLabs.Needlr.Hosting/HostApplicationBuilderPluginOptions.cs
+++ b/src/NexusLabs.Needlr.Hosting/HostApplicationBuilderPluginOptions.cs
@@ -8,6 +8,13 @@ namespace NexusLabs.Needlr.Hosting;
 /// <summary>
 /// Options passed to <see cref="IHostApplicationBuilderPlugin.Configure"/>.
 /// </summary>
+/// <param name="Builder">The host application builder being configured.</param>
+/// <param name="Assemblies">
+/// The candidate assemblies selected by Needlr. Source-generated discovery includes every
+/// generated TypeRegistry participant, including empty registries, when assembly metadata is available.
+/// </param>
+/// <param name="Logger">Logger for host plugin execution.</param>
+/// <param name="PluginFactory">Factory for creating additional plugin instances.</param>
 public sealed record HostApplicationBuilderPluginOptions(
     HostApplicationBuilder Builder,
     IReadOnlyList<Assembly> Assemblies,

--- a/src/NexusLabs.Needlr.Hosting/HostPluginOptions.cs
+++ b/src/NexusLabs.Needlr.Hosting/HostPluginOptions.cs
@@ -7,6 +7,12 @@ namespace NexusLabs.Needlr.Hosting;
 /// <summary>
 /// Options passed to <see cref="IHostPlugin.Configure"/>.
 /// </summary>
+/// <param name="Host">The built host being configured.</param>
+/// <param name="Assemblies">
+/// The candidate assemblies selected by Needlr. Source-generated discovery includes every
+/// generated TypeRegistry participant, including empty registries, when assembly metadata is available.
+/// </param>
+/// <param name="PluginFactory">Factory for creating additional plugin instances.</param>
 public sealed record HostPluginOptions(
     IHost Host,
     IReadOnlyList<Assembly> Assemblies,

--- a/src/NexusLabs.Needlr.Injection.Bundle.Tests/SyringeBundleExtensionsTests.cs
+++ b/src/NexusLabs.Needlr.Injection.Bundle.Tests/SyringeBundleExtensionsTests.cs
@@ -32,6 +32,21 @@ public sealed class SyringeBundleExtensionsTests
     }
 
     [Fact]
+    public void UsingAutoConfiguration_WithRegistryParticipant_IncludesParticipantAssembly()
+    {
+        using var scope = NeedlrSourceGenBootstrap.BeginTestScope(
+            () => [],
+            () => [],
+            [typeof(SyringeBundleExtensionsTests)]);
+
+        var syringe = new Syringe().UsingAutoConfiguration();
+
+        var assembly = Assert.Single(
+            syringe.GetOrCreateAssemblyProvider().GetCandidateAssemblies());
+        Assert.Same(typeof(SyringeBundleExtensionsTests).Assembly, assembly);
+    }
+
+    [Fact]
     public void UsingAutoConfiguration_WithoutSourceGen_FallsBackToReflection()
     {
         // Arrange - ensure no source-gen bootstrap

--- a/src/NexusLabs.Needlr.Injection.Bundle/SyringeBundleExtensions.cs
+++ b/src/NexusLabs.Needlr.Injection.Bundle/SyringeBundleExtensions.cs
@@ -43,14 +43,20 @@ public static class SyringeBundleExtensions
     {
         ArgumentNullException.ThrowIfNull(syringe);
 
-        if (NeedlrSourceGenBootstrap.TryGetProviders(out var injectableTypeProvider, out var pluginTypeProvider))
+        if (NeedlrSourceGenBootstrap.TryGetProviders(
+            out var injectableTypeProvider,
+            out var pluginTypeProvider,
+            out var registryParticipantTypes))
         {
             var configured = new ConfiguredSyringe(syringe) with
             {
                 ServiceProviderBuilderFactory = (populator, assemblyProvider, additionalAssemblies) => 
                     new ServiceProviderBuilder(populator, assemblyProvider, additionalAssemblies)
             };
-            return configured.UsingGeneratedComponents(injectableTypeProvider, pluginTypeProvider);
+            return configured.UsingGeneratedComponents(
+                injectableTypeProvider,
+                pluginTypeProvider,
+                registryParticipantTypes);
         }
 
         // Fallback to reflection
@@ -76,14 +82,20 @@ public static class SyringeBundleExtensions
     {
         ArgumentNullException.ThrowIfNull(syringe);
 
-        if (NeedlrSourceGenBootstrap.TryGetProviders(out var injectableTypeProvider, out var pluginTypeProvider))
+        if (NeedlrSourceGenBootstrap.TryGetProviders(
+            out var injectableTypeProvider,
+            out var pluginTypeProvider,
+            out var registryParticipantTypes))
         {
             var configured = new ConfiguredSyringe(syringe) with
             {
                 ServiceProviderBuilderFactory = (populator, assemblyProvider, additionalAssemblies) => 
                     new ServiceProviderBuilder(populator, assemblyProvider, additionalAssemblies)
             };
-            return configured.UsingGeneratedComponents(injectableTypeProvider, pluginTypeProvider);
+            return configured.UsingGeneratedComponents(
+                injectableTypeProvider,
+                pluginTypeProvider,
+                registryParticipantTypes);
         }
 
         // Invoke fallback handler if provided

--- a/src/NexusLabs.Needlr.Injection.SourceGen/Loaders/GeneratedAssemblyProvider.cs
+++ b/src/NexusLabs.Needlr.Injection.SourceGen/Loaders/GeneratedAssemblyProvider.cs
@@ -10,13 +10,14 @@ namespace NexusLabs.Needlr.Injection.SourceGen.Loaders;
 /// <remarks>
 /// <para>
 /// When using source generation, the TypeRegistry contains all injectable types
-/// and plugins discovered at compile time. This provider extracts the unique
-/// assemblies from those types, enabling cross-assembly plugin discovery without
-/// runtime assembly scanning.
+/// and plugins discovered at compile time. Generated bootstraps also provide a
+/// registry participant type so assemblies with no injectable types or plugins
+/// remain available without runtime assembly scanning.
 /// </para>
 /// <para>
 /// This provider should be used with <see cref="PluginFactories.GeneratedPluginFactory"/>
-/// to ensure that all assemblies containing generated types are included in plugin discovery.
+/// to ensure that all generated registry participants are included in plugin discovery
+/// when runtime assembly metadata is available.
 /// </para>
 /// <para>
 /// For assembly ordering, use <c>SyringeExtensions.OrderAssemblies</c> after configuring the Syringe.
@@ -32,13 +33,42 @@ public sealed class GeneratedAssemblyProvider : IAssemblyProvider
     /// </summary>
     /// <param name="injectableTypesProvider">A function that returns the injectable types.</param>
     /// <param name="pluginTypesProvider">A function that returns the plugin types.</param>
+    /// <remarks>
+    /// This compatibility overload can derive assemblies only from injectable and plugin metadata.
+    /// Use the three-argument overload when generated registry participant types are available.
+    /// </remarks>
     public GeneratedAssemblyProvider(
         Func<IReadOnlyList<InjectableTypeInfo>> injectableTypesProvider,
         Func<IReadOnlyList<PluginTypeInfo>> pluginTypesProvider)
+        : this(
+            injectableTypesProvider,
+            pluginTypesProvider,
+            Array.Empty<Type>())
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GeneratedAssemblyProvider"/> class.
+    /// </summary>
+    /// <param name="injectableTypesProvider">A function that returns the injectable types.</param>
+    /// <param name="pluginTypesProvider">A function that returns the plugin types.</param>
+    /// <param name="registryParticipantTypes">
+    /// Generated types whose assemblies identify every TypeRegistry participant.
+    /// </param>
+    /// <remarks>
+    /// Assemblies represented by injectable and plugin metadata preserve their existing order.
+    /// Marker-only participant assemblies are appended in registration order.
+    /// </remarks>
+    public GeneratedAssemblyProvider(
+        Func<IReadOnlyList<InjectableTypeInfo>> injectableTypesProvider,
+        Func<IReadOnlyList<PluginTypeInfo>> pluginTypesProvider,
+        IReadOnlyList<Type> registryParticipantTypes)
     {
         ArgumentNullException.ThrowIfNull(injectableTypesProvider);
         ArgumentNullException.ThrowIfNull(pluginTypesProvider);
+        ArgumentNullException.ThrowIfNull(registryParticipantTypes);
 
+        var registryParticipantTypeSnapshot = registryParticipantTypes.ToArray();
         _lazyAssemblies = new(() =>
         {
             // In NativeAOT with reflection disabled, Type.Assembly can throw.
@@ -46,21 +76,33 @@ public sealed class GeneratedAssemblyProvider : IAssemblyProvider
             // For source generation, the plugin/type registries already define the universe.
             try
             {
-                var assemblies = new HashSet<Assembly>();
+                var assemblies = new List<Assembly>();
+                var seenAssemblies = new HashSet<Assembly>();
 
-                // Extract assemblies from injectable types
                 foreach (var info in injectableTypesProvider())
                 {
-                    assemblies.Add(info.Type.Assembly);
+                    AddAssembly(info.Type.Assembly);
                 }
 
-                // Extract assemblies from plugin types
                 foreach (var info in pluginTypesProvider())
                 {
-                    assemblies.Add(info.PluginType.Assembly);
+                    AddAssembly(info.PluginType.Assembly);
                 }
 
-                return assemblies.ToList();
+                foreach (var registryParticipantType in registryParticipantTypeSnapshot)
+                {
+                    AddAssembly(registryParticipantType.Assembly);
+                }
+
+                return assemblies;
+
+                void AddAssembly(Assembly assembly)
+                {
+                    if (seenAssemblies.Add(assembly))
+                    {
+                        assemblies.Add(assembly);
+                    }
+                }
             }
             catch (NotSupportedException)
             {

--- a/src/NexusLabs.Needlr.Injection.SourceGen/SyringeSourceGenExtensions.cs
+++ b/src/NexusLabs.Needlr.Injection.SourceGen/SyringeSourceGenExtensions.cs
@@ -35,7 +35,8 @@ public static class SyringeSourceGenExtensions
     /// </summary>
     /// <remarks>
     /// <para>
-    /// This method uses the type providers registered via <see cref="NeedlrSourceGenBootstrap"/>.
+    /// This method uses the type providers and registry participant identities registered via
+    /// <see cref="NeedlrSourceGenBootstrap"/>.
     /// The bootstrap is automatically registered by the generated module initializer when you use
     /// <c>[assembly: GenerateTypeRegistry(...)]</c>.
     /// </para>
@@ -49,14 +50,20 @@ public static class SyringeSourceGenExtensions
     {
         ArgumentNullException.ThrowIfNull(syringe);
 
-        if (!NeedlrSourceGenBootstrap.TryGetProviders(out var injectableTypeProvider, out var pluginTypeProvider))
+        if (!NeedlrSourceGenBootstrap.TryGetProviders(
+            out var injectableTypeProvider,
+            out var pluginTypeProvider,
+            out var registryParticipantTypes))
         {
             throw new InvalidOperationException(
                 "No source-generated type providers found. Ensure your assembly has " +
                 "[assembly: GenerateTypeRegistry(...)] and references NexusLabs.Needlr.Generators.");
         }
 
-        return new ConfiguredSyringe(syringe).UsingGeneratedComponents(injectableTypeProvider, pluginTypeProvider);
+        return new ConfiguredSyringe(syringe).UsingGeneratedComponents(
+            injectableTypeProvider,
+            pluginTypeProvider,
+            registryParticipantTypes);
     }
 
     /// <summary>
@@ -65,6 +72,8 @@ public static class SyringeSourceGenExtensions
     /// <remarks>
     /// This is a strategy method that creates a ConfiguredSyringe. Use this when you have
     /// explicit type providers (e.g., from generated code) rather than using the bootstrap.
+    /// Assemblies are derived only from the supplied injectable and plugin metadata; use the
+    /// overload with registry participant types when empty registries must remain visible.
     /// </remarks>
     /// <param name="syringe">The base syringe to configure.</param>
     /// <param name="injectableTypeProvider">A function that returns the injectable types.</param>
@@ -75,16 +84,42 @@ public static class SyringeSourceGenExtensions
         Func<IReadOnlyList<InjectableTypeInfo>> injectableTypeProvider,
         Func<IReadOnlyList<PluginTypeInfo>> pluginTypeProvider)
     {
+        return syringe.UsingGeneratedComponents(
+            injectableTypeProvider,
+            pluginTypeProvider,
+            Array.Empty<Type>());
+    }
+
+    /// <summary>
+    /// Configures the syringe with all generated components and registry participant identities.
+    /// </summary>
+    /// <param name="syringe">The base syringe to configure.</param>
+    /// <param name="injectableTypeProvider">A function that returns the injectable types.</param>
+    /// <param name="pluginTypeProvider">A function that returns the plugin types.</param>
+    /// <param name="registryParticipantTypes">
+    /// Generated types whose assemblies identify every TypeRegistry participant.
+    /// </param>
+    /// <returns>A configured syringe with all source-generated components.</returns>
+    public static ConfiguredSyringe UsingGeneratedComponents(
+        this Syringe syringe,
+        Func<IReadOnlyList<InjectableTypeInfo>> injectableTypeProvider,
+        Func<IReadOnlyList<PluginTypeInfo>> pluginTypeProvider,
+        IReadOnlyList<Type> registryParticipantTypes)
+    {
         ArgumentNullException.ThrowIfNull(syringe);
         ArgumentNullException.ThrowIfNull(injectableTypeProvider);
         ArgumentNullException.ThrowIfNull(pluginTypeProvider);
+        ArgumentNullException.ThrowIfNull(registryParticipantTypes);
 
         return new ConfiguredSyringe(syringe) with
         {
             TypeRegistrar = new GeneratedTypeRegistrar(injectableTypeProvider),
             TypeFilterer = new GeneratedTypeFilterer(injectableTypeProvider),
             PluginFactory = new GeneratedPluginFactory(pluginTypeProvider),
-            AssemblyProvider = new GeneratedAssemblyProvider(injectableTypeProvider, pluginTypeProvider),
+            AssemblyProvider = new GeneratedAssemblyProvider(
+                injectableTypeProvider,
+                pluginTypeProvider,
+                registryParticipantTypes),
             ServiceProviderBuilderFactory = (populator, assemblyProvider, _) => 
                 new GeneratedServiceProviderBuilder(populator, assemblyProvider, pluginTypeProvider)
         };
@@ -93,6 +128,10 @@ public static class SyringeSourceGenExtensions
     /// <summary>
     /// Configures the syringe with all generated components for zero-reflection operation.
     /// </summary>
+    /// <remarks>
+    /// Assemblies are derived only from the supplied injectable and plugin metadata; use the
+    /// overload with registry participant types when empty registries must remain visible.
+    /// </remarks>
     /// <param name="syringe">The configured syringe to update.</param>
     /// <param name="injectableTypeProvider">A function that returns the injectable types.</param>
     /// <param name="pluginTypeProvider">A function that returns the plugin types.</param>
@@ -102,16 +141,42 @@ public static class SyringeSourceGenExtensions
         Func<IReadOnlyList<InjectableTypeInfo>> injectableTypeProvider,
         Func<IReadOnlyList<PluginTypeInfo>> pluginTypeProvider)
     {
+        return syringe.UsingGeneratedComponents(
+            injectableTypeProvider,
+            pluginTypeProvider,
+            Array.Empty<Type>());
+    }
+
+    /// <summary>
+    /// Configures the syringe with all generated components and registry participant identities.
+    /// </summary>
+    /// <param name="syringe">The configured syringe to update.</param>
+    /// <param name="injectableTypeProvider">A function that returns the injectable types.</param>
+    /// <param name="pluginTypeProvider">A function that returns the plugin types.</param>
+    /// <param name="registryParticipantTypes">
+    /// Generated types whose assemblies identify every TypeRegistry participant.
+    /// </param>
+    /// <returns>A configured syringe with all source-generated components.</returns>
+    public static ConfiguredSyringe UsingGeneratedComponents(
+        this ConfiguredSyringe syringe,
+        Func<IReadOnlyList<InjectableTypeInfo>> injectableTypeProvider,
+        Func<IReadOnlyList<PluginTypeInfo>> pluginTypeProvider,
+        IReadOnlyList<Type> registryParticipantTypes)
+    {
         ArgumentNullException.ThrowIfNull(syringe);
         ArgumentNullException.ThrowIfNull(injectableTypeProvider);
         ArgumentNullException.ThrowIfNull(pluginTypeProvider);
+        ArgumentNullException.ThrowIfNull(registryParticipantTypes);
 
         return syringe with
         {
             TypeRegistrar = new GeneratedTypeRegistrar(injectableTypeProvider),
             TypeFilterer = new GeneratedTypeFilterer(injectableTypeProvider),
             PluginFactory = new GeneratedPluginFactory(pluginTypeProvider),
-            AssemblyProvider = new GeneratedAssemblyProvider(injectableTypeProvider, pluginTypeProvider),
+            AssemblyProvider = new GeneratedAssemblyProvider(
+                injectableTypeProvider,
+                pluginTypeProvider,
+                registryParticipantTypes),
             ServiceProviderBuilderFactory = (populator, assemblyProvider, _) => 
                 new GeneratedServiceProviderBuilder(populator, assemblyProvider, pluginTypeProvider)
         };
@@ -165,6 +230,10 @@ public static class SyringeSourceGenExtensions
     /// <summary>
     /// Configures the syringe to use the generated assembly provider.
     /// </summary>
+    /// <remarks>
+    /// Assemblies are derived only from the supplied injectable and plugin metadata; use the
+    /// overload with registry participant types when empty registries must remain visible.
+    /// </remarks>
     /// <param name="syringe">The configured syringe to update.</param>
     /// <param name="injectableTypeProvider">A function that returns the injectable types.</param>
     /// <param name="pluginTypeProvider">A function that returns the plugin types.</param>
@@ -174,10 +243,36 @@ public static class SyringeSourceGenExtensions
         Func<IReadOnlyList<InjectableTypeInfo>> injectableTypeProvider,
         Func<IReadOnlyList<PluginTypeInfo>> pluginTypeProvider)
     {
+        return syringe.UsingGeneratedAssemblyProvider(
+            injectableTypeProvider,
+            pluginTypeProvider,
+            Array.Empty<Type>());
+    }
+
+    /// <summary>
+    /// Configures the syringe to use the generated assembly provider with registry participant identities.
+    /// </summary>
+    /// <param name="syringe">The configured syringe to update.</param>
+    /// <param name="injectableTypeProvider">A function that returns the injectable types.</param>
+    /// <param name="pluginTypeProvider">A function that returns the plugin types.</param>
+    /// <param name="registryParticipantTypes">
+    /// Generated types whose assemblies identify every TypeRegistry participant.
+    /// </param>
+    /// <returns>A new configured syringe instance.</returns>
+    public static ConfiguredSyringe UsingGeneratedAssemblyProvider(
+        this ConfiguredSyringe syringe,
+        Func<IReadOnlyList<InjectableTypeInfo>> injectableTypeProvider,
+        Func<IReadOnlyList<PluginTypeInfo>> pluginTypeProvider,
+        IReadOnlyList<Type> registryParticipantTypes)
+    {
         ArgumentNullException.ThrowIfNull(syringe);
         ArgumentNullException.ThrowIfNull(injectableTypeProvider);
         ArgumentNullException.ThrowIfNull(pluginTypeProvider);
+        ArgumentNullException.ThrowIfNull(registryParticipantTypes);
         return syringe.UsingAssemblyProvider(
-            new GeneratedAssemblyProvider(injectableTypeProvider, pluginTypeProvider));
+            new GeneratedAssemblyProvider(
+                injectableTypeProvider,
+                pluginTypeProvider,
+                registryParticipantTypes));
     }
 }

--- a/src/NexusLabs.Needlr.Injection.Tests/Bootstrap/NeedlrSourceGenBootstrapCompositionTests.cs
+++ b/src/NexusLabs.Needlr.Injection.Tests/Bootstrap/NeedlrSourceGenBootstrapCompositionTests.cs
@@ -9,8 +9,8 @@ namespace NexusLabs.Needlr.Injection.Tests.Bootstrap;
 
 /// <summary>
 /// Contract coverage for how <see cref="NeedlrSourceGenBootstrap"/> composes generated
-/// registrations: empty state, single and multiple registrars, ordering, deduplication,
-/// cache invalidation, test scopes, and argument guards.
+/// registrations: empty state, participant identities, single and multiple registrars,
+/// ordering, deduplication, cache invalidation, test scopes, and argument guards.
 /// </summary>
 [Collection(SourceGenBootstrapCollection.Name)]
 public sealed class NeedlrSourceGenBootstrapCompositionTests : IDisposable
@@ -35,6 +35,20 @@ public sealed class NeedlrSourceGenBootstrapCompositionTests : IDisposable
         Assert.False(found, "Expected no providers when nothing has been registered");
         Assert.Null(injectableTypeProvider);
         Assert.Null(pluginTypeProvider);
+    }
+
+    [Fact]
+    public void TryGetProviders_NoRegistrations_WithParticipantOutput_ReturnsFalseWithNullOutputs()
+    {
+        var found = NeedlrSourceGenBootstrap.TryGetProviders(
+            out var injectableTypeProvider,
+            out var pluginTypeProvider,
+            out var registryParticipantTypes);
+
+        Assert.False(found, "Expected no providers when nothing has been registered");
+        Assert.Null(injectableTypeProvider);
+        Assert.Null(pluginTypeProvider);
+        Assert.Null(registryParticipantTypes);
     }
 
     [Fact]
@@ -107,6 +121,41 @@ public sealed class NeedlrSourceGenBootstrapCompositionTests : IDisposable
         Assert.Equal(
             [typeof(BootstrapTestPluginOne), typeof(BootstrapTestPluginTwo)],
             pluginTypeProvider().Select(p => p.PluginType).ToArray());
+    }
+
+    [Fact]
+    public void TryGetProviders_RegistryParticipants_PreservesRegistrationOrderAndDeduplicates()
+    {
+        NeedlrSourceGenBootstrap.Register(
+            typeof(BootstrapTestServiceOne),
+            () => [],
+            () => []);
+        NeedlrSourceGenBootstrap.Register(
+            typeof(BootstrapTestServiceTwo),
+            () => [],
+            () => []);
+        NeedlrSourceGenBootstrap.Register(
+            typeof(BootstrapTestServiceOne),
+            () => [],
+            () => []);
+
+        Assert.True(
+            NeedlrSourceGenBootstrap.TryGetProviders(out _, out _, out var registryParticipantTypes),
+            "Expected providers after registry participants were registered");
+        Assert.Equal(
+            [typeof(BootstrapTestServiceOne), typeof(BootstrapTestServiceTwo)],
+            registryParticipantTypes);
+    }
+
+    [Fact]
+    public void TryGetProviders_LegacyRegistration_HasNoRegistryParticipants()
+    {
+        NeedlrSourceGenBootstrap.Register(() => [], () => []);
+
+        Assert.True(
+            NeedlrSourceGenBootstrap.TryGetProviders(out _, out _, out var registryParticipantTypes),
+            "Expected providers after a legacy registration");
+        Assert.Empty(registryParticipantTypes);
     }
 
     [Fact]
@@ -464,6 +513,15 @@ public sealed class NeedlrSourceGenBootstrapCompositionTests : IDisposable
             NeedlrSourceGenBootstrap.Register(null!, () => []));
 
         Assert.Equal("injectableTypeProvider", exception.ParamName);
+    }
+
+    [Fact]
+    public void Register_NullRegistryParticipantType_ThrowsArgumentNullException()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+            NeedlrSourceGenBootstrap.Register(null!, () => [], () => []));
+
+        Assert.Equal("registryParticipantType", exception.ParamName);
     }
 
     [Fact]

--- a/src/NexusLabs.Needlr.Injection.Tests/Loaders/GeneratedAssemblyProviderTests.cs
+++ b/src/NexusLabs.Needlr.Injection.Tests/Loaders/GeneratedAssemblyProviderTests.cs
@@ -1,0 +1,62 @@
+using Microsoft.Extensions.DependencyInjection;
+
+using NexusLabs.Needlr.Generators;
+using NexusLabs.Needlr.Injection.SourceGen.Loaders;
+
+using Xunit;
+
+namespace NexusLabs.Needlr.Injection.Tests.Loaders;
+
+public sealed class GeneratedAssemblyProviderTests
+{
+    [Fact]
+    public void GetCandidateAssemblies_EmptyMetadataProviders_ReturnsRegistryParticipantAssembly()
+    {
+        var provider = new GeneratedAssemblyProvider(
+            () => [],
+            () => [],
+            [typeof(ServiceCollection)]);
+
+        var assembly = Assert.Single(provider.GetCandidateAssemblies());
+
+        Assert.Same(typeof(ServiceCollection).Assembly, assembly);
+    }
+
+    [Fact]
+    public void GetCandidateAssemblies_ParticipantsAppendAfterMetadataAndDeduplicate()
+    {
+        var injectable = new InjectableTypeInfo(typeof(string), []);
+        var plugin = new PluginTypeInfo(
+            typeof(GeneratedAssemblyProviderTests),
+            [],
+            static () => new object(),
+            []);
+        var provider = new GeneratedAssemblyProvider(
+            () => [injectable],
+            () => [plugin],
+            [
+                typeof(string),
+                typeof(ServiceCollection),
+                typeof(GeneratedAssemblyProviderTests)
+            ]);
+
+        var assemblies = provider.GetCandidateAssemblies();
+
+        Assert.Equal(
+            [
+                typeof(string).Assembly,
+                typeof(GeneratedAssemblyProviderTests).Assembly,
+                typeof(ServiceCollection).Assembly
+            ],
+            assemblies);
+    }
+
+    [Fact]
+    public void Constructor_NullRegistryParticipantTypes_ThrowsArgumentNullException()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+            new GeneratedAssemblyProvider(() => [], () => [], null!));
+
+        Assert.Equal("registryParticipantTypes", exception.ParamName);
+    }
+}

--- a/src/NexusLabs.Needlr/PostBuildServiceCollectionPluginOptions.cs
+++ b/src/NexusLabs.Needlr/PostBuildServiceCollectionPluginOptions.cs
@@ -10,7 +10,10 @@ namespace NexusLabs.Needlr;
 /// </summary>
 /// <param name="Provider">The built service provider for resolving dependencies.</param>
 /// <param name="Config">The application configuration.</param>
-/// <param name="Assemblies">The list of assemblies discovered by Needlr.</param>
+/// <param name="Assemblies">
+/// The candidate assemblies selected by Needlr. Source-generated discovery includes every
+/// generated TypeRegistry participant, including empty registries, when assembly metadata is available.
+/// </param>
 /// <param name="PluginFactory">Factory for creating additional plugin instances.</param>
 public sealed record PostBuildServiceCollectionPluginOptions(
     IServiceProvider Provider,

--- a/src/NexusLabs.Needlr/ServiceCollectionPluginOptions.cs
+++ b/src/NexusLabs.Needlr/ServiceCollectionPluginOptions.cs
@@ -11,7 +11,10 @@ namespace NexusLabs.Needlr;
 /// </summary>
 /// <param name="Services">The service collection for registering dependencies.</param>
 /// <param name="Config">The application configuration.</param>
-/// <param name="Assemblies">The list of assemblies discovered by Needlr.</param>
+/// <param name="Assemblies">
+/// The candidate assemblies selected by Needlr. Source-generated discovery includes every
+/// generated TypeRegistry participant, including empty registries, when assembly metadata is available.
+/// </param>
 /// <param name="PluginFactory">Factory for creating additional plugin instances.</param>
 public sealed record ServiceCollectionPluginOptions(
     IServiceCollection Services,


### PR DESCRIPTION
## Summary
- register each generated `TypeRegistry` as an assembly-identity marker alongside its type and plugin providers
- carry marker-only participants through direct source-gen and bundle composition without changing existing metadata-derived ordering
- document the plugin assembly contract and cover empty/non-empty participants with generator, bootstrap, provider, bundle, and multi-project tests

## Consumer impact
Consumers using `UsingSourceGen()` only need to update the Needlr package family and rebuild. Existing bootstrap and manual-component overloads remain available. Precompiled assemblies produced by an older generator must be rebuilt before they can emit the new participant identity.

## Validation
- affected generator, injection, bundle, multi-project integration, ASP.NET, and Hosting projects built with 0 warnings and 0 errors
- affected generator tests: 80 passed, 0 failed, 0 skipped
- bootstrap and generated assembly provider tests: 37 passed, 0 failed, 0 skipped
- bundle participant test: 1 passed, 0 failed, 0 skipped
- multi-project plugin-options regression: 1 passed, 0 failed, 0 skipped
- strict MkDocs build passed

Local targeted validation used installed SDK 10.0.303 because the repository-pinned 10.0.302 SDK was unavailable. Pull-request CI remains responsible for the pinned SDK, complete suite, package validation, and Native AOT smoke coverage.