### PR TITLE
chore: prepare v0.0.3-alpha.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+## [0.0.3-alpha.5] - 2026-08-14
+
 ### Fixed
 
 - Source-generated plugin assembly options now include every generated `TypeRegistry` participant, including contract or abstractions assemblies whose registries contain no injectable types or plugins. Generated module initializers carry their registry identity through `NeedlrSourceGenBootstrap`, and `GeneratedAssemblyProvider` appends marker-only assemblies without synthetic registrations, `AppDomain` scanning, duplicates, or changes to existing metadata-derived ordering.

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.0.3-alpha.4",
+  "version": "0.0.3-alpha.5",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release/v\\d+\\.\\d+",


### PR DESCRIPTION
## Summary
- reset the repository version to `0.0.3-alpha.5`
- promote the empty-registry assembly fix from `Unreleased` into the dated release section
- leave analyzer release tracking unchanged because no `NDLR*` rows remain unshipped

## Validation
- `scripts/test-release.ps1`: passed
- strict MkDocs build: passed
- analyzer release tracking scan: no unshipped rules
- remote version sequence: `v0.0.3-alpha.4` is current; `v0.0.3-alpha.5` is unused

## Readiness notes
- The exact `scripts/release.ps1 0.0.3-alpha.5 -DryRun` gate intentionally cannot pass on this preparation branch because NBGV resolves `0.0.3-alpha.5.g<sha>` until the version-reset commit is squash-merged onto public `main`.
- Full build, package validation, and AOT validation are delegated to the ready pull request CI on the pinned Needlr runner image.
- No diagnostics, package set changes, or version-specific API documentation updates are pending.