### PR TITLE
test: add advisory mutation testing

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -2,6 +2,13 @@
   "version": 1,
   "isRoot": true,
   "tools": {
+    "dotnet-stryker": {
+      "version": "4.16.0",
+      "commands": [
+        "dotnet-stryker"
+      ],
+      "rollForward": false
+    },
     "defaultdocumentation.console": {
       "version": "1.2.2",
       "commands": [

--- a/.github/genesis-delivery.json
+++ b/.github/genesis-delivery.json
@@ -41,6 +41,8 @@
         "release/create-release",
         "benchmarks/check-changes",
         "benchmarks/run-benchmarks",
+        "mutation-testing/runtime",
+        "mutation-testing/generators",
         "ide-extensions/build-vscode",
         "ide-extensions/release"
       ]
@@ -65,6 +67,8 @@
         "release/create-release",
         "benchmarks/check-changes",
         "benchmarks/run-benchmarks",
+        "mutation-testing/runtime",
+        "mutation-testing/generators",
         "ide-extensions/build-vscode",
         "ide-extensions/release"
       ]
@@ -98,6 +102,16 @@
         "release-deploy"
       ],
       "draftBehavior": "not-applicable",
+      "requiredChecks": []
+    },
+    {
+      "source": "needlr",
+      "path": ".github/workflows/mutation-testing.yml",
+      "roles": [
+        "draft-optional",
+        "post-merge"
+      ],
+      "draftBehavior": "ready-only",
       "requiredChecks": []
     },
     {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,11 @@ jobs:
       shell: pwsh
       run: scripts/test-runner-profile.ps1
 
+    - name: Validate mutation testing contract
+      if: needs.changes.outputs.source_required == 'true'
+      shell: pwsh
+      run: scripts/test-mutation.ps1
+
     - name: Restore
       if: needs.changes.outputs.source_required == 'true'
       run: dotnet restore src/NexusLabs.Needlr.slnx

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -1,0 +1,121 @@
+name: Mutation testing
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
+    paths:
+      - '.config/dotnet-tools.json'
+      - '.github/workflows/mutation-testing.yml'
+      - 'global.json'
+      - 'scripts/get-mutation-scope.ps1'
+      - 'scripts/run-mutation-tests.ps1'
+      - 'scripts/test-mutation.ps1'
+      - 'scripts/mutation/**'
+      - 'src/Directory.Build.props'
+      - 'src/Directory.Packages.props'
+      - 'src/NexusLabs.Needlr/**'
+      - 'src/NexusLabs.Needlr.Tests/**'
+      - 'src/NexusLabs.Needlr.Generators/**'
+      - 'src/NexusLabs.Needlr.Generators.Attributes/**'
+      - 'src/NexusLabs.Needlr.Generators.Tests/**'
+  workflow_dispatch:
+  schedule:
+    - cron: '30 4 * * 1'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mutation-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: 1
+
+jobs:
+  changes:
+    name: Mutation scope
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      runtime_required: ${{ steps.scope.outputs.runtime_required }}
+      generators_required: ${{ steps.scope.outputs.generators_required }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Resolve mutation scope
+        id: scope
+        shell: pwsh
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          FORCE_ALL: ${{ github.event_name != 'pull_request' }}
+        run: |
+          $arguments = @{
+            BaseSha = $env:BASE_SHA
+            HeadSha = $env:HEAD_SHA
+            ForceAll = $env:FORCE_ALL -eq 'true'
+          }
+          scripts/get-mutation-scope.ps1 @arguments
+
+  runtime:
+    name: Runtime mutation analysis
+    needs: changes
+    if: >-
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
+      needs.changes.outputs.runtime_required == 'true'
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || vars.CI_RUNNER || fromJSON('["self-hosted","linux","x64","general-purpose"]') }}
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: ./.github/actions/setup-dotnet
+        with:
+          global-json-file: global.json
+
+      - name: Run runtime mutation testing
+        shell: pwsh
+        run: |
+          scripts/run-mutation-tests.ps1 `
+            -Scope runtime `
+            -OutputPath (Join-Path $env:RUNNER_TEMP 'needlr-mutation')
+
+  generators:
+    name: Generator mutation analysis
+    needs: changes
+    if: >-
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
+      needs.changes.outputs.generators_required == 'true'
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || vars.CI_RUNNER || fromJSON('["self-hosted","linux","x64","general-purpose"]') }}
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: ./.github/actions/setup-dotnet
+        with:
+          global-json-file: global.json
+
+      - name: Run generator mutation testing
+        shell: pwsh
+        run: |
+          scripts/run-mutation-tests.ps1 `
+            -Scope generators `
+            -OutputPath (Join-Path $env:RUNNER_TEMP 'needlr-mutation')

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,8 @@ ScaffoldingReadMe.txt
 *~
 CodeCoverage/
 coverage/
+.stryker-tmp/
+StrykerOutput/
 
 # MSBuild Binary and Structured Log
 *.binlog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Added
+
+- Added advisory Stryker.NET mutation testing for bounded runtime-core and source-generator implementation scopes. Pull requests run only affected scopes, scheduled and manual runs cover both, mutation scores are reported without a break threshold, and reports remain ephemeral in job summaries and logs rather than GitHub artifacts or an external dashboard.
+
 ## [0.0.3-alpha.5] - 2026-08-14
 
 ### Fixed

--- a/docs/adr/adr-0011-adopt-advisory-mutation-testing.md
+++ b/docs/adr/adr-0011-adopt-advisory-mutation-testing.md
@@ -1,0 +1,163 @@
+---
+title: "ADR-0011: Adopt bounded advisory mutation testing"
+status: "Accepted"
+date: "2026-08-15"
+authors: ["Nick Cosentino"]
+tags: ["architecture", "decision", "testing", "mutation", "source-generation", "ci"]
+supersedes: ""
+superseded_by: ""
+---
+
+## Context and scope
+
+Needlr's unit and integration tests verify expected behavior, but line coverage cannot
+show whether an assertion would detect a plausible defect. Mutation testing provides
+that additional signal by changing production code and checking whether tests fail.
+
+Needlr also contains Roslyn source generators and analyzers. Stryker.NET 4.16.0 mutates
+authored project syntax trees and reruns source generators while compiling mutants;
+generated syntax trees are not direct mutation inputs. Tests that invoke generators
+through Roslyn at runtime can therefore kill generator-implementation mutants, while a
+consumer test assembly built once before mutation does not provide equivalent evidence.
+Analyzer execution remains a separate concern because normal mutant compilation does not
+replace analyzer-specific test harnesses.
+
+Mutation runs can be expensive, and the repository has no reviewed mutation baseline.
+The initial integration must not invent a threshold, become a required merge check, add
+GitHub artifact storage, or upload source-level reports to an external dashboard.
+
+This decision governs the initial Stryker.NET scopes, CI cadence, reporting, and score
+policy. It does not establish a permanent mutation threshold or claim repository-wide
+mutation coverage.
+
+## Decision drivers
+
+- Mutation testing must expose weak assertions that line coverage cannot distinguish.
+- Source-generator implementation code needs direct Roslyn test-harness evidence.
+- Initial runtime and cost must remain bounded and measurable.
+- Mutation score must not block delivery before survivors and uncovered mutants are
+  reviewed.
+- Tool, build, and initial-test failures must remain visible rather than being converted
+  into successful mutation reports.
+- Reports must remain available in the workflow without creating more GitHub artifacts
+  or sending repository data to a third-party dashboard.
+- External fork pull requests must stay off self-hosted infrastructure.
+
+## Decision
+
+Needlr pins `dotnet-stryker` 4.16.0 in the repository tool manifest and defines two
+explicit configurations.
+
+The `runtime` scope mutates selected dependency-injection, verification, and diagnostic
+logic in `NexusLabs.Needlr`, using `NexusLabs.Needlr.Tests`.
+
+The `generators` scope mutates selected authored helper and emitter files in
+`NexusLabs.Needlr.Generators`, using focused tests in
+`NexusLabs.Needlr.Generators.Tests` that invoke Roslyn generators at runtime. It does
+not attempt to mutate generated syntax trees. Analyzer projects and the full generator
+project remain outside the initial scope until their cost and signal are measured
+separately.
+
+Both scopes use the stable VSTest runner, Standard mutation level, per-test coverage
+analysis, concurrency two, and explicit file lists. Each uses `thresholds.break = 0`.
+A low score is therefore advisory; Stryker setup failures, compilation failures, and
+initial test failures still return failure.
+
+The mutation workflow:
+
+- runs affected scopes for ready pull requests;
+- runs both scopes weekly and on manual dispatch;
+- is declared non-required in the delivery contract;
+- routes trusted runs through Needlr's configured CI runner and external forks through
+  GitHub-hosted runners;
+- writes Markdown results to the GitHub job summary and leaves JSON/Markdown reports
+  ephemeral on the runner;
+- does not upload artifacts and does not enable the Stryker dashboard.
+
+Regular CI validates the tool pin, bounded configs, score policy, workflow triggers,
+fork routing, artifact prohibition, and change classifier.
+
+## Alternatives considered
+
+### Mutate the complete solution immediately
+
+A complete run would maximize breadth and avoid selecting initial scopes. It was
+rejected because Stryker mutates one project at a time, Needlr has many projects, and
+the runtime and survivor volume would be unknown. A broad aggregate score would also
+hide which subsystem needs stronger tests.
+
+### Exclude source-generator implementation code
+
+This avoids Roslyn-specific uncertainty. It was rejected because Stryker reruns source
+generators during mutant compilation, and Needlr already has tests that invoke generator
+drivers directly. A bounded authored-generator scope provides useful evidence without
+claiming that generated output itself is mutated.
+
+### Use the preview Microsoft Testing Platform runner
+
+Needlr targets modern .NET and xUnit v3, so MTP is plausible and may eventually improve
+performance. It was rejected for the first integration because Stryker's MTP runner is
+still documented as preview with incomplete per-test filtering. Needlr already carries
+the VSTest adapter, making VSTest the lower-risk baseline.
+
+### Add a mutation threshold immediately
+
+Any positive break threshold would create a gate before the repository has classified
+survivors, uncovered mutants, compile errors, and equivalents. It was rejected. A later
+decision may ratchet one measured scope after triage.
+
+### Persist reports or baselines
+
+GitHub artifacts, dashboard uploads, or disk-baseline caches would improve report
+retention or incremental execution. They were rejected because the initial requirement
+forbids additional artifact storage, dashboard upload would cross a new external data
+boundary, and disk baselines have no value on ephemeral runners without persistence.
+
+## Consequences
+
+### Positive
+
+- Needlr gains direct evidence about assertion strength in runtime and generator code.
+- Source generation is exercised through the same Roslyn runtime tests that own its
+  behavior.
+- Pull-request cost is limited by path classification and bounded source lists.
+- Mutation score is visible without prematurely blocking delivery.
+- No new GitHub artifact storage or external reporting service is required.
+
+### Negative
+
+- Initial mutation coverage is intentionally incomplete.
+- VSTest may be slower than the preview MTP runner.
+- Reports disappear with the runner after their summary has been written.
+- Surviving mutants require human triage before any threshold can be justified.
+
+### Neutral
+
+- Mutation testing remains separate from the required `CI` summary.
+- Normal unit, integration, package, and Native AOT checks remain the correctness and
+  delivery gates.
+- A future expansion can add scopes or thresholds without changing the source-generation
+  model established here.
+
+## Confirmation
+
+`scripts/test-mutation.ps1` validates the pinned tool, explicit scopes, VSTest selection,
+Standard mutation level, zero break thresholds, local reporters, workflow cadence,
+non-required delivery declaration, fork routing, and prohibition on artifact/dashboard
+publication.
+
+The first ready pull-request run must demonstrate that both Stryker scopes complete on
+the repository runner, emit non-empty reports, append readable GitHub job summaries, and
+do not upload artifacts. Its measured duration and mutant outcomes become the evidence
+for survivor triage and any future scope-specific threshold.
+
+## References
+
+- Stryker.NET configuration documents project selection, mutate globs, VSTest/MTP
+  runners, coverage analysis, concurrency, reporters, and threshold behavior:
+  <https://stryker-mutator.io/docs/stryker-net/configuration/>.
+- Stryker.NET reporter documentation defines local JSON and Markdown reporters and the
+  separate dashboard upload boundary:
+  <https://stryker-mutator.io/docs/stryker-net/reporters/>.
+- Stryker.NET 4.16.0 is the pinned mutation tool:
+  <https://github.com/stryker-mutator/stryker-net/releases/tag/dotnet-stryker%404.16.0>.

--- a/docs/testing/evaluations-and-benchmarks.md
+++ b/docs/testing/evaluations-and-benchmarks.md
@@ -4,6 +4,47 @@ Needlr uses deterministic tests to protect behavior and BenchmarkDotNet measurem
 to evaluate performance. Tests remain the correctness authority; benchmarks compare
 equivalent production paths after correctness is established.
 
+## Mutation testing
+
+Stryker.NET measures whether focused tests detect meaningful changes to authored
+production code. It supplements normal tests; it does not replace them or prove that
+behavior is correct.
+
+Needlr starts with two bounded scopes:
+
+- `runtime` mutates selected dependency-injection and verification logic in
+  `NexusLabs.Needlr`;
+- `generators` mutates selected authored helpers and code emitters in
+  `NexusLabs.Needlr.Generators`.
+
+Roslyn-generated syntax trees are not direct mutation targets. Stryker mutates the
+generator's authored input syntax trees, reruns the source generators while compiling
+the mutant, and then executes tests. The generator scope therefore uses tests that
+invoke Roslyn generators at runtime; consumer projects that only compiled generated
+output before the mutation run would not provide equivalent evidence.
+
+Run both scopes locally:
+
+```powershell
+dotnet tool restore
+pwsh scripts/run-mutation-tests.ps1
+```
+
+Run one scope with `-Scope runtime` or `-Scope generators`. Reports are written under
+`artifacts/mutation/`, which is ignored by git.
+
+The mutation workflow is advisory and is not a required pull-request check. It runs
+affected scopes on ready pull requests, both scopes on a weekly schedule, and both
+scopes when dispatched manually. Each configuration uses `thresholds.break = 0`, so a
+low mutation score is reported but does not fail the workflow. Tool failures, build
+failures, and initial test failures still fail loudly.
+
+Mutation JSON and Markdown reports are ephemeral runner files. The workflow copies the
+Markdown summary into the GitHub job summary and does not upload GitHub artifacts or
+send results to the Stryker dashboard. A future threshold must be based on a reviewed,
+post-triage baseline for that exact scope rather than an arbitrary repository-wide
+percentage.
+
 ## Benchmark harnesses
 
 Benchmark methods contain only the production call under test. Setup, data generation,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -203,6 +203,7 @@ nav:
     - ADR-0008 Own a Version-Aware Agent Marketplace: adr/adr-0008-own-version-aware-agent-marketplace.md
     - ADR-0009 Stage Release Publication: adr/adr-0009-stage-release-publication.md
     - ADR-0010 Own a Repository Runner Image: adr/adr-0010-own-repository-runner-image.md
+    - ADR-0011 Adopt Advisory Mutation Testing: adr/adr-0011-adopt-advisory-mutation-testing.md
 
 plugins:
   - search

--- a/scripts/get-mutation-scope.ps1
+++ b/scripts/get-mutation-scope.ps1
@@ -1,0 +1,104 @@
+<#
+.SYNOPSIS
+    Classifies changed files for Needlr mutation testing.
+
+.DESCRIPTION
+    Mutation tooling and shared build changes run both scopes. Runtime and generator
+    source or test changes run only their corresponding scope. Manual and scheduled
+    workflows force both scopes.
+#>
+param(
+    [string]$BaseSha,
+    [string]$HeadSha,
+    [string[]]$ChangedPaths,
+    [switch]$ForceAll,
+    [switch]$NoCiOutput
+)
+
+$ErrorActionPreference = 'Stop'
+
+$sharedPatterns = @(
+    '^\.config/dotnet-tools\.json$',
+    '^\.github/workflows/mutation-testing\.yml$',
+    '^global\.json$',
+    '^scripts/get-mutation-scope\.ps1$',
+    '^scripts/run-mutation-tests\.ps1$',
+    '^scripts/test-mutation\.ps1$',
+    '^scripts/mutation/',
+    '^src/Directory\.Build\.props$',
+    '^src/Directory\.Packages\.props$'
+)
+$runtimePatterns = @(
+    '^src/NexusLabs\.Needlr/',
+    '^src/NexusLabs\.Needlr\.Tests/'
+)
+$generatorPatterns = @(
+    '^src/NexusLabs\.Needlr\.Generators/',
+    '^src/NexusLabs\.Needlr\.Generators\.Attributes/',
+    '^src/NexusLabs\.Needlr\.Generators\.Tests/'
+)
+
+function Test-AnyPattern {
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)][string[]]$Patterns
+    )
+
+    return $null -ne (
+        $Patterns |
+            Where-Object { $Path -match $_ } |
+            Select-Object -First 1)
+}
+
+if ($ForceAll -or $BaseSha -match '^0+$') {
+    $runtimeRequired = $true
+    $generatorsRequired = $true
+    $paths = @()
+} else {
+    if ($null -eq $ChangedPaths) {
+        if ([string]::IsNullOrWhiteSpace($BaseSha) -or
+            [string]::IsNullOrWhiteSpace($HeadSha)) {
+            throw 'BaseSha and HeadSha are required when ChangedPaths is not supplied.'
+        }
+
+        $diffOutput = & git diff --name-only "$BaseSha...$HeadSha" 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            throw "Could not determine changed files.`n$($diffOutput | Out-String)"
+        }
+        $paths = @($diffOutput | Where-Object { $_ })
+    } else {
+        $paths = @($ChangedPaths | Where-Object { $_ })
+    }
+
+    $normalizedPaths = @($paths | ForEach-Object { $_.Replace('\', '/') })
+    $sharedChanged = $null -ne (
+        $normalizedPaths |
+            Where-Object { Test-AnyPattern -Path $_ -Patterns $sharedPatterns } |
+            Select-Object -First 1)
+    $runtimeRequired = $sharedChanged -or $null -ne (
+        $normalizedPaths |
+            Where-Object { Test-AnyPattern -Path $_ -Patterns $runtimePatterns } |
+            Select-Object -First 1)
+    $generatorsRequired = $sharedChanged -or $null -ne (
+        $normalizedPaths |
+            Where-Object { Test-AnyPattern -Path $_ -Patterns $generatorPatterns } |
+            Select-Object -First 1)
+}
+
+$result = [ordered]@{
+    runtime_required = $runtimeRequired
+    generators_required = $generatorsRequired
+    changed_count = $paths.Count
+}
+
+if (-not $NoCiOutput -and
+    -not [string]::IsNullOrWhiteSpace($env:GITHUB_OUTPUT)) {
+    Add-Content `
+        -Path $env:GITHUB_OUTPUT `
+        -Value "runtime_required=$($runtimeRequired.ToString().ToLowerInvariant())"
+    Add-Content `
+        -Path $env:GITHUB_OUTPUT `
+        -Value "generators_required=$($generatorsRequired.ToString().ToLowerInvariant())"
+}
+
+$result | ConvertTo-Json -Compress

--- a/scripts/mutation/stryker-generators.json
+++ b/scripts/mutation/stryker-generators.json
@@ -1,0 +1,30 @@
+{
+  "stryker-config": {
+    "project": "NexusLabs.Needlr.Generators.csproj",
+    "test-runner": "vstest",
+    "configuration": "Release",
+    "mutation-level": "Standard",
+    "coverage-analysis": "perTest",
+    "concurrency": 2,
+    "mutate": [
+      "GeneratorHelpers.cs",
+      "TypedConstantRenderer.cs",
+      "BreadcrumbWriter.cs",
+      "CodeGen/BootstrapCodeGenerator.cs",
+      "CodeGen/EmptyTypeRegistryCodeGenerator.cs"
+    ],
+    "test-case-filter": "FullyQualifiedName~GeneratorHelpersTests|FullyQualifiedName~TypedConstantRendererTests|FullyQualifiedName~BreadcrumbTests|FullyQualifiedName~BootstrapCodeGeneratorRuntimeTests|FullyQualifiedName~TypeRegistryGeneratorTests",
+    "reporters": [
+      "progress",
+      "json",
+      "markdown"
+    ],
+    "report-file-name": "mutation-report",
+    "thresholds": {
+      "high": 80,
+      "low": 60,
+      "break": 0
+    },
+    "break-on-initial-test-failure": true
+  }
+}

--- a/scripts/mutation/stryker-runtime.json
+++ b/scripts/mutation/stryker-runtime.json
@@ -1,0 +1,29 @@
+{
+  "stryker-config": {
+    "project": "NexusLabs.Needlr.csproj",
+    "test-runner": "vstest",
+    "configuration": "Release",
+    "mutation-level": "Standard",
+    "coverage-analysis": "perTest",
+    "concurrency": 2,
+    "mutate": [
+      "ServiceCollectionExtensions.cs",
+      "ServiceProviderExtensions.cs",
+      "ServiceCollectionVerificationExtensions.cs",
+      "LifetimeMismatchExtensions.cs",
+      "DumpExtensions.cs"
+    ],
+    "reporters": [
+      "progress",
+      "json",
+      "markdown"
+    ],
+    "report-file-name": "mutation-report",
+    "thresholds": {
+      "high": 80,
+      "low": 60,
+      "break": 0
+    },
+    "break-on-initial-test-failure": true
+  }
+}

--- a/scripts/run-mutation-tests.ps1
+++ b/scripts/run-mutation-tests.ps1
@@ -1,0 +1,147 @@
+<#
+.SYNOPSIS
+    Runs one or both bounded Needlr mutation-testing scopes.
+
+.PARAMETER Scope
+    The runtime, generators, or all mutation scope.
+
+.PARAMETER OutputPath
+    Report root. Defaults to artifacts/mutation under the repository.
+#>
+param(
+    [ValidateSet('runtime', 'generators', 'all')]
+    [string]$Scope = 'all',
+
+    [string]$OutputPath
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+if ([string]::IsNullOrWhiteSpace($OutputPath)) {
+    $OutputPath = Join-Path $repoRoot 'artifacts' 'mutation'
+}
+$OutputPath = [IO.Path]::GetFullPath($OutputPath)
+
+$definitions = @(
+    [PSCustomObject]@{
+        Name = 'runtime'
+        WorkingDirectory = Join-Path $repoRoot 'src' 'NexusLabs.Needlr.Tests'
+        ConfigPath = Join-Path $PSScriptRoot 'mutation' 'stryker-runtime.json'
+    },
+    [PSCustomObject]@{
+        Name = 'generators'
+        WorkingDirectory = Join-Path $repoRoot 'src' 'NexusLabs.Needlr.Generators.Tests'
+        ConfigPath = Join-Path $PSScriptRoot 'mutation' 'stryker-generators.json'
+    }
+)
+if ($Scope -ne 'all') {
+    $definitions = @($definitions | Where-Object Name -eq $Scope)
+}
+
+Push-Location $repoRoot
+try {
+    & dotnet tool restore
+    if ($LASTEXITCODE -ne 0) {
+        throw "dotnet tool restore failed with exit code $LASTEXITCODE."
+    }
+} finally {
+    Pop-Location
+}
+
+$summaries = foreach ($definition in $definitions) {
+    $scopeOutput = Join-Path $OutputPath $definition.Name
+    if (Test-Path -LiteralPath $scopeOutput) {
+        throw (
+            "Mutation output already exists at '$scopeOutput'. " +
+            'Choose a new OutputPath or remove that scope directory explicitly.')
+    }
+
+    Write-Host "Running Stryker.NET scope '$($definition.Name)'..." -ForegroundColor Cyan
+    $relativeConfigPath = [IO.Path]::GetRelativePath(
+        $definition.WorkingDirectory,
+        $definition.ConfigPath)
+    Push-Location $definition.WorkingDirectory
+    try {
+        & dotnet stryker `
+            --config-file $relativeConfigPath `
+            --output $scopeOutput `
+            --skip-version-check
+        if ($LASTEXITCODE -ne 0) {
+            throw "Stryker.NET scope '$($definition.Name)' failed with exit code $LASTEXITCODE."
+        }
+    } finally {
+        Pop-Location
+    }
+
+    $reportDirectory = Join-Path $scopeOutput 'reports'
+    $jsonPath = Join-Path $reportDirectory 'mutation-report.json'
+    $markdownPath = Join-Path $reportDirectory 'mutation-report.md'
+    if (-not (Test-Path -LiteralPath $jsonPath -PathType Leaf)) {
+        throw "Stryker.NET scope '$($definition.Name)' did not produce $jsonPath."
+    }
+    if (-not (Test-Path -LiteralPath $markdownPath -PathType Leaf)) {
+        throw "Stryker.NET scope '$($definition.Name)' did not produce $markdownPath."
+    }
+
+    $report = Get-Content -LiteralPath $jsonPath -Raw | ConvertFrom-Json
+    $mutants = @(
+        $report.files.PSObject.Properties |
+            ForEach-Object { @($_.Value.mutants) })
+    if ($mutants.Count -eq 0) {
+        throw "Stryker.NET scope '$($definition.Name)' produced no mutants."
+    }
+
+    $counts = [ordered]@{
+        Killed = 0
+        Survived = 0
+        NoCoverage = 0
+        Timeout = 0
+        CompileError = 0
+        RuntimeError = 0
+        Ignored = 0
+    }
+    foreach ($group in ($mutants | Group-Object status | Sort-Object Name)) {
+        $counts[$group.Name] = $group.Count
+    }
+
+    $detected = $counts.Killed + $counts.Timeout
+    $undetected = $counts.Survived + $counts.NoCoverage
+    $score = if ($detected + $undetected -eq 0) {
+        $null
+    } else {
+        [Math]::Round(($detected * 100.0) / ($detected + $undetected), 2)
+    }
+
+    $summary = [ordered]@{
+        scope = $definition.Name
+        totalMutants = $mutants.Count
+        mutationScore = $score
+        counts = $counts
+        reportDirectory = $reportDirectory
+    }
+    $summaryPath = Join-Path $scopeOutput 'mutation-summary.json'
+    [IO.File]::WriteAllText(
+        $summaryPath,
+        (ConvertTo-Json $summary -Depth 5) + "`n",
+        [Text.UTF8Encoding]::new($false))
+
+    Write-Host (
+        "Scope '$($definition.Name)': score=$score; " +
+        "killed=$($counts.Killed); survived=$($counts.Survived); " +
+        "no-coverage=$($counts.NoCoverage); compile-errors=$($counts.CompileError).")
+
+    if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_STEP_SUMMARY)) {
+        Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Value (
+            "## Mutation testing: $($definition.Name)`n")
+        Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Value (
+            "_Advisory score: `thresholds.break` is `0`; mutation score does not gate this workflow._`n")
+        Get-Content -LiteralPath $markdownPath |
+            Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY
+        Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Value "`n"
+    }
+
+    [PSCustomObject]$summary
+}
+
+$summaries

--- a/scripts/test-mutation.ps1
+++ b/scripts/test-mutation.ps1
@@ -1,0 +1,166 @@
+<#
+.SYNOPSIS
+    Validates Needlr's advisory mutation-testing contract.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$toolManifestPath = Join-Path $repoRoot '.config\dotnet-tools.json'
+$runtimeConfigPath = Join-Path $PSScriptRoot 'mutation\stryker-runtime.json'
+$generatorConfigPath = Join-Path $PSScriptRoot 'mutation\stryker-generators.json'
+$runnerPath = Join-Path $PSScriptRoot 'run-mutation-tests.ps1'
+$classifierPath = Join-Path $PSScriptRoot 'get-mutation-scope.ps1'
+$workflowPath = Join-Path $repoRoot '.github\workflows\mutation-testing.yml'
+$deliveryPath = Join-Path $repoRoot '.github\genesis-delivery.json'
+
+function Assert-Condition {
+    param(
+        [Parameter(Mandatory)][bool]$Condition,
+        [Parameter(Mandatory)][string]$Message
+    )
+
+    if (-not $Condition) {
+        throw $Message
+    }
+}
+
+function Assert-PowerShellSyntax {
+    param([Parameter(Mandatory)][string]$Path)
+
+    $tokens = $null
+    $parseErrors = $null
+    [void][System.Management.Automation.Language.Parser]::ParseFile(
+        $Path,
+        [ref]$tokens,
+        [ref]$parseErrors)
+    Assert-Condition `
+        -Condition ($parseErrors.Count -eq 0) `
+        -Message "$Path has PowerShell parse errors: $($parseErrors.Message -join '; ')"
+}
+
+foreach ($path in @(
+        $toolManifestPath,
+        $runtimeConfigPath,
+        $generatorConfigPath,
+        $runnerPath,
+        $classifierPath,
+        $workflowPath,
+        $deliveryPath)) {
+    Assert-Condition `
+        -Condition (Test-Path -LiteralPath $path -PathType Leaf) `
+        -Message "Mutation-testing surface is missing: $path"
+}
+
+$toolManifest = Get-Content -LiteralPath $toolManifestPath -Raw | ConvertFrom-Json
+$strykerTool = $toolManifest.tools.'dotnet-stryker'
+Assert-Condition `
+    -Condition ([string]$strykerTool.version -ceq '4.16.0') `
+    -Message 'dotnet-stryker must be pinned to 4.16.0.'
+Assert-Condition `
+    -Condition ((@($strykerTool.commands) -join ',') -ceq 'dotnet-stryker') `
+    -Message 'The local tool manifest must expose the dotnet-stryker command.'
+
+foreach ($entry in @(
+        [PSCustomObject]@{
+            Name = 'runtime'
+            Path = $runtimeConfigPath
+            Project = 'NexusLabs.Needlr.csproj'
+        },
+        [PSCustomObject]@{
+            Name = 'generators'
+            Path = $generatorConfigPath
+            Project = 'NexusLabs.Needlr.Generators.csproj'
+        })) {
+    $config = (
+        Get-Content -LiteralPath $entry.Path -Raw |
+            ConvertFrom-Json).'stryker-config'
+    Assert-Condition `
+        -Condition ([string]$config.project -ceq $entry.Project) `
+        -Message "The $($entry.Name) scope targets the wrong project."
+    Assert-Condition `
+        -Condition ([string]$config.'test-runner' -ceq 'vstest') `
+        -Message "The $($entry.Name) scope must use the stable VSTest runner."
+    Assert-Condition `
+        -Condition ([string]$config.'mutation-level' -ceq 'Standard') `
+        -Message "The $($entry.Name) scope must use Standard mutation level."
+    Assert-Condition `
+        -Condition ([int]$config.thresholds.break -eq 0) `
+        -Message "The $($entry.Name) scope must remain score-nonblocking."
+    Assert-Condition `
+        -Condition (
+            @($config.reporters) -contains 'json' -and
+            @($config.reporters) -contains 'markdown' -and
+            @($config.reporters) -notcontains 'dashboard') `
+        -Message "The $($entry.Name) scope must report locally without the dashboard."
+    Assert-Condition `
+        -Condition (@($config.mutate).Count -gt 0) `
+        -Message "The $($entry.Name) scope must remain explicitly bounded."
+}
+
+Assert-PowerShellSyntax -Path $runnerPath
+Assert-PowerShellSyntax -Path $classifierPath
+
+$workflow = Get-Content -LiteralPath $workflowPath -Raw
+Assert-Condition `
+    -Condition (
+        $workflow -match '(?m)^  pull_request:\r?$' -and
+        $workflow -match '(?m)^  workflow_dispatch:\r?$' -and
+        $workflow -match '(?m)^  schedule:\r?$') `
+    -Message 'Mutation testing must support ready PR, manual, and scheduled execution.'
+Assert-Condition `
+    -Condition ($workflow -notmatch 'actions/upload-artifact|dashboard') `
+    -Message 'Mutation testing must not upload artifacts or use the Stryker dashboard.'
+Assert-Condition `
+    -Condition ($workflow -notmatch 'continue-on-error') `
+    -Message 'Mutation tool, build, and initial-test failures must remain visible.'
+Assert-Condition `
+    -Condition ($workflow -match 'github\.event\.pull_request\.draft == false') `
+    -Message 'Mutation testing must not occupy runners for draft pull requests.'
+Assert-Condition `
+    -Condition ($workflow -match 'head\.repo\.full_name != github\.repository') `
+    -Message 'External fork mutation runs must use GitHub-hosted infrastructure.'
+
+$runtimeOnly = (
+    & $classifierPath `
+        -ChangedPaths @('src/NexusLabs.Needlr/TypeExtensions.cs') `
+        -NoCiOutput |
+        ConvertFrom-Json)
+Assert-Condition `
+    -Condition (
+        $runtimeOnly.runtime_required -and
+        -not $runtimeOnly.generators_required) `
+    -Message 'Runtime changes must select only runtime mutation testing.'
+
+$generatorsOnly = (
+    & $classifierPath `
+        -ChangedPaths @('src/NexusLabs.Needlr.Generators/GeneratorHelpers.cs') `
+        -NoCiOutput |
+        ConvertFrom-Json)
+Assert-Condition `
+    -Condition (
+        -not $generatorsOnly.runtime_required -and
+        $generatorsOnly.generators_required) `
+    -Message 'Generator changes must select only generator mutation testing.'
+
+$shared = (
+    & $classifierPath `
+        -ChangedPaths @('scripts/mutation/stryker-runtime.json') `
+        -NoCiOutput |
+        ConvertFrom-Json)
+Assert-Condition `
+    -Condition ($shared.runtime_required -and $shared.generators_required) `
+    -Message 'Shared mutation tooling changes must select both scopes.'
+
+$delivery = Get-Content -LiteralPath $deliveryPath -Raw | ConvertFrom-Json
+$component = @($delivery.componentWorkflows) |
+    Where-Object path -eq '.github/workflows/mutation-testing.yml' |
+    Select-Object -First 1
+Assert-Condition `
+    -Condition ($null -ne $component) `
+    -Message 'The delivery contract must declare the mutation workflow.'
+Assert-Condition `
+    -Condition (@($component.requiredChecks).Count -eq 0) `
+    -Message 'Mutation testing must remain outside required branch checks.'
+
+Write-Host 'Mutation testing contract validation passed.' -ForegroundColor Green


### PR DESCRIPTION
## Summary
- pin Stryker.NET 4.16.0 as a repository-local tool
- add bounded runtime-core and authored source-generator mutation scopes
- run affected scopes for ready pull requests and both scopes on weekly/manual runs
- publish advisory Markdown summaries without GitHub artifacts or dashboard uploads
- keep mutation score nonblocking with `thresholds.break = 0`
- record the source-generation behavior and initial policy in ADR-0011

## Source-generation behavior
Stryker mutates authored generator input syntax trees and reruns Roslyn source generators while compiling mutants. Generated syntax trees are not direct mutation targets. The generator scope therefore targets authored helpers and emitters and uses tests that invoke generator drivers at runtime.

The first integration deliberately excludes analyzer projects and the rest of the 17,000-line generator project until the bounded scope has measured runtime and survivor evidence.

## Validation
- mutation testing contract: passed
- runner routing contract: passed
- CI scope classifier: passed
- delivery JSON schema: passed
- workflow YAML parsing: passed
- strict MkDocs build: passed
- local tool restore: `dotnet-stryker` 4.16.0 restored successfully

## Readiness gaps
- the two real Stryker runs have not yet executed; they are intentionally deferred to the ready-state pull-request workflow on PitCrew
- no mutation threshold is proposed until survivors, uncovered mutants, compile errors, and hosted duration are reviewed
- mutation reports are intentionally ephemeral and are not uploaded as artifacts