### PR TITLE
fix(hosting): register generated options in hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 - CI/CD now runs exclusively on standard GitHub-hosted runners with a committed label allowlist and one-day explicit artifact retention.
 
+### Fixed
+
+- Generic hosts built through `ForHost().BuildHost()` now invoke source-generated options and extension registrars with the host configuration, matching the service-provider and web-application composition paths. Generated `[Options]` values bind before hosted services start, and `ValidateOnStart` failures now stop host startup.
+
 ### Removed
 
 - Removed PitCrew routing, self-hosted runner profiles, the repository-owned runner image, and the `CI_RUNNER` workflow contract.

--- a/src/NexusLabs.Needlr.AspNet/WebApplicationSyringe.cs
+++ b/src/NexusLabs.Needlr.AspNet/WebApplicationSyringe.cs
@@ -96,24 +96,11 @@ public sealed record WebApplicationSyringe
         var additionalAssemblies = BaseSyringe.GetAdditionalAssemblies();
         var userCallbacks = BaseSyringe.GetPostPluginRegistrationCallbacks();
 
-        // Build the full list of post-plugin callbacks. User-registered callbacks
-        // run first, then the source-generated options/extension registrars — the
-        // same ordering <see cref="ConfiguredSyringe.BuildServiceProvider(IConfiguration)"/>
-        // uses on the console path. Without these, <c>[Options]</c>-decorated
-        // classes bound via the generator would never have their
-        // <c>IConfigureOptions&lt;T&gt;</c> registered and every
-        // <c>IOptions&lt;T&gt;.Value</c> would return a default-constructed instance.
-        var callbacksWithExtras = new List<Action<IServiceCollection>>(userCallbacks);
-
-        if (SourceGenRegistry.TryGetOptionsRegistrar(out var optionsRegistrar) && optionsRegistrar is not null)
-        {
-            callbacksWithExtras.Add(services => InvokeWithConfiguration(services, optionsRegistrar));
-        }
-
-        if (SourceGenRegistry.TryGetExtensionRegistrar(out var extensionRegistrar) && extensionRegistrar is not null)
-        {
-            callbacksWithExtras.Add(services => InvokeWithConfiguration(services, extensionRegistrar));
-        }
+        var callbacksWithExtras = ConfiguredSyringe.ComposePostPluginRegistrationCallbacks(
+            userCallbacks,
+            services => ConfiguredSyringe.GetRequiredRegisteredConfiguration(
+                services,
+                nameof(WebApplicationSyringe)));
 
         var serviceProviderBuilder = BaseSyringe.GetOrCreateServiceProviderBuilder(
             serviceCollectionPopulator,
@@ -130,65 +117,6 @@ public sealed record WebApplicationSyringe
         return webApplicationFactory.Create(
             options,
             ConfigureCallback);
-    }
-
-    /// <summary>
-    /// Invokes a source-generated registrar that expects both an
-    /// <see cref="IServiceCollection"/> and an <see cref="IConfiguration"/>.
-    /// </summary>
-    /// <remarks>
-    /// Post-plugin registration callbacks in the web path receive only the
-    /// <see cref="IServiceCollection"/>. The
-    /// <see cref="Microsoft.AspNetCore.Builder.WebApplicationBuilder"/> registers
-    /// its <see cref="IConfiguration"/> into that collection as an
-    /// <see cref="ServiceDescriptor.ImplementationInstance"/> before the callbacks
-    /// fire, so the configuration can be located by scanning descriptors without
-    /// materializing a temporary <see cref="IServiceProvider"/>.
-    /// </remarks>
-    private static void InvokeWithConfiguration(
-        IServiceCollection services,
-        Action<object, object> registrar)
-    {
-        var configuration = FindRegisteredConfiguration(services)
-            ?? throw new InvalidOperationException(
-                "WebApplicationSyringe could not locate an IConfiguration in the service " +
-                "collection when invoking a source-generated registrar. This usually means " +
-                "the WebApplicationBuilder has not registered IConfiguration yet, which " +
-                "indicates a serious misconfiguration of the host pipeline.");
-
-        registrar(services, configuration);
-    }
-
-    /// <summary>
-    /// Searches <paramref name="services"/> for a previously-registered
-    /// <see cref="IConfiguration"/> instance. Prefers
-    /// <see cref="ServiceDescriptor.ImplementationInstance"/> (the pattern used by
-    /// <see cref="Microsoft.AspNetCore.Builder.WebApplicationBuilder"/>) and falls
-    /// back to building a minimal service provider if only a factory registration
-    /// is present.
-    /// </summary>
-    private static IConfiguration? FindRegisteredConfiguration(IServiceCollection services)
-    {
-        // Walk the descriptors in reverse so the most-recently-registered
-        // IConfiguration wins — mirrors DI's "last registration wins" semantics.
-        for (var i = services.Count - 1; i >= 0; i--)
-        {
-            var descriptor = services[i];
-            if (descriptor.ServiceType != typeof(IConfiguration))
-            {
-                continue;
-            }
-
-            if (descriptor.ImplementationInstance is IConfiguration instance)
-            {
-                return instance;
-            }
-        }
-
-        // Fallback: build a minimal provider just to resolve IConfiguration.
-        // This handles exotic registrations via ImplementationFactory.
-        using var tempProvider = services.BuildServiceProvider();
-        return tempProvider.GetService<IConfiguration>();
     }
 
     /// <summary>

--- a/src/NexusLabs.Needlr.Hosting/HostSyringe.cs
+++ b/src/NexusLabs.Needlr.Hosting/HostSyringe.cs
@@ -90,7 +90,11 @@ public sealed record HostSyringe
         var serviceCollectionPopulator = BaseSyringe.GetOrCreateServiceCollectionPopulator(typeRegistrar, typeFilterer, pluginFactory);
         var assemblyProvider = BaseSyringe.GetOrCreateAssemblyProvider();
         var additionalAssemblies = BaseSyringe.GetAdditionalAssemblies();
-        var callbacks = BaseSyringe.GetPostPluginRegistrationCallbacks();
+        var callbacks = ConfiguredSyringe.ComposePostPluginRegistrationCallbacks(
+            BaseSyringe.GetPostPluginRegistrationCallbacks(),
+            services => ConfiguredSyringe.GetRequiredRegisteredConfiguration(
+                services,
+                nameof(HostSyringe)));
 
         var serviceProviderBuilder = BaseSyringe.GetOrCreateServiceProviderBuilder(
             serviceCollectionPopulator,

--- a/src/NexusLabs.Needlr.Injection/ConfiguredSyringe.cs
+++ b/src/NexusLabs.Needlr.Injection/ConfiguredSyringe.cs
@@ -108,20 +108,9 @@ public sealed record ConfiguredSyringe
         var postCallbacks = PostPluginRegistrationCallbacks ?? [];
         var verificationOptions = VerificationOptions ?? Needlr.VerificationOptions.Default;
 
-        // Build the list of post-plugin callbacks
-        var callbacksWithExtras = new List<Action<IServiceCollection>>(postCallbacks);
-        
-        // Auto-register options from source-generated bootstrap
-        if (SourceGenRegistry.TryGetOptionsRegistrar(out var optionsRegistrar) && optionsRegistrar != null)
-        {
-            callbacksWithExtras.Add(services => optionsRegistrar(services, config));
-        }
-        
-        // Auto-register extensions (e.g., FluentValidation) from source-generated bootstrap
-        if (SourceGenRegistry.TryGetExtensionRegistrar(out var extensionRegistrar) && extensionRegistrar != null)
-        {
-            callbacksWithExtras.Add(services => extensionRegistrar(services, config));
-        }
+        var callbacksWithExtras = ComposePostPluginRegistrationCallbacks(
+            postCallbacks,
+            _ => config);
         
         // Add verification as the final callback
         callbacksWithExtras.Add(services => RunVerification(services, verificationOptions));
@@ -136,6 +125,60 @@ public sealed record ConfiguredSyringe
             config: config,
             preRegistrationCallbacks: [.. preCallbacks],
             postPluginRegistrationCallbacks: callbacksWithExtras);
+    }
+
+    internal static List<Action<IServiceCollection>> ComposePostPluginRegistrationCallbacks(
+        IReadOnlyList<Action<IServiceCollection>> callbacks,
+        Func<IServiceCollection, IConfiguration> configurationResolver)
+    {
+        ArgumentNullException.ThrowIfNull(callbacks);
+        ArgumentNullException.ThrowIfNull(configurationResolver);
+
+        var callbacksWithRegistrars = new List<Action<IServiceCollection>>(callbacks);
+
+        if (SourceGenRegistry.TryGetOptionsRegistrar(out var optionsRegistrar) &&
+            optionsRegistrar is not null)
+        {
+            callbacksWithRegistrars.Add(
+                services => optionsRegistrar(
+                    services,
+                    configurationResolver(services)));
+        }
+
+        if (SourceGenRegistry.TryGetExtensionRegistrar(out var extensionRegistrar) &&
+            extensionRegistrar is not null)
+        {
+            callbacksWithRegistrars.Add(
+                services => extensionRegistrar(
+                    services,
+                    configurationResolver(services)));
+        }
+
+        return callbacksWithRegistrars;
+    }
+
+    internal static IConfiguration GetRequiredRegisteredConfiguration(
+        IServiceCollection services,
+        string compositionPath)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentException.ThrowIfNullOrWhiteSpace(compositionPath);
+
+        for (var index = services.Count - 1; index >= 0; index--)
+        {
+            var descriptor = services[index];
+            if (descriptor.ServiceType == typeof(IConfiguration) &&
+                descriptor.ImplementationInstance is IConfiguration configuration)
+            {
+                return configuration;
+            }
+        }
+
+        using var provider = services.BuildServiceProvider();
+        return provider.GetService<IConfiguration>()
+            ?? throw new InvalidOperationException(
+                $"{compositionPath} could not locate an IConfiguration registration " +
+                "when invoking source-generated registrars.");
     }
 
     private static void RunVerification(IServiceCollection services, VerificationOptions options)

--- a/src/NexusLabs.Needlr.IntegrationTests/SourceGen/OptionsHostSourceGenTests.cs
+++ b/src/NexusLabs.Needlr.IntegrationTests/SourceGen/OptionsHostSourceGenTests.cs
@@ -1,0 +1,133 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+using NexusLabs.Needlr.Generators;
+using NexusLabs.Needlr.Hosting;
+using NexusLabs.Needlr.Injection;
+using NexusLabs.Needlr.Injection.SourceGen;
+
+using Xunit;
+
+namespace NexusLabs.Needlr.IntegrationTests.SourceGen;
+
+public sealed class OptionsHostSourceGenTests
+{
+    [Fact]
+    public async Task Options_HostAndServiceProvider_BindSameConfiguredValues()
+    {
+        var values = new Dictionary<string, string?>
+        {
+            ["GeneratedHostWorker:Enabled"] = "true",
+            ["ValidatedOptions:Name"] = "ValidName",
+            ["ExternallyValidated:Email"] = "valid@example.com"
+        };
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+
+        var provider = CreateSyringe().BuildServiceProvider(configuration);
+        using var host = CreateSyringe()
+            .ForHost()
+            .UsingConfigurationCallback((builder, _) =>
+            {
+                builder.Configuration.AddInMemoryCollection(values);
+                builder.Services.AddSingleton<GeneratedOptionsHostedService>();
+                builder.Services.AddSingleton<IHostedService>(
+                    services => services.GetRequiredService<GeneratedOptionsHostedService>());
+            })
+            .BuildHost();
+
+        var providerOptions = provider
+            .GetRequiredService<IOptions<GeneratedHostWorkerOptions>>()
+            .Value;
+        var hostedService = host.Services
+            .GetRequiredService<GeneratedOptionsHostedService>();
+
+        Assert.True(providerOptions.Enabled, "The service-provider path should bind the configured value.");
+        Assert.Null(hostedService.EnabledAtStart);
+
+        await host.StartAsync(TestContext.Current.CancellationToken);
+
+        Assert.True(
+            hostedService.EnabledAtStart is true,
+            "The host path should bind options before hosted services start.");
+
+        await host.StopAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Options_HostValidationFailure_StopsStartup()
+    {
+        var values = new Dictionary<string, string?>
+        {
+            ["ValidatedOptions:Name"] = "ValidName",
+            ["ExternallyValidated:Email"] = "valid@example.com"
+        };
+        using var host = CreateSyringe()
+            .ForHost()
+            .UsingConfigurationCallback((builder, _) =>
+                builder.Configuration.AddInMemoryCollection(values))
+            .BuildHost();
+
+        var exception = await Assert.ThrowsAsync<OptionsValidationException>(
+            () => host.StartAsync(TestContext.Current.CancellationToken));
+
+        Assert.Contains("Generated host worker must be enabled.", exception.Message);
+    }
+
+    private static ConfiguredSyringe CreateSyringe()
+    {
+        return new Syringe()
+            .UsingGeneratedComponents(
+                NexusLabs.Needlr.IntegrationTests.Generated.TypeRegistry.GetInjectableTypes,
+                NexusLabs.Needlr.IntegrationTests.Generated.TypeRegistry.GetPluginTypes);
+    }
+}
+
+/// <summary>
+/// Provides validated options for generic-host source-generation tests.
+/// </summary>
+[Options("GeneratedHostWorker", ValidateOnStart = true)]
+public sealed record GeneratedHostWorkerOptions
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether the generated host worker is enabled.
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Validates that the generated host worker is enabled.
+    /// </summary>
+    /// <returns>The validation errors.</returns>
+    public IEnumerable<ValidationError> Validate()
+    {
+        if (!Enabled)
+        {
+            yield return "Generated host worker must be enabled.";
+        }
+    }
+}
+
+/// <summary>
+/// Captures the generated options value observed when the host starts.
+/// </summary>
+[DoNotAutoRegister]
+internal sealed class GeneratedOptionsHostedService(
+    IOptions<GeneratedHostWorkerOptions> options) :
+    IHostedService
+{
+    public bool? EnabledAtStart { get; private set; }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        EnabledAtStart = options.Value.Enabled;
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Summary

- compose source-generated options and extension registrar callbacks in one shared path
- apply those callbacks to generic hosts with the `HostApplicationBuilder` configuration
- preserve existing callback ordering for service-provider and web-application composition
- add source-generated host integration tests for bound values before hosted-service startup and `ValidateOnStart` failure

## Verification

- source-generated options integration selection: 41 passed
- `NexusLabs.Needlr.Hosting.Tests`: 98 passed
- `NexusLabs.Needlr.AspNet.Tests`: 84 passed
- `NexusLabs.Needlr.Injection.Tests`: 474 passed
- focused issue regression selection: 2 passed
- `git diff --check`

Fixes #131