### PR TITLE
fix(hosting): surface bootstrapper failures to the process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Changed
 
+- **BREAKING (alpha): `NeedlrBootstrapper.RunAsync` and `NeedlrSerilogBootstrapper.RunAsync` no longer swallow unexpected exceptions.** An unexpected exception is logged once at `Critical` (surfacing as `Fatal` through Serilog), cleanup and log flushing still run in `finally`, and the exception is then rethrown so an unhandled top-level `await` produces a nonzero process exit code. Service managers, containers, and CI smoke tests can therefore detect a worker that never started. Cooperative cancellation through the token passed to `RunAsync`, and clean host shutdown, continue to complete normally with exit code `0`. Callers that intentionally relied on the previous swallow behavior must now catch around their own `RunAsync` call.
 - CI/CD now runs exclusively on standard GitHub-hosted runners with a committed label allowlist and one-day explicit artifact retention.
 
 ### Removed

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -1384,7 +1384,7 @@ These analyzers work with Needlr's registration attributes (`[Singleton]`, `[Sco
 
 1. **Pre-DI bootstrap logger** — a console logger is available before any DI container is built.
 2. **Pre-DI bootstrap configuration** — an `IConfiguration` is available before DI, so bootstrap behavior can be config-driven.
-3. **Top-level exception handling** — unhandled exceptions are logged at `Critical` level and do not rethrow.
+3. **Top-level exception handling** — unexpected exceptions are logged at `Critical` and rethrown after cleanup so an unhandled top-level failure exits nonzero.
 4. **Guaranteed cleanup** — an optional async cleanup delegate runs in `finally` (useful for flushing log sinks).
 
 The callback receives a `NeedlrBootstrapContext` that exposes the bootstrap `ILogger` and `IConfiguration`.
@@ -1410,7 +1410,7 @@ await new NeedlrBootstrapper()
 !!! note
     The `CancellationToken` parameter follows standard .NET async conventions — it comes last and is separate from
     `NeedlrBootstrapContext`. Pass your own `CancellationToken` when you need cooperative cancellation; omit it to
-    use the default.
+    use the default. Requested cancellation completes normally without a critical log.
 
 ### Bootstrap Configuration
 
@@ -1535,8 +1535,8 @@ await new NeedlrSerilogBootstrapper()
 ```
 
 `ctx.Logger` is backed by the configured Serilog pipeline. Omit `.Configure(...)` to use the default console sink.
-All lifecycle guarantees from `NeedlrBootstrapper` apply: exceptions are caught and logged at `Critical`,
-and `Log.CloseAndFlushAsync` is always called in `finally`.
+All lifecycle guarantees from `NeedlrBootstrapper` apply: unexpected exceptions are logged at `Critical`
+and rethrown after `Log.CloseAndFlushAsync` runs, while cooperative cancellation completes normally.
 
 #### Config-driven Serilog bootstrap
 

--- a/docs/serilog.md
+++ b/docs/serilog.md
@@ -205,11 +205,13 @@ await new NeedlrSerilogBootstrapper()
 2. Sets `Log.Logger` globally.
 3. Creates a `SerilogLoggerFactory` and passes it to `NeedlrBootstrapper.UsingLoggerFactory(...)`.
 4. Registers `Log.CloseAndFlushAsync` via `NeedlrBootstrapper.WithCleanup(...)`.
-5. Calls `NeedlrBootstrapper.RunAsync(...)` for exception catching, cleanup, and factory lifetime.
+5. Calls `NeedlrBootstrapper.RunAsync(...)` for exception logging and propagation, cancellation, cleanup, and factory lifetime.
 
 This guarantees:
 
-- Exceptions are caught, logged at `Critical`, and do **not** rethrow.
+- Unexpected exceptions are logged once at `Critical` and rethrown after cleanup, so an
+  unhandled top-level failure produces a nonzero process exit code.
+- Cooperative cancellation completes normally without a critical log.
 - `Log.CloseAndFlushAsync` is called in `finally`, even if the callback throws.
 - `Log.Logger` is available via the static Serilog API throughout the application lifetime.
 

--- a/src/NexusLabs.Needlr.Hosting.Tests/NeedlrBootstrapperTests.cs
+++ b/src/NexusLabs.Needlr.Hosting.Tests/NeedlrBootstrapperTests.cs
@@ -276,11 +276,12 @@ public sealed class NeedlrBootstrapperTests
                     ["Key"] = "BeforeException",
                 }));
 
-        await bootstrapper.RunAsync((ctx, ct) =>
-        {
-            captured = ctx.BootstrapConfiguration;
-            throw new InvalidOperationException("boom");
-        }, TestContext.Current.CancellationToken);
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            bootstrapper.RunAsync((ctx, ct) =>
+            {
+                captured = ctx.BootstrapConfiguration;
+                throw new InvalidOperationException("boom");
+            }, TestContext.Current.CancellationToken));
 
         Assert.NotNull(captured);
         Assert.Equal("BeforeException", captured!["Key"]);
@@ -321,9 +322,10 @@ public sealed class NeedlrBootstrapperTests
                 return Task.CompletedTask;
             });
 
-        await bootstrapper.RunAsync(
-            (ctx, ct) => throw new InvalidOperationException("boom"),
-            TestContext.Current.CancellationToken);
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            bootstrapper.RunAsync(
+                (ctx, ct) => throw new InvalidOperationException("boom"),
+                TestContext.Current.CancellationToken));
 
         Assert.True(cleanupCalled);
     }
@@ -363,30 +365,57 @@ public sealed class NeedlrBootstrapperTests
     // -------------------------------------------------------------------------
 
     [Fact]
-    public async Task RunAsync_DoesNotRethrow_OnException()
+    public async Task RunAsync_Rethrows_OnException()
     {
+        var exception = new InvalidOperationException("unhandled");
         var bootstrapper = new NeedlrBootstrapper()
             .UsingLoggerFactory(new CapturingLoggerFactory());
 
-        // Must not throw
-        await bootstrapper.RunAsync(
-            (ctx, ct) => throw new InvalidOperationException("unhandled"),
-            TestContext.Current.CancellationToken);
+        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            bootstrapper.RunAsync(
+                (ctx, ct) => throw exception,
+                TestContext.Current.CancellationToken));
+
+        Assert.Same(exception, thrown);
     }
 
     [Fact]
-    public async Task RunAsync_LogsCritical_OnException()
+    public async Task RunAsync_LogsCriticalOnce_OnException()
     {
         var factory = new CapturingLoggerFactory();
         var ex = new InvalidOperationException("boom");
         var bootstrapper = new NeedlrBootstrapper()
             .UsingLoggerFactory(factory);
 
-        await bootstrapper.RunAsync(
-            (ctx, ct) => throw ex,
-            TestContext.Current.CancellationToken);
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            bootstrapper.RunAsync(
+                (ctx, ct) => throw ex,
+                TestContext.Current.CancellationToken));
 
-        Assert.Contains(factory.Logger.Logs, e => e.Level == LogLevel.Critical && e.Ex == ex);
+        var criticalLog = Assert.Single(
+            factory.Logger.Logs,
+            entry => entry.Level == LogLevel.Critical);
+        Assert.Same(ex, criticalLog.Ex);
+    }
+
+    [Fact]
+    public async Task RunAsync_RequestedCancellation_CompletesWithoutCriticalLog()
+    {
+        var factory = new CapturingLoggerFactory();
+        using var cancellationTokenSource =
+            CancellationTokenSource.CreateLinkedTokenSource(
+                TestContext.Current.CancellationToken);
+        cancellationTokenSource.Cancel();
+        var bootstrapper = new NeedlrBootstrapper()
+            .UsingLoggerFactory(factory);
+
+        await bootstrapper.RunAsync(
+            (ctx, ct) => Task.FromCanceled(ct),
+            cancellationTokenSource.Token);
+
+        Assert.DoesNotContain(
+            factory.Logger.Logs,
+            entry => entry.Level == LogLevel.Critical);
     }
 }
 

--- a/src/NexusLabs.Needlr.Hosting/NeedlrBootstrapper.cs
+++ b/src/NexusLabs.Needlr.Hosting/NeedlrBootstrapper.cs
@@ -22,8 +22,9 @@ namespace NexusLabs.Needlr.Hosting;
 /// See <see cref="NeedlrBootstrapContext.BootstrapConfiguration"/> for details.
 /// </para>
 /// <para>
-/// Unhandled exceptions from the callback are caught, logged at <c>Critical</c>, and then
-/// swallowed so the process exits cleanly after cleanup.
+/// Unexpected exceptions from the callback are logged at <c>Critical</c> and rethrown
+/// after cleanup so a top-level caller produces a nonzero process exit code. Cooperative
+/// cancellation completes normally without a critical log.
 /// </para>
 /// </remarks>
 /// <example>
@@ -62,7 +63,10 @@ public sealed record NeedlrBootstrapper
     /// <param name="cancellationToken">
     /// Optional cancellation token forwarded to the callback.
     /// </param>
-    /// <returns>A <see cref="Task"/> that completes when the application exits.</returns>
+    /// <returns>
+    /// A <see cref="Task"/> that completes when the application exits normally or through
+    /// cooperative cancellation, and faults after cleanup for an unexpected exception.
+    /// </returns>
     /// <example>
     /// <code>
     /// await new NeedlrBootstrapper().RunAsync(async (ctx, ct) =>
@@ -98,9 +102,17 @@ public sealed record NeedlrBootstrapper
                 cancellationToken)
                 .ConfigureAwait(false);
         }
+        // Cooperative shutdown requested through this token is an intended exit, not a
+        // failure, so it must not log critically or fault the returned task. Any other
+        // cancellation still propagates through the general handler below.
+        catch (OperationCanceledException)
+            when (cancellationToken.IsCancellationRequested)
+        {
+        }
         catch (Exception ex)
         {
-            logger.LogCritical(ex, "Application terminated unexpectedly.");
+            NeedlrBootstrapperLog.ApplicationTerminatedUnexpectedly(logger, ex);
+            throw;
         }
         finally
         {

--- a/src/NexusLabs.Needlr.Hosting/NeedlrBootstrapperLog.cs
+++ b/src/NexusLabs.Needlr.Hosting/NeedlrBootstrapperLog.cs
@@ -1,0 +1,16 @@
+using Microsoft.Extensions.Logging;
+
+namespace NexusLabs.Needlr.Hosting;
+
+/// <summary>
+/// Provides generated logging for <see cref="NeedlrBootstrapper"/>.
+/// </summary>
+internal static partial class NeedlrBootstrapperLog
+{
+    [LoggerMessage(
+        Level = LogLevel.Critical,
+        Message = "Application terminated unexpectedly.")]
+    internal static partial void ApplicationTerminatedUnexpectedly(
+        ILogger logger,
+        Exception exception);
+}

--- a/src/NexusLabs.Needlr.Serilog.Tests/NeedlrSerilogBootstrapperTests.cs
+++ b/src/NexusLabs.Needlr.Serilog.Tests/NeedlrSerilogBootstrapperTests.cs
@@ -1,6 +1,8 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
+using Serilog.Events;
+
 using Xunit;
 
 namespace NexusLabs.Needlr.Serilog.Tests;
@@ -329,23 +331,97 @@ public sealed class NeedlrSerilogBootstrapperTests
     // -------------------------------------------------------------------------
 
     [Fact]
-    public async Task RunAsync_DoesNotRethrow_OnException()
+    public async Task RunAsync_StartupFailure_LogsOnceAndRethrows()
     {
-        await new NeedlrSerilogBootstrapper()
-            .Configure(cfg => cfg.WriteTo.Sink(new CapturingSink()))
-            .RunAsync(
-                (ctx, ct) => throw new InvalidOperationException("boom"),
-                TestContext.Current.CancellationToken);
+        var sink = new CapturingSink();
+        var exception = new InvalidOperationException("startup failure");
+        var bootstrapper = new NeedlrSerilogBootstrapper()
+            .Configure(cfg => cfg.WriteTo.Sink(sink));
+
+        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            bootstrapper.RunAsync(
+                (ctx, ct) => throw exception,
+                TestContext.Current.CancellationToken));
+
+        Assert.Same(exception, thrown);
+        var fatalEvent = Assert.Single(
+            sink.Events,
+            logEvent => logEvent.Level == LogEventLevel.Fatal);
+        Assert.Same(exception, fatalEvent.Exception);
     }
 
     [Fact]
-    public async Task RunAsync_DoesNotRethrow_OnSerilogConfigurationFailure()
+    public async Task RunAsync_RuntimeFailure_LogsOnceAndRethrows()
     {
-        // Simulate a broken Configure delegate — should not escape
+        var sink = new CapturingSink();
+        var exception = new InvalidOperationException("runtime failure");
+        var bootstrapper = new NeedlrSerilogBootstrapper()
+            .Configure(cfg => cfg.WriteTo.Sink(sink));
+
+        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            bootstrapper.RunAsync(
+                async (ctx, ct) =>
+                {
+                    await Task.Yield();
+                    throw exception;
+                },
+                TestContext.Current.CancellationToken));
+
+        Assert.Same(exception, thrown);
+        var fatalEvent = Assert.Single(
+            sink.Events,
+            logEvent => logEvent.Level == LogEventLevel.Fatal);
+        Assert.Same(exception, fatalEvent.Exception);
+    }
+
+    [Fact]
+    public async Task RunAsync_RequestedCancellation_CompletesWithoutFatalLog()
+    {
+        var sink = new CapturingSink();
+        using var cancellationTokenSource =
+            CancellationTokenSource.CreateLinkedTokenSource(
+                TestContext.Current.CancellationToken);
+        cancellationTokenSource.Cancel();
+
         await new NeedlrSerilogBootstrapper()
-            .Configure(cfg => throw new InvalidOperationException("bad serilog config"))
+            .Configure(cfg => cfg.WriteTo.Sink(sink))
+            .RunAsync(
+                (ctx, ct) => Task.FromCanceled(ct),
+                cancellationTokenSource.Token);
+
+        Assert.DoesNotContain(
+            sink.Events,
+            logEvent => logEvent.Level == LogEventLevel.Fatal);
+    }
+
+    [Fact]
+    public async Task RunAsync_CleanCompletion_CompletesWithoutFatalLog()
+    {
+        var sink = new CapturingSink();
+
+        await new NeedlrSerilogBootstrapper()
+            .Configure(cfg => cfg.WriteTo.Sink(sink))
             .RunAsync(
                 (ctx, ct) => Task.CompletedTask,
                 TestContext.Current.CancellationToken);
+
+        Assert.DoesNotContain(
+            sink.Events,
+            logEvent => logEvent.Level == LogEventLevel.Fatal);
+    }
+
+    [Fact]
+    public async Task RunAsync_SerilogConfigurationFailure_Rethrows()
+    {
+        var exception = new InvalidOperationException("bad serilog config");
+        var bootstrapper = new NeedlrSerilogBootstrapper()
+            .Configure(cfg => throw exception);
+
+        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            bootstrapper.RunAsync(
+                (ctx, ct) => Task.CompletedTask,
+                TestContext.Current.CancellationToken));
+
+        Assert.Same(exception, thrown);
     }
 }

--- a/src/NexusLabs.Needlr.Serilog/NeedlrSerilogBootstrapper.cs
+++ b/src/NexusLabs.Needlr.Serilog/NeedlrSerilogBootstrapper.cs
@@ -15,8 +15,9 @@ namespace NexusLabs.Needlr.Serilog;
 /// <remarks>
 /// <para>
 /// <see cref="NeedlrSerilogBootstrapper"/> composes <see cref="NeedlrBootstrapper"/> internally.
-/// All lifecycle behaviour (exception catching, cleanup, logger factory ownership) is delegated
-/// to <see cref="NeedlrBootstrapper"/> — this type only adds Serilog-specific wiring:
+/// All lifecycle behaviour (exception logging and propagation, cancellation, cleanup, and logger
+/// factory ownership) is delegated to <see cref="NeedlrBootstrapper"/> — this type only adds
+/// Serilog-specific wiring:
 /// setting <c>Log.Logger</c> before the callback runs and flushing it in <c>finally</c>.
 /// </para>
 /// <para>
@@ -74,7 +75,10 @@ public sealed record NeedlrSerilogBootstrapper
     /// <param name="cancellationToken">
     /// Optional cancellation token forwarded to the callback.
     /// </param>
-    /// <returns>A <see cref="Task"/> that completes when the application exits.</returns>
+    /// <returns>
+    /// A <see cref="Task"/> that completes when the application exits normally or through
+    /// cooperative cancellation, and faults after Serilog flushes for an unexpected exception.
+    /// </returns>
     public async Task RunAsync(
         Func<NeedlrBootstrapContext, CancellationToken, Task> runAsync,
         CancellationToken cancellationToken = default)
@@ -111,13 +115,9 @@ public sealed record NeedlrSerilogBootstrapper
         catch (Exception ex)
         {
             // Serilog configuration failed — fall back to a bare console logger so
-            // the error is visible, then rethrow into the inner bootstrapper's
-            // catch/cleanup path via a wrapper callback.
+            // the inner bootstrapper can log the failure before cleanup and propagation.
             Log.Logger = new LoggerConfiguration().WriteTo.Console().CreateLogger();
-            Log.Fatal(ex, "Failed to configure Serilog bootstrap logger.");
 
-            // Let the inner bootstrapper handle cleanup. The callback will throw
-            // the original exception so it is logged at Critical by NeedlrBootstrapper.
             var capturedEx = ex;
             await RunInnerBootstrapper(
                 bootstrapConfiguration,
@@ -159,11 +159,16 @@ public sealed record NeedlrSerilogBootstrapper
         // same sources — this is acceptable because bootstrap config is cheap
         // and the Serilog config phase is done.
 
-        await inner.RunAsync(runAsync, cancellationToken)
-            .ConfigureAwait(false);
-
-        // Dispose our pre-built config after the inner bootstrapper has
-        // disposed its own copy and completed cleanup.
-        (bootstrapConfiguration as IDisposable)?.Dispose();
+        try
+        {
+            await inner.RunAsync(runAsync, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            // Dispose our pre-built config after the inner bootstrapper has
+            // disposed its own copy and completed cleanup.
+            (bootstrapConfiguration as IDisposable)?.Dispose();
+        }
     }
 }


### PR DESCRIPTION
## Summary

- log an unexpected bootstrapper exception once at `Critical`, run cleanup and Serilog flushing, then rethrow
- an unhandled top-level `await` therefore produces a nonzero process exit code
- cooperative cancellation through the token supplied to `RunAsync`, and clean shutdown, still complete with exit code `0`
- remove the duplicate `Log.Fatal` emitted on the Serilog configuration-failure path so the failure is logged exactly once
- dispose the pre-built bootstrap configuration in `finally` so it is released even when the callback fails

## Behavior change

This is a breaking (alpha) change: `NeedlrBootstrapper.RunAsync` and `NeedlrSerilogBootstrapper.RunAsync` previously swallowed every exception. Callers that intentionally relied on that must now catch around their own `RunAsync` call. Recorded in `CHANGELOG.md` and updated in `docs/serilog.md` and `docs/advanced-usage.md`.

## Verification

Unit/behavior tests:

- `NexusLabs.Needlr.Hosting.Tests`: 99 passed
- `NexusLabs.Needlr.Serilog.Tests`: 37 passed
- `dotnet build src/NexusLabs.Needlr.slnx --configuration Release`: succeeded, 0 errors

End-to-end process exit codes, measured with a throwaway consumer that mirrors a real entry point (`await ...RunAsync(...)`):

| Scenario | Exit code | Critical/Fatal entries |
| --- | ---: | ---: |
| clean completion | 0 | 0 |
| startup failure | -532462766 (`0xE0434352`) | 1 |
| requested cancellation | 0 | 0 |
| Serilog clean completion | 0 | 0 |
| Serilog worker failure | -532462766 (`0xE0434352`) | 1 |

The single logged entry is Needlr's; the second stack trace in the failure output is the .NET runtime's own unhandled-exception report, which is the mechanism that sets the nonzero exit code.

## Delivery notes

- The advisory `Mutation analysis` job is expected to fail on this branch for a reason unrelated to this change: the generated Stryker config serializes `mutate` as a scalar when a scope selects exactly one changed file. That defect is fixed in a separate targeted pull request. Required checks are unaffected.

Fixes #132