### PR TITLE
fix(ci): emit mutate as an array for single-file scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 - CI/CD now runs exclusively on standard GitHub-hosted runners with a committed label allowlist and one-day explicit artifact retention.
 
+### Fixed
+
+- Mutation analysis no longer fails when a pull request changes exactly one file in a scope. The generated Stryker configuration now always emits `mutate` as a JSON array, and the mutation contract test covers both the single-file and multi-file shapes.
+
 ### Removed
 
 - Removed PitCrew routing, self-hosted runner profiles, the repository-owned runner image, and the `CI_RUNNER` workflow contract.

--- a/scripts/run-mutation-tests.ps1
+++ b/scripts/run-mutation-tests.ps1
@@ -13,6 +13,10 @@
 
 .PARAMETER OutputPath
     Report root. Defaults to artifacts/mutation under the repository.
+
+.PARAMETER EmitConfigOnly
+    Writes the generated Stryker configuration and returns its path without
+    running Stryker. Used by the mutation contract test.
 #>
 param(
     [Parameter(Mandatory)]
@@ -23,7 +27,9 @@ param(
 
     [string]$SinceTarget,
 
-    [string]$OutputPath
+    [string]$OutputPath,
+
+    [switch]$EmitConfigOnly
 )
 
 $ErrorActionPreference = 'Stop'
@@ -50,7 +56,10 @@ if (Test-Path -LiteralPath $scopeOutput) {
 }
 
 $maxFiles = [int]$manifest.limits.maxFilesPerScope
-$selectedFiles = if (@($MutateFiles).Count -gt 0) {
+# Declaring the array type is required: assigning from a statement block unwraps a
+# single-element array into a scalar, which Stryker rejects because `mutate` must be
+# a JSON array even when a pull request changes exactly one file in this scope.
+[string[]]$selectedFiles = if (@($MutateFiles).Count -gt 0) {
     @($MutateFiles)
 } else {
     @($definition.priorityFiles | Select-Object -First $maxFiles)
@@ -93,6 +102,10 @@ if (-not [string]::IsNullOrWhiteSpace($SinceTarget)) {
     $configPath,
     (ConvertTo-Json ([ordered]@{ 'stryker-config' = $options }) -Depth 10) + "`n",
     [Text.UTF8Encoding]::new($false))
+
+if ($EmitConfigOnly) {
+    return $configPath
+}
 
 Push-Location $repoRoot
 try {

--- a/scripts/test-mutation.ps1
+++ b/scripts/test-mutation.ps1
@@ -405,4 +405,43 @@ Assert-Condition `
     -Condition (@($component.requiredChecks).Count -eq 0) `
     -Message 'Mutation testing must remain outside required branch checks.'
 
+# A pull request that changes exactly one file in a scope must still produce a JSON
+# array for `mutate`; Stryker rejects a scalar and the whole job fails.
+$configFixture = Join-Path (
+    [IO.Path]::GetTempPath()) (
+    'needlr-mutation-config-' + [guid]::NewGuid().ToString('N'))
+try {
+    foreach ($fileCount in @(1, 2)) {
+        $fixtureFiles = @($manifest.scopes[0].priorityFiles | Select-Object -First $fileCount)
+        Assert-Condition `
+            -Condition (@($fixtureFiles).Count -eq $fileCount) `
+            -Message "Expected $fileCount priority file(s) for the config fixture."
+
+        $emittedConfigPath = & $runnerPath `
+            -Scope ([string]$manifest.scopes[0].name) `
+            -MutateFiles $fixtureFiles `
+            -OutputPath (Join-Path $configFixture "files-$fileCount") `
+            -EmitConfigOnly
+        $emittedConfig = [Text.Json.JsonDocument]::Parse(
+            [IO.File]::ReadAllText([string]$emittedConfigPath))
+        try {
+            $mutateElement = $emittedConfig.RootElement.
+                GetProperty('stryker-config').
+                GetProperty('mutate')
+            Assert-Condition `
+                -Condition ($mutateElement.ValueKind -eq [Text.Json.JsonValueKind]::Array) `
+                -Message "Generated Stryker config must emit 'mutate' as an array for $fileCount file(s)."
+            Assert-Condition `
+                -Condition ($mutateElement.GetArrayLength() -eq $fileCount) `
+                -Message "Generated Stryker config must list all $fileCount selected file(s)."
+        } finally {
+            $emittedConfig.Dispose()
+        }
+    }
+} finally {
+    if (Test-Path -LiteralPath $configFixture) {
+        Remove-Item -LiteralPath $configFixture -Recurse -Force
+    }
+}
+
 Write-Host 'Mutation testing contract validation passed.' -ForegroundColor Green


### PR DESCRIPTION
## Summary

- always emit `mutate` as a JSON array in the generated Stryker configuration
- add a mutation contract regression test covering both the single-file and multi-file shapes

## Problem

Assigning from a PowerShell statement block unwraps a single-element array into a scalar. When a pull request changed exactly one file in a scope, `scripts/run-mutation-tests.ps1` therefore wrote `"mutate": "HostSyringe.cs"` instead of `"mutate": ["HostSyringe.cs"]`, and Stryker rejected the config:

```
The JSON value could not be converted to System.String[].
Path: $.stryker-config.mutate | LineNumber: 8 | BytePositionInLine: 30.
```

The job then failed loudly, as the workflow is designed to do. The original trial run selected five files per scope, so the single-file shape was never exercised until a small pull request appeared. Observed on [PR #134](https://github.com/ncosentino/needlr/pull/134), where both selected scopes changed exactly one file.

This is advisory-only tooling, so required checks were never affected.

## Verification

- `pwsh scripts/test-mutation.ps1`: passes with the fix.
- Same test with the fix temporarily reverted: fails with `Generated Stryker config must emit 'mutate' as an array for 1 file(s).` and exit code 1, confirming the regression test detects the defect rather than passing vacuously.
- `pwsh scripts/test-hosted-runner-policy.ps1`: passes.
- `git diff --check`: clean.

`-EmitConfigOnly` was added to `scripts/run-mutation-tests.ps1` so the contract test can assert the generated configuration shape without invoking Stryker.