### PR TITLE
chore: prepare v0.0.3-alpha.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+## [0.0.3-alpha.6] - 2026-08-22
+
 ### Added
 
 - Added advisory Stryker.NET mutation testing for fourteen directly tested runtime packages. Pull requests select at most two affected project scopes and five changed files per scope, cap each job at ten minutes, report omitted work explicitly, and keep results ephemeral in job summaries and logs without baselines, artifacts, scheduled runs, or an external dashboard.

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.0.3-alpha.5",
+  "version": "0.0.3-alpha.6",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release/v\\d+\\.\\d+",


### PR DESCRIPTION
## Summary

Prepares the `0.0.3-alpha.6` release.

- set `version.json` to `0.0.3-alpha.6` via `nbgv set-version`
- convert the accumulated `## [Unreleased]` content into `## [0.0.3-alpha.6] - 2026-08-22`

No analyzer diagnostics were pending, so no rules moved into a shipped file and there is no `### Shipped analyzers` section.

## Release contents

- **Added:** advisory Stryker.NET mutation testing for fourteen directly tested runtime packages.
- **Changed (BREAKING, alpha):** `NeedlrBootstrapper.RunAsync` and `NeedlrSerilogBootstrapper.RunAsync` no longer swallow unexpected exceptions, so a failed startup now produces a nonzero process exit code.
- **Changed:** CI/CD runs exclusively on standard GitHub-hosted runners.
- **Fixed:** generic hosts now invoke the source-generated options and extension registrars, so `[Options]` values bind before hosted services start.
- **Fixed:** mutation analysis no longer fails when a pull request changes exactly one file in a scope.
- **Removed:** PitCrew routing, self-hosted runner profiles, the repository-owned runner image, and the `CI_RUNNER` workflow contract.

## Verification

- `pwsh scripts/test-release.ps1`: passed
- `dotnet build src/NexusLabs.Needlr.slnx -c Release`: 0 errors
- `pwsh scripts/test-packages.ps1`: passed, including all 40 example projects and the multi-project tests
- `python -m mkdocs build --strict`: passed
- `git diff --check`: clean

The base commit `2f114d1` has a successful `main` CI run, which the tag-only finalization re-verifies independently for the squash-merge commit.