### PR TITLE
docs: bring AGENTS.md within its size budget and enforce it

### DIFF
--- a/.claude/rules/generated/csharp-conventions.md
+++ b/.claude/rules/generated/csharp-conventions.md
@@ -1,0 +1,51 @@
+---
+# AUTO-GENERATED from .github/instructions/csharp-conventions.instructions.md — do not edit
+paths:
+  - "**/*.cs"
+---
+# Needlr C# Conventions
+
+## File layout
+
+- **One type per file.** Never put multiple classes, structs, records, or enums in the same `.cs` file.
+- **File-scoped namespaces** everywhere — `namespace Foo;`, not `namespace Foo { }`.
+- **`internal` by default.** Only types a consumer references directly should be `public`.
+
+## Type selection
+
+- **Data carriers are records.** DTOs, options, contexts, definitions, results, snapshots,
+  evidence, counts, and structured failures must be `record` types, including body-style
+  records with validated constructors. Reserve classes for behavior, mutable runtime
+  state, and services.
+- **Non-static class-only non-services require `[DoNotAutoRegister]`.** Never rely on
+  `required` members, constructor shape, generic arity, visibility, or namespace filters
+  to keep an instantiable class out of Needlr's automatic DI registration.
+
+## Naming
+
+- PascalCase for all public members, types, and namespaces.
+- `_camelCase` for private fields.
+- Diagnostic IDs use the `NDLR` prefix plus a component code: `NDLRCOR` (core),
+  `NDLRGEN` (generators), `NDLRSIG` (SignalR), `NDLRLOG` (logging), `NDLRHTTP` (HttpClient).
+
+## XML documentation
+
+Required on all `public` types and members, using `<summary>`, `<param>`, `<returns>`, and
+`<example>` where appropriate. Internal types need XML docs on the type itself; individual
+members are optional unless non-obvious.
+
+## Design principles
+
+- **Composition over inheritance.** Base classes should be extremely rare and exist only
+  as pure convenience for implementors. Always prefer interfaces plus composition. If a
+  pattern has common boilerplate, solve it with source generation or composable helper
+  types, not an inheritance hierarchy.
+- **Interfaces over static classes.** Static classes are acceptable only for trivial value
+  calculations or extension-method containers. Anything with behavior, state, or
+  dependencies must be an interface registered through DI.
+- **No static singleton holders.** Never use a `static Instance` property, a `static Holder`
+  class, or any pattern that stores a singleton in a static field to share state between
+  components. It destroys testability, breaks multi-threaded scenarios, and is antithetical
+  to dependency injection. Pass dependencies through constructors, method parameters, or
+  DI — never through static state. This is a dependency injection library; use dependency
+  injection.

--- a/.claude/rules/generated/project-files.md
+++ b/.claude/rules/generated/project-files.md
@@ -1,0 +1,38 @@
+---
+# AUTO-GENERATED from .github/instructions/project-files.instructions.md — do not edit
+paths:
+  - "**/*.csproj"
+  - "**/Directory.Packages.props"
+  - "**/Directory.Build.props"
+  - "**/*.slnx"
+---
+# Needlr Project Files
+
+## Central package management
+
+All NuGet package versions are declared in `src/Directory.Packages.props`
+(`ManagePackageVersionsCentrally=true`). Individual `.csproj` files reference packages by
+name only:
+
+```xml
+<!-- CORRECT -->
+<PackageReference Include="Microsoft.Extensions.Logging" />
+
+<!-- WRONG — inline versions bypass central management -->
+<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.3" />
+```
+
+Adding a package means two edits: a `<PackageVersion>` entry in
+`src/Directory.Packages.props` and a `<PackageReference>` in the consuming project.
+
+## Analyzer and generator packages
+
+Reference build-time-only packages with `PrivateAssets="all"` so they do not flow to
+consumers of the produced NuGet package.
+
+## Determinism
+
+`src/Directory.Build.props` sets `<Deterministic>true</Deterministic>` and enables
+`ContinuousIntegrationBuild` under CI. Do not disable either. That flag only constrains the
+compiler — see `generator-determinism.instructions.md` for the rules that keep generated
+source deterministic.

--- a/.github/instructions/csharp-conventions.instructions.md
+++ b/.github/instructions/csharp-conventions.instructions.md
@@ -1,0 +1,50 @@
+---
+applyTo: "**/*.cs"
+---
+
+# Needlr C# Conventions
+
+## File layout
+
+- **One type per file.** Never put multiple classes, structs, records, or enums in the same `.cs` file.
+- **File-scoped namespaces** everywhere — `namespace Foo;`, not `namespace Foo { }`.
+- **`internal` by default.** Only types a consumer references directly should be `public`.
+
+## Type selection
+
+- **Data carriers are records.** DTOs, options, contexts, definitions, results, snapshots,
+  evidence, counts, and structured failures must be `record` types, including body-style
+  records with validated constructors. Reserve classes for behavior, mutable runtime
+  state, and services.
+- **Non-static class-only non-services require `[DoNotAutoRegister]`.** Never rely on
+  `required` members, constructor shape, generic arity, visibility, or namespace filters
+  to keep an instantiable class out of Needlr's automatic DI registration.
+
+## Naming
+
+- PascalCase for all public members, types, and namespaces.
+- `_camelCase` for private fields.
+- Diagnostic IDs use the `NDLR` prefix plus a component code: `NDLRCOR` (core),
+  `NDLRGEN` (generators), `NDLRSIG` (SignalR), `NDLRLOG` (logging), `NDLRHTTP` (HttpClient).
+
+## XML documentation
+
+Required on all `public` types and members, using `<summary>`, `<param>`, `<returns>`, and
+`<example>` where appropriate. Internal types need XML docs on the type itself; individual
+members are optional unless non-obvious.
+
+## Design principles
+
+- **Composition over inheritance.** Base classes should be extremely rare and exist only
+  as pure convenience for implementors. Always prefer interfaces plus composition. If a
+  pattern has common boilerplate, solve it with source generation or composable helper
+  types, not an inheritance hierarchy.
+- **Interfaces over static classes.** Static classes are acceptable only for trivial value
+  calculations or extension-method containers. Anything with behavior, state, or
+  dependencies must be an interface registered through DI.
+- **No static singleton holders.** Never use a `static Instance` property, a `static Holder`
+  class, or any pattern that stores a singleton in a static field to share state between
+  components. It destroys testability, breaks multi-threaded scenarios, and is antithetical
+  to dependency injection. Pass dependencies through constructors, method parameters, or
+  DI — never through static state. This is a dependency injection library; use dependency
+  injection.

--- a/.github/instructions/project-files.instructions.md
+++ b/.github/instructions/project-files.instructions.md
@@ -1,0 +1,34 @@
+---
+applyTo: "**/*.csproj,**/Directory.Packages.props,**/Directory.Build.props,**/*.slnx"
+---
+
+# Needlr Project Files
+
+## Central package management
+
+All NuGet package versions are declared in `src/Directory.Packages.props`
+(`ManagePackageVersionsCentrally=true`). Individual `.csproj` files reference packages by
+name only:
+
+```xml
+<!-- CORRECT -->
+<PackageReference Include="Microsoft.Extensions.Logging" />
+
+<!-- WRONG — inline versions bypass central management -->
+<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.3" />
+```
+
+Adding a package means two edits: a `<PackageVersion>` entry in
+`src/Directory.Packages.props` and a `<PackageReference>` in the consuming project.
+
+## Analyzer and generator packages
+
+Reference build-time-only packages with `PrivateAssets="all"` so they do not flow to
+consumers of the produced NuGet package.
+
+## Determinism
+
+`src/Directory.Build.props` sets `<Deterministic>true</Deterministic>` and enables
+`ContinuousIntegrationBuild` under CI. Do not disable either. That flag only constrains the
+compiler — see `generator-determinism.instructions.md` for the rules that keep generated
+source deterministic.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,11 @@ jobs:
       shell: pwsh
       run: scripts/test-hosted-runner-policy.ps1
 
+    - name: Validate agent root files
+      if: needs.changes.outputs.source_required == 'true'
+      shell: pwsh
+      run: scripts/test-agent-root-files.ps1
+
     - name: Validate mutation testing contract
       if: needs.changes.outputs.source_required == 'true'
       shell: pwsh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,101 +1,49 @@
 # Needlr — AI Agent Instructions
 
-Needlr is an opinionated dependency injection framework for .NET with compile-time source generation as the primary discovery strategy. Reflection is opt-in.
+Needlr is an opinionated dependency injection framework for .NET. Compile-time source
+generation is the primary discovery strategy; reflection is opt-in.
 
-## Build & Test
+## Before you touch anything
 
-```bash
-dotnet build src/NexusLabs.Needlr.slnx
-dotnet test src/NexusLabs.Needlr.slnx
-```
+- **Never write to the repository root.** Source lives under `src/`, docs under `docs/`,
+  scripts under `scripts/`.
+- **Never add technical rules to this file.** It loads in every session and is capped at
+  60 lines / 3072 bytes, enforced by `scripts/test-agent-root-files.ps1`. Put rules in a
+  path-scoped instruction file whose glob matches the code the rule governs.
+- **Never edit `.github/instructions/genesis/`.** Those files are replaced by sync. Add
+  project specialization in a sibling file outside that directory.
 
-## File Conventions
+## Build and test
 
-- **One type per file.** Never put multiple classes, structs, or enums in the same `.cs` file.
-- **Never save files to the repo root.** Source code lives under `src/`, docs under `docs/`, scripts under `scripts/`.
-- **File-scoped namespaces** everywhere (`namespace Foo;`, not `namespace Foo { }`).
-- **`internal` by default** for types that are not part of the public API surface. Only types consumers reference directly should be `public`.
-- **Data carriers are records.** DTOs, options, contexts, definitions, results, snapshots, evidence,
-  counts, and structured failures must be `record` types, including body-style records with
-  validated constructors. Reserve classes for behavior, mutable runtime state, and services.
-- **Non-static class-only non-services require `[DoNotAutoRegister]`.** Never rely on `required`
-  members, constructor shape, generic arity, visibility, or namespace filters to keep an
-  instantiable class out of Needlr's automatic DI registration.
+    dotnet build src/NexusLabs.Needlr.slnx
+    dotnet test src/NexusLabs.Needlr.slnx
 
-## Naming
+## Where the rules live
 
-- PascalCase for all public members, types, and namespaces.
-- `_camelCase` for private fields.
-- Diagnostic IDs use the `NDLR` prefix with a component code: `NDLRCOR` (core), `NDLRGEN` (generators), `NDLRSIG` (SignalR), `NDLRLOG` (logging), `NDLRHTTP` (HttpClient).
+Path-scoped rules in `.github/instructions/**/*.instructions.md` activate automatically
+from their `applyTo` glob. Read the file that matches what you are editing.
 
-## XML Documentation
+| Editing | File |
+|---|---|
+| Any `.cs` | `csharp-conventions.instructions.md` |
+| Source generators | `source-generators.instructions.md` |
+| Anything reaching `AddSource` | `generator-determinism.instructions.md` |
+| Discovery helpers | `discovery-helpers.instructions.md` |
+| Generator models | `models.instructions.md` |
+| Attributes package | `attributes.instructions.md` |
+| Integration tests | `integration-tests.instructions.md` |
+| Project and props files | `project-files.instructions.md` |
+| Docs and `mkdocs.yml` | `docs.instructions.md` |
+| Examples | `examples.instructions.md` |
+| Workflows and CI | `needlr/hosted-ci.instructions.md` |
 
-Required on all `public` types and members. Use `<summary>`, `<param>`, `<returns>`, and `<example>` tags where appropriate. Internal types should have XML docs on the class itself; individual members are optional unless non-obvious.
+## Key documents
 
-## Central Package Management
+- Feature layer pattern: `docs/architecture/feature-layers.md` — a new source-generated
+  feature needs every layer, including the analyzer, docs, and integration tests.
+- Architecture decisions: `docs/architecture/decisions.md` — check existing ADRs before
+  implementing, and propose one when a choice is costly to reverse.
+- Delivery: `docs/development/delivery.md` — branch and PR rules, draft versus ready CI
+  scope, review policy, and the disclosure required before marking a PR ready.
 
-All NuGet package versions are declared in `src/Directory.Packages.props` (`ManagePackageVersionsCentrally=true`). Individual `.csproj` files reference packages by name only — never specify a version inline.
-
-## Design Principles
-
-- **Composition over inheritance.** Base classes should be extremely rare and only exist as pure convenience for implementors. Always prefer interfaces + composition. If a pattern has common boilerplate, solve it with source generation or composable helper types, not inheritance hierarchies.
-- **Interfaces over static classes.** Static classes are acceptable only for trivial value calculations or extension method containers. Anything with behavior, state, or dependencies must be an interface registered via DI.
-- **No static singleton holders.** Never use `static Instance` properties, `static Holder` classes, or any pattern that stores a singleton in a static field to share state between components. This destroys testability, breaks multi-threaded scenarios, and is antithetical to dependency injection. Pass dependencies through constructors, method parameters, or DI — never through static state. We are a dependency injection library; use dependency injection.
-
-## Architecture Decision Records
-
-When a task involves a significant architectural or technical decision:
-
-- Check existing ADRs before implementation. Flag contradictions with accepted decisions
-  instead of silently diverging.
-- Propose an ADR when the choice changes system structure, technology, integration
-  boundaries, important quality attributes, or another convention that is costly to
-  reverse.
-- Do not create an ADR for a routine implementation choice, straightforward bug fix, or
-  decision already covered by an accepted record.
-- Use the repository's established ADR location and format; default to `docs/adr/` only
-  when no convention exists.
-
-## Architecture
-
-The codebase follows a consistent per-feature pattern:
-
-| Layer | Location | Role |
-|-------|----------|------|
-| **Attribute** | `NexusLabs.Needlr.Generators.Attributes/` | User-facing marker (`[Options]`, `[HttpClientOptions]`, `[GenerateFactory]`, etc.). Targets `netstandard2.0`. |
-| **Discovery helper** | `NexusLabs.Needlr.Generators/*DiscoveryHelper.cs` or `*AttributeHelper.cs` | Roslyn-side logic that reads the attribute from `INamedTypeSymbol` and extracts a model struct. |
-| **Model** | `NexusLabs.Needlr.Generators/Models/` | `internal readonly struct` holding discovered metadata. One type per file, organized into feature subfolders. |
-| **Code generator** | `NexusLabs.Needlr.Generators/CodeGen/*CodeGenerator.cs` | `internal static class` that emits C# source text into a `StringBuilder`. |
-| **Analyzer** | `NexusLabs.Needlr.Generators/*Analyzer.cs` | `DiagnosticAnalyzer` enforcing compile-time contracts for the feature's attribute. |
-| **Integration tests** | `NexusLabs.Needlr.IntegrationTests/SourceGen/` | xUnit tests that build a real `Syringe` service provider and verify the generated code runs correctly. |
-| **Docs** | `docs/<feature>.md` + `docs/analyzers/NDLRXXX.md` | Feature page + per-diagnostic reference page, registered in `mkdocs.yml` nav. |
-
-When adding a new source-generated feature, follow ALL layers of this pattern — don't skip the analyzer, the docs, or the integration tests.
-
-## Glob-Targeted Instructions
-
-Pattern-specific rules live in `.github/instructions/*.instructions.md`. These activate automatically when you edit files matching their glob. See that directory for rules covering source generators, generated-output determinism, analyzers, CodeGen emission, attributes, integration tests, discovery helpers, models, docs, examples, and project files.
-
-## Deterministic Generated Output
-
-`<Deterministic>true</Deterministic>` is set repo-wide. Never read the clock, randomness, or host identity inside a source generator — everything passed to `AddSource` is compiled into the consumer's assembly. Timestamps that are genuinely wanted must be stamped where the artifact is written, not where the source is generated. See `docs/development/deterministic-generators.md`.
-
-## Pull Request Delivery
-
-- Deliver every change through a feature branch and pull request. Direct updates or
-  deletions of `main` are forbidden; local checkpoint commits on feature branches are
-  unrestricted.
-- "Open a draft PR" means keep the pull request in draft while the configured
-  `CI_DRAFT_MODE` validation runs. "Open" or "publish" a PR means make it ready for
-  review so a fresh full validation run publishes the stable `CI` check.
-- Use a conventional pull request title no longer than 72 characters. GitHub uses the
-  PR title as the squash commit subject and the PR body as the squash commit message.
-- `GENESIS_REVIEW_POLICY=copilot-one-approval` requires a ready pull request authored
-  by the Copilot bot to receive one trusted human approval on its current head SHA.
-  Pushing another commit invalidates that approval for delivery purposes.
-- An approval to run workflows from an external fork authorizes the entire proposed
-  workflow, including runner selection. Inspect workflow changes and confirm fork jobs
-  remain on GitHub-hosted runners before approving them.
-- Before marking a PR ready, report omitted behavior, implementation gaps, test
-  results, technical debt, missing coverage, weak assertions, and assumptions. Fix
-  every high-severity gap and discuss every medium-severity gap before delivery.
+Deliver every change through a feature branch and pull request. Never push to `main`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,3 @@
 # Claude Code Configuration
 
-**See `AGENTS.md` for all project conventions, patterns, and coding standards.**
-
-## Build & Test
-
-```bash
-dotnet build src/NexusLabs.Needlr.slnx
-dotnet test src/NexusLabs.Needlr.slnx
-```
+See `AGENTS.md` for all project conventions, patterns, and coding standards.

--- a/docs/architecture/feature-layers.md
+++ b/docs/architecture/feature-layers.md
@@ -1,0 +1,33 @@
+# Per-feature layer pattern
+
+Needlr's source-generated features follow one consistent shape. A feature that skips a
+layer is incomplete, even when it works.
+
+| Layer | Location | Role |
+|-------|----------|------|
+| **Attribute** | `NexusLabs.Needlr.Generators.Attributes/` | User-facing marker (`[Options]`, `[HttpClientOptions]`, `[GenerateFactory]`, and similar). Targets `netstandard2.0`. |
+| **Discovery helper** | `NexusLabs.Needlr.Generators/*DiscoveryHelper.cs` or `*AttributeHelper.cs` | Roslyn-side logic that reads the attribute from an `INamedTypeSymbol` and extracts a model struct. |
+| **Model** | `NexusLabs.Needlr.Generators/Models/` | `internal readonly struct` holding discovered metadata. One type per file, organized into feature subfolders. |
+| **Code generator** | `NexusLabs.Needlr.Generators/CodeGen/*CodeGenerator.cs` | `internal static class` that emits C# source text into a `StringBuilder`. |
+| **Analyzer** | `NexusLabs.Needlr.Generators/*Analyzer.cs` | `DiagnosticAnalyzer` enforcing the feature's compile-time contracts. |
+| **Integration tests** | `NexusLabs.Needlr.IntegrationTests/SourceGen/` | xUnit tests that build a real `Syringe` service provider and verify the generated code runs. |
+| **Docs** | `docs/<feature>.md` plus `docs/analyzers/NDLRXXX.md` | Feature page and per-diagnostic reference page, both registered in `mkdocs.yml` nav. |
+
+When adding a new source-generated feature, follow **all** layers of this pattern. Do not
+skip the analyzer, the docs, or the integration tests.
+
+## Why every layer matters
+
+The analyzer is the layer most often skipped, and it is the one that turns a silent
+misuse into a compile error. A generator that quietly emits nothing when an attribute is
+applied incorrectly produces a runtime failure far from its cause.
+
+The integration tests are the second most often skipped. Generator unit tests assert on
+emitted text; only an integration test proves the emitted code compiles, registers, and
+resolves through a real container.
+
+## See also
+
+- [Deterministic generator output](../development/deterministic-generators.md)
+- [Roslyn analyzers](../development/roslyn-analyzers.md)
+- [.NET engineering conventions](../development/dotnet-engineering.md)

--- a/docs/development/delivery.md
+++ b/docs/development/delivery.md
@@ -1,0 +1,54 @@
+# Pull request delivery
+
+Every change ships through a feature branch and a pull request. Direct updates or
+deletions of `main` are forbidden. Local checkpoint commits on a feature branch are
+unrestricted.
+
+## Draft versus ready
+
+`CI_DRAFT_MODE` controls how much validation a draft pull request runs. It is currently
+set to `subset`, so a draft skips `build-and-test`, the Native AOT jobs, and package
+validation.
+
+- **"Open a draft PR"** means keep the pull request in draft while the configured
+  draft-mode validation runs.
+- **"Open a PR"** or **"publish a PR"** means make it ready for review, so a fresh full
+  validation run publishes the stable `CI` check.
+
+A draft that is green has not been fully validated. Read the check list rather than the
+summary colour.
+
+## Title format
+
+Use a conventional pull request title no longer than 72 characters. GitHub uses the title
+as the squash commit subject and the body as the squash commit message, so both become
+permanent history.
+
+Allowed types are declared in `.github/genesis-delivery.json`:
+`feat`, `fix`, `docs`, `refactor`, `test`, `style`, `build`, `ci`, `chore`, `perf`, `revert`.
+Release preparation uses `chore: prepare vX.Y.Z release`.
+
+## Review policy
+
+`GENESIS_REVIEW_POLICY=copilot-one-approval` requires a ready pull request authored by the
+Copilot bot to receive one trusted human approval on its **current head SHA**. Pushing
+another commit invalidates that approval for delivery purposes.
+
+Branch protection requires branches to be up to date, so each merge forces the next open
+pull request to update. `CHANGELOG.md` is the usual conflict point.
+
+## Fork workflow approval
+
+Approving workflows from an external fork authorizes the entire proposed workflow,
+including runner selection. Inspect workflow changes and confirm fork jobs remain on
+GitHub-hosted runners before approving. See
+[GitHub Actions runners](../github-actions.md).
+
+## Disclosure before marking ready
+
+Before marking a pull request ready, report omitted behavior, implementation gaps, test
+results, technical debt, missing coverage, weak assertions, and assumptions. Fix every
+high-severity gap and discuss every medium-severity gap before delivery.
+
+State what was **not** done as plainly as what was. A reviewer who discovers an omission
+after approving has been misled, even when nothing was stated falsely.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,9 +94,11 @@ nav:
       - Project Structure: architecture/project-structure.md
       - Data Access Boundary: architecture/data-access.md
       - HTTP Clients and Options: architecture/http-clients-and-options.md
+      - Feature Layer Pattern: architecture/feature-layers.md
     - Development:
       - .NET Engineering: development/dotnet-engineering.md
       - Deterministic Generator Output: development/deterministic-generators.md
+      - Pull Request Delivery: development/delivery.md
       - Roslyn Analyzers: development/roslyn-analyzers.md
       - Validation and Scheduling Boundaries: development/request-validation-and-jobs.md
       - Performance: performance/dotnet-performance.md

--- a/scripts/test-agent-root-files.ps1
+++ b/scripts/test-agent-root-files.ps1
@@ -1,0 +1,101 @@
+<#
+.SYNOPSIS
+    Validates Needlr's agent root-file budget.
+
+.DESCRIPTION
+    AGENTS.md loads in every agent session, so every byte competes with the task for
+    context. The budget in .github/instructions/genesis/agent-root-files.instructions.md
+    caps it at 60 lines and 3072 UTF-8 bytes. Redirect files must stay redirects rather
+    than accumulating copies of guidance that already lives elsewhere.
+
+    Without this check the budget is advisory, and a file that every agent appends one
+    reasonable section to grows without bound.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$maximumLines = 60
+$maximumBytes = 3072
+$instructionsUrl = '.github/instructions/genesis/agent-root-files.instructions.md'
+
+$failures = [System.Collections.Generic.List[string]]::new()
+
+function Measure-File {
+    param(
+        [Parameter(Mandatory)]
+        [string]$RelativePath)
+
+    $fullPath = Join-Path $repoRoot $RelativePath
+    if (-not (Test-Path -LiteralPath $fullPath)) {
+        return $null
+    }
+
+    $raw = Get-Content -LiteralPath $fullPath -Raw
+    if ($null -eq $raw) {
+        $raw = ''
+    }
+
+    return [pscustomobject]@{
+        Path  = $RelativePath
+        Lines = ($raw -split "`r?`n").Count
+        Bytes = [System.Text.Encoding]::UTF8.GetByteCount($raw)
+        Text  = $raw
+    }
+}
+
+$agents = Measure-File -RelativePath 'AGENTS.md'
+if ($null -eq $agents) {
+    $failures.Add('AGENTS.md is missing.')
+}
+else {
+    if ($agents.Lines -gt $maximumLines) {
+        $failures.Add(
+            "AGENTS.md is $($agents.Lines) lines; the budget is $maximumLines. " +
+            "Move technical rules into a path-scoped file under .github/instructions/ " +
+            "whose glob matches the code the rule governs. See $instructionsUrl.")
+    }
+
+    if ($agents.Bytes -gt $maximumBytes) {
+        $failures.Add(
+            "AGENTS.md is $($agents.Bytes) UTF-8 bytes; the budget is $maximumBytes. " +
+            "Move architecture and rationale into docs/ and exact technical rules into " +
+            "path-scoped instructions. See $instructionsUrl.")
+    }
+}
+
+# Redirects exist to point at AGENTS.md. Duplicating guidance in them means an agent
+# reads the same rule twice and the copies drift apart.
+foreach ($redirect in @('CLAUDE.md', '.github/copilot-instructions.md')) {
+    $file = Measure-File -RelativePath $redirect
+    if ($null -eq $file) {
+        continue
+    }
+
+    if ($file.Text -notmatch 'AGENTS\.md') {
+        $failures.Add("$redirect must point at AGENTS.md.")
+    }
+
+    if ($file.Text -match '(?m)^\s*```') {
+        $failures.Add(
+            "$redirect contains a code block. Redirects must not restate build, test, " +
+            "or workflow guidance that belongs in AGENTS.md or a path-scoped instruction.")
+    }
+}
+
+if ($failures.Count -gt 0) {
+    Write-Host 'Agent root-file policy violations:' -ForegroundColor Red
+    foreach ($failure in $failures) {
+        Write-Host "  - $failure" -ForegroundColor Red
+    }
+    exit 1
+}
+
+$summary = if ($null -ne $agents) {
+    "AGENTS.md $($agents.Lines)/$maximumLines lines, $($agents.Bytes)/$maximumBytes bytes."
+}
+else {
+    'AGENTS.md not measured.'
+}
+
+Write-Host "Agent root-file policy satisfied. $summary" -ForegroundColor Green


### PR DESCRIPTION
Fixes #140. First of a stack; see "Stack" below.

## What was wrong

`AGENTS.md` loads in **every** agent session, so every byte competes with the actual task for context. `.github/instructions/genesis/agent-root-files.instructions.md` caps it at **60 lines / 3,072 UTF-8 bytes**. It was well past that, and had been for a while:

| State | Lines | Bytes |
|---|---:|---:|
| Budget | 60 | 3,072 |
| Before #139 | 97 | 6,871 |
| After #139 | 101 | 7,422 |
| **Now** | **49** | **2,349** |

#139 made it worse by adding a determinism section that duplicated the path-scoped instruction file created in the same PR. That was the trigger for this work, but it was not the cause — the file was already 2.2× over the byte budget before it.

## The actual defect was the missing guard rail

Nothing checked the budget. No script, no CI job, no test. A documented-but-unenforced limit drifts by definition: every agent that adds "one more reasonable section" is individually defensible and collectively destroys the file.

`scripts/test-agent-root-files.ps1` now measures `AGENTS.md` and asserts the redirect files stay redirects. It is wired into the `Delivery preflight` job alongside the other repository policy checks.

## Red → green

The check was written **before** the trim and observed failing against the real over-budget tree, so it is known to detect the defect rather than merely to agree with a already-fixed file.

**Red** — against the tree as it stood:

```
Agent root-file policy violations:
  - AGENTS.md is 102 lines; the budget is 60. Move technical rules into a path-scoped
    file under .github/instructions/ whose glob matches the code the rule governs.
  - AGENTS.md is 7422 UTF-8 bytes; the budget is 3072. Move architecture and rationale
    into docs/ and exact technical rules into path-scoped instructions.
  - CLAUDE.md contains a code block. Redirects must not restate build, test, or workflow
    guidance that belongs in AGENTS.md or a path-scoped instruction.
EXIT CODE: 1
```

**Green** — after the trim, with no change to the check:

```
Agent root-file policy satisfied. AGENTS.md 49/60 lines, 2349/3072 bytes.
EXIT CODE: 0
```

Note the check caught a third violation I had not set out to fix: `CLAUDE.md` was carrying its own copy of the build commands, which the instructions explicitly forbid.

## Nothing was deleted — everything moved to where its audience is

The risk in this kind of change is relocating a rule under a glob that does not match its code, which silently deletes it. Each rule moved to a file that actually activates for the work it governs:

| Rule | New home | Activates on |
|---|---|---|
| File layout, type selection, naming, XML docs, design principles | `csharp-conventions.instructions.md` **(new)** | `**/*.cs` |
| Central package management, determinism flags | `project-files.instructions.md` **(new)** | `**/*.csproj`, props, `**/*.slnx` |
| Per-feature layer table | `docs/architecture/feature-layers.md` **(new)** | referenced from AGENTS.md routing |
| Pull request delivery | `docs/development/delivery.md` **(new)** | referenced from AGENTS.md routing |
| Architecture Decision Records | already in `docs/architecture/decisions.md` | AGENTS.md now routes instead of restating |

The ADR section turned out to be a **third** copy — the same guidance already existed in both `docs/architecture/decisions.md` and `genesis/adr.instructions.md`. Deleting the copy loses nothing as long as the routing survives, which it does.

`AGENTS.md` now carries only project identity, safeguards needed *before* any file is selected, and a routing table to the path-scoped instructions.

## Preventing recurrence

Enforcement catches the symptom after the fact; the guidance has to steer agents away from writing into the root file at all. `AGENTS.md` now states its own budget, names the enforcing script, and instructs agents to put new rules in a path-scoped file — so an agent reading it in a fresh session is told not to append to it.

Two new instruction files also close a gap: the C# and project-file rules previously had **no** glob-scoped home, which is part of why they accumulated in the root file. "Put it in a path-scoped instruction" is now actionable rather than aspirational.

## Verification

- `scripts/test-agent-root-files.ps1` — red and green captured above.
- `python -m mkdocs build --strict` passes with both new pages in nav.
- Recompiled `.claude/rules/generated/` for the two new instruction files only.

## Stack

1. **This PR** — AGENTS.md budget and enforcement (#140)
2. `fix: emit numeric literals with invariant culture` — #141, live compile break
3. `fix: order generated output ordinally` — #141
4. `fix: normalize emitted source paths` — #141

## Disclosures

- **The `genesis/**` Claude-rule drift backlog is still outstanding.** The compiler regenerates every rule; ~70 new and ~45 modified `genesis/**` files with real content changes were reverted to keep this diff reviewable. That sync still needs its own PR and is not tracked by an issue yet.
- The new check gates on `source_required`, matching the sibling policy checks. The scope classifier fails closed, so an `AGENTS.md`-only change does set `source_required=true` and the check runs — verified in `scripts/get-ci-scope.ps1`, but not yet observed on a docs-only PR in practice.
- The relocation is mechanical but touches guidance governing the whole repository. It should be reviewed for **meaning**, not line count: I believe every rule kept an accurate glob, but that judgement is worth a second reader.
