### PR TITLE
fix: emit generated source independently of build machine locale

### DIFF
--- a/.claude/rules/generated/generator-determinism.md
+++ b/.claude/rules/generated/generator-determinism.md
@@ -20,14 +20,42 @@ No `AddSource` output may depend on:
 - the wall clock — `DateTime.UtcNow`, `DateTime.Now`, `DateTimeOffset.UtcNow`, `DateTimeOffset.Now`, `DateTime.Today`;
 - randomness — `Guid.NewGuid`, `Random`;
 - host identity — `Environment.MachineName`, `Environment.UserName`, `Environment.TickCount`;
+- **the ambient culture** — see below;
 - unordered enumeration — sort symbols with an explicit `StringComparer` before emitting.
 
 `BannedSymbols.txt` enforces the API list through `Microsoft.CodeAnalysis.BannedApiAnalyzers`.
 `TreatWarningsAsErrors` is on, so a violation fails the build with `RS0030`. Do not
 suppress it — fix the emitter.
 
-## Stamp timestamps where the artifact is written
+## Ambient culture is ambient state
 
+Determinism is per-machine, per-OS, **and per-locale**. A rebuild that is byte-identical
+on one machine can still differ on another with a different locale.
+
+- **Emit every number through `GeneratorHelpers.Literal(int)`.** String interpolation
+  formats with `CultureInfo.CurrentCulture`, and locales including `sv-SE`, `fi-FI`, and
+  `lt-LT` render a negative number with U+2212 MINUS SIGN. That is not valid C#, so a
+  negative `Order` produces generated code that does not compile.
+- **Give every string sort an explicit `StringComparer.Ordinal`.** `OrderBy(x => x.Name)`
+  with no comparer uses `Comparer<string>.Default`, which is culture-sensitive.
+  `_Cache`, `IUserservice`, and `my_type` all sort differently under culture collation
+  than under ordinal, and Lithuanian collation reorders others again.
+- **Use invariant casing.** `ToLowerInvariant` / `ToUpperInvariant`, never `ToLower` /
+  `ToUpper`.
+
+Two enforcement routes do **not** work here, so do not rely on them:
+
+- `CA1305` (Specify `IFormatProvider`) does not flag interpolated strings in this
+  project — measured, zero hits against the known-defective code.
+- Pinning the culture centrally is banned. `EnforceExtendedAnalyzerRules` raises
+  `RS1035` for any use of `CultureInfo.CurrentCulture`, because analyzers must use the
+  locale supplied by the compiler.
+
+`GeneratedSourceCultureInvarianceTests` is therefore the guard: it runs generation under
+`en-US` and under hostile locales and compares every generated file. Extend its source
+sample when adding an emitter, or the new emitter is uncovered.
+
+## Stamp timestamps where the artifact is written
 A timestamp is legitimate in a human-readable report, but it must never reach `AddSource`.
 Emit a constant placeholder and substitute the real value at the point the artifact is
 written to disk. Both existing cases follow this shape:

--- a/.github/instructions/generator-determinism.instructions.md
+++ b/.github/instructions/generator-determinism.instructions.md
@@ -17,14 +17,42 @@ No `AddSource` output may depend on:
 - the wall clock — `DateTime.UtcNow`, `DateTime.Now`, `DateTimeOffset.UtcNow`, `DateTimeOffset.Now`, `DateTime.Today`;
 - randomness — `Guid.NewGuid`, `Random`;
 - host identity — `Environment.MachineName`, `Environment.UserName`, `Environment.TickCount`;
+- **the ambient culture** — see below;
 - unordered enumeration — sort symbols with an explicit `StringComparer` before emitting.
 
 `BannedSymbols.txt` enforces the API list through `Microsoft.CodeAnalysis.BannedApiAnalyzers`.
 `TreatWarningsAsErrors` is on, so a violation fails the build with `RS0030`. Do not
 suppress it — fix the emitter.
 
-## Stamp timestamps where the artifact is written
+## Ambient culture is ambient state
 
+Determinism is per-machine, per-OS, **and per-locale**. A rebuild that is byte-identical
+on one machine can still differ on another with a different locale.
+
+- **Emit every number through `GeneratorHelpers.Literal(int)`.** String interpolation
+  formats with `CultureInfo.CurrentCulture`, and locales including `sv-SE`, `fi-FI`, and
+  `lt-LT` render a negative number with U+2212 MINUS SIGN. That is not valid C#, so a
+  negative `Order` produces generated code that does not compile.
+- **Give every string sort an explicit `StringComparer.Ordinal`.** `OrderBy(x => x.Name)`
+  with no comparer uses `Comparer<string>.Default`, which is culture-sensitive.
+  `_Cache`, `IUserservice`, and `my_type` all sort differently under culture collation
+  than under ordinal, and Lithuanian collation reorders others again.
+- **Use invariant casing.** `ToLowerInvariant` / `ToUpperInvariant`, never `ToLower` /
+  `ToUpper`.
+
+Two enforcement routes do **not** work here, so do not rely on them:
+
+- `CA1305` (Specify `IFormatProvider`) does not flag interpolated strings in this
+  project — measured, zero hits against the known-defective code.
+- Pinning the culture centrally is banned. `EnforceExtendedAnalyzerRules` raises
+  `RS1035` for any use of `CultureInfo.CurrentCulture`, because analyzers must use the
+  locale supplied by the compiler.
+
+`GeneratedSourceCultureInvarianceTests` is therefore the guard: it runs generation under
+`en-US` and under hostile locales and compares every generated file. Extend its source
+sample when adding an emitter, or the new emitter is uncovered.
+
+## Stamp timestamps where the artifact is written
 A timestamp is legitimate in a human-readable report, but it must never reach `AddSource`.
 Emit a constant placeholder and substitute the real value at the point the artifact is
 written to disk. Both existing cases follow this shape:

--- a/src/NexusLabs.Needlr.Generators.Tests/GeneratedSourceCultureInvarianceTests.cs
+++ b/src/NexusLabs.Needlr.Generators.Tests/GeneratedSourceCultureInvarianceTests.cs
@@ -1,0 +1,136 @@
+using System.Globalization;
+
+using NexusLabs.Needlr;
+
+using Xunit;
+
+namespace NexusLabs.Needlr.Generators.Tests;
+
+/// <summary>
+/// Guards generated source against the ambient culture of the build machine.
+/// </summary>
+/// <remarks>
+/// <para>
+/// String interpolation formats numbers using <see cref="CultureInfo.CurrentCulture"/>.
+/// Several locales render a negative number with U+2212 MINUS SIGN rather than U+002D
+/// HYPHEN-MINUS, producing generated C# that does not compile. Negative <c>Order</c>
+/// values are a supported feature, so this is reachable in ordinary use.
+/// </para>
+/// <para>
+/// The whole-output comparison is the real guard. It covers every emitter at once,
+/// including emitters added later, which matters because per-call-site correctness
+/// cannot be enforced by an analyzer here: <c>CA1305</c> does not flag interpolated
+/// strings in this project, and <c>RS1035</c> forbids a generator from touching the
+/// ambient culture to fix the problem centrally.
+/// </para>
+/// <para>
+/// These tests deliberately run generation under a hostile culture. Asserting only
+/// under a typical developer culture would pass whether or not the defect is present.
+/// </para>
+/// </remarks>
+public sealed class GeneratedSourceCultureInvarianceTests
+{
+    private const char UnicodeMinusSign = '\u2212';
+
+    private const string Source = """
+        using NexusLabs.Needlr;
+        using NexusLabs.Needlr.Generators;
+
+        [assembly: GenerateTypeRegistry]
+
+        namespace TestApp
+        {
+            public interface IService { }
+
+            public sealed class Service : IService { }
+
+            [DecoratorFor<IService>(Order = -100)]
+            public sealed class EarlyDecorator : IService
+            {
+                public EarlyDecorator(IService inner) { }
+            }
+
+            [DecoratorFor<IService>(Order = -5)]
+            public sealed class LateDecorator : IService
+            {
+                public LateDecorator(IService inner) { }
+            }
+        }
+        """;
+
+    [Theory]
+    [InlineData("sv-SE")]
+    [InlineData("fi-FI")]
+    [InlineData("lt-LT")]
+    public void GeneratedFiles_AreIdenticalUnderAnyCulture(string hostileCulture)
+    {
+        var reference = RunUnderCulture("en-US", GenerateAll);
+        var hostile = RunUnderCulture(hostileCulture, GenerateAll);
+
+        Assert.Equal(reference.Count, hostile.Count);
+
+        foreach (var file in reference)
+        {
+            Assert.True(
+                hostile.ContainsKey(file.Key),
+                $"'{file.Key}' was generated under en-US but not under {hostileCulture}.");
+
+            Assert.True(
+                string.Equals(file.Value, hostile[file.Key], StringComparison.Ordinal),
+                $"'{file.Key}' differs between en-US and {hostileCulture}. Generated source "
+                    + "must not depend on the build machine's culture.");
+        }
+    }
+
+    [Theory]
+    [InlineData("sv-SE")]
+    [InlineData("fi-FI")]
+    [InlineData("lt-LT")]
+    public void NegativeNumbers_NeverUseTheUnicodeMinusSign(string hostileCulture)
+    {
+        var generated = RunUnderCulture(hostileCulture, GenerateAll);
+
+        foreach (var file in generated)
+        {
+            Assert.False(
+                file.Value.IndexOf(UnicodeMinusSign) >= 0,
+                $"'{file.Key}' contains U+2212 MINUS SIGN. Emitted numeric literals must use "
+                    + "the invariant culture; U+2212 is not valid C#.");
+        }
+
+        var catalog = generated.Single(
+            f => f.Key.EndsWith("ServiceCatalog.g.cs", StringComparison.Ordinal));
+        Assert.Contains(", -100,", catalog.Value, StringComparison.Ordinal);
+    }
+
+    private static Dictionary<string, string> GenerateAll()
+    {
+        var files = GeneratorTestRunner.ForTypeRegistry()
+            .WithReference<DecoratorForAttribute<object>>()
+            .WithSource(Source)
+            .WithDiagnosticsEnabled()
+            .WithGraphExportEnabled()
+            .RunTypeRegistryGeneratorFiles();
+
+        return files.ToDictionary(f => f.FilePath, f => f.Content, StringComparer.Ordinal);
+    }
+
+    private static T RunUnderCulture<T>(string culture, Func<T> action)
+    {
+        var thread = System.Threading.Thread.CurrentThread;
+        var originalCulture = thread.CurrentCulture;
+        var originalUiCulture = thread.CurrentUICulture;
+        try
+        {
+            var target = new CultureInfo(culture);
+            thread.CurrentCulture = target;
+            thread.CurrentUICulture = target;
+            return action();
+        }
+        finally
+        {
+            thread.CurrentCulture = originalCulture;
+            thread.CurrentUICulture = originalUiCulture;
+        }
+    }
+}

--- a/src/NexusLabs.Needlr.Generators/CodeGen/DecoratorsCodeGenerator.cs
+++ b/src/NexusLabs.Needlr.Generators/CodeGen/DecoratorsCodeGenerator.cs
@@ -68,7 +68,7 @@ internal static class DecoratorsCodeGenerator
                 // Group decorators by service type and order by Order property
                 var decoratorsByService = decorators
                     .GroupBy(d => d.ServiceTypeName)
-                    .OrderBy(g => g.Key);
+                    .OrderBy(g => g.Key, StringComparer.Ordinal);
 
                 foreach (var serviceGroup in decoratorsByService)
                 {
@@ -86,7 +86,7 @@ internal static class DecoratorsCodeGenerator
                             var sourcePath = dec.SourceFilePath != null
                                 ? BreadcrumbWriter.GetRelativeSourcePath(dec.SourceFilePath, projectDirectory)
                                 : $"[{dec.AssemblyName}]";
-                            lines.Add($"  {i + 1}. {dec.DecoratorTypeName.Split('.').Last()} (Order={dec.Order}) ← {sourcePath}");
+                            lines.Add($"  {GeneratorHelpers.Literal(i + 1)}. {dec.DecoratorTypeName.Split('.').Last()} (Order={GeneratorHelpers.Literal(dec.Order)}) ← {sourcePath}");
                         }
                         lines.Add($"Triggered by: [DecoratorFor<{serviceGroup.Key.Split('.').Last()}>] attributes");
 
@@ -101,7 +101,7 @@ internal static class DecoratorsCodeGenerator
 
                     foreach (var decorator in serviceGroup.OrderBy(d => d.Order))
                     {
-                        builder.AppendLine($"        services.AddDecorator<{decorator.ServiceTypeName}, {decorator.DecoratorTypeName}>(); // Order: {decorator.Order}");
+                        builder.AppendLine($"        services.AddDecorator<{decorator.ServiceTypeName}, {decorator.DecoratorTypeName}>(); // Order: {GeneratorHelpers.Literal(decorator.Order)}");
                     }
                 }
             }

--- a/src/NexusLabs.Needlr.Generators/CodeGen/FactoryCodeGenerator.cs
+++ b/src/NexusLabs.Needlr.Generators/CodeGen/FactoryCodeGenerator.cs
@@ -287,7 +287,7 @@ internal static class FactoryCodeGenerator
         builder.AppendLine("    /// <summary>");
         builder.AppendLine("    /// Gets the number of factory types generated at compile time.");
         builder.AppendLine("    /// </summary>");
-        builder.AppendLine($"    public static int Count => {factories.Count};");
+        builder.AppendLine($"    public static int Count => {GeneratorHelpers.Literal(factories.Count)};");
         builder.AppendLine("}");
 
         return builder.ToString();

--- a/src/NexusLabs.Needlr.Generators/CodeGen/GeneratedConstructorCodeGenerator.cs
+++ b/src/NexusLabs.Needlr.Generators/CodeGen/GeneratedConstructorCodeGenerator.cs
@@ -31,7 +31,7 @@ internal static class GeneratedConstructorCodeGenerator
 
         var safeName = GeneratorHelpers.SanitizeIdentifier(baseName);
 
-        return $"{safeName}_T{model.Arity}{GeneratedConstructorFileSuffix}";
+        return $"{safeName}_T{GeneratorHelpers.Literal(model.Arity)}{GeneratedConstructorFileSuffix}";
     }
 
     internal static string GenerateConstructorSource(GeneratedConstructorModel model, string assemblyName, BreadcrumbWriter breadcrumbs)
@@ -48,7 +48,7 @@ internal static class GeneratedConstructorCodeGenerator
             builder.AppendLine();
         }
 
-        breadcrumbs.WriteInlineComment(builder, string.Empty, $"Constructor generated from {model.Fields.Length} eligible field(s)");
+        breadcrumbs.WriteInlineComment(builder, string.Empty, $"Constructor generated from {GeneratorHelpers.Literal(model.Fields.Length)} eligible field(s)");
         builder.AppendLine($"partial class {model.ContainingTypeName}{model.TypeParameterList}");
         builder.AppendLine("{");
 

--- a/src/NexusLabs.Needlr.Generators/CodeGen/InjectableTypesCodeGenerator.cs
+++ b/src/NexusLabs.Needlr.Generators/CodeGen/InjectableTypesCodeGenerator.cs
@@ -21,13 +21,13 @@ internal static class InjectableTypesCodeGenerator
         builder.AppendLine("    private static readonly InjectableTypeInfo[] _types =");
         builder.AppendLine("    [");
 
-        var typesByAssembly = types.GroupBy(t => t.AssemblyName).OrderBy(g => g.Key);
+        var typesByAssembly = types.GroupBy(t => t.AssemblyName).OrderBy(g => g.Key, StringComparer.Ordinal);
 
         foreach (var group in typesByAssembly)
         {
             breadcrumbs.WriteInlineComment(builder, "        ", $"From {group.Key}");
 
-            foreach (var type in group.OrderBy(t => t.TypeName))
+            foreach (var type in group.OrderBy(t => t.TypeName, StringComparer.Ordinal))
             {
                 // Write breadcrumb for this type
                 if (breadcrumbs.Level == BreadcrumbLevel.Verbose)

--- a/src/NexusLabs.Needlr.Generators/CodeGen/InterceptorCodeGenerator.cs
+++ b/src/NexusLabs.Needlr.Generators/CodeGen/InterceptorCodeGenerator.cs
@@ -333,7 +333,7 @@ internal static class InterceptorCodeGenerator
         builder.AppendLine("    /// <summary>");
         builder.AppendLine("    /// Gets the number of intercepted services discovered at compile time.");
         builder.AppendLine("    /// </summary>");
-        builder.AppendLine($"    public static int Count => {interceptedServices.Count};");
+        builder.AppendLine($"    public static int Count => {GeneratorHelpers.Literal(interceptedServices.Count)};");
         builder.AppendLine("}");
 
         return builder.ToString();

--- a/src/NexusLabs.Needlr.Generators/CodeGen/OptionsCodeGenerator.cs
+++ b/src/NexusLabs.Needlr.Generators/CodeGen/OptionsCodeGenerator.cs
@@ -345,7 +345,7 @@ internal static class OptionsCodeGenerator
         var byNamespace = optionsNeedingConstructors
             .Where(o => o.PositionalRecordInfo != null)
             .GroupBy(o => o.PositionalRecordInfo!.Value.ContainingNamespace)
-            .OrderBy(g => g.Key);
+            .OrderBy(g => g.Key, StringComparer.Ordinal);
 
         foreach (var namespaceGroup in byNamespace)
         {

--- a/src/NexusLabs.Needlr.Generators/CodeGen/PluginsCodeGenerator.cs
+++ b/src/NexusLabs.Needlr.Generators/CodeGen/PluginsCodeGenerator.cs
@@ -27,7 +27,7 @@ internal static class PluginsCodeGenerator
             .ToList();
 
         // Group for breadcrumb display, but maintain the sorted order
-        var pluginsByAssembly = sortedPlugins.GroupBy(p => p.AssemblyName).OrderBy(g => g.Key);
+        var pluginsByAssembly = sortedPlugins.GroupBy(p => p.AssemblyName).OrderBy(g => g.Key, StringComparer.Ordinal);
 
         foreach (var group in pluginsByAssembly)
         {
@@ -45,7 +45,7 @@ internal static class PluginsCodeGenerator
                     var interfaces = plugin.InterfaceNames.Length > 0
                         ? string.Join(", ", plugin.InterfaceNames.Select(i => i.Split('.').Last()))
                         : "none";
-                    var orderInfo = plugin.Order != 0 ? $"Order: {plugin.Order}" : "Order: 0 (default)";
+                    var orderInfo = plugin.Order != 0 ? $"Order: {GeneratorHelpers.Literal(plugin.Order)}" : "Order: 0 (default)";
 
                     breadcrumbs.WriteVerboseBox(builder, "        ",
                         $"Plugin: {plugin.TypeName.Split('.').Last()}",
@@ -56,7 +56,7 @@ internal static class PluginsCodeGenerator
                 else if (breadcrumbs.Level == BreadcrumbLevel.Minimal && plugin.Order != 0)
                 {
                     // Show order in minimal mode only if non-default
-                    breadcrumbs.WriteInlineComment(builder, "        ", $"{plugin.TypeName.Split('.').Last()} (Order: {plugin.Order})");
+                    breadcrumbs.WriteInlineComment(builder, "        ", $"{plugin.TypeName.Split('.').Last()} (Order: {GeneratorHelpers.Literal(plugin.Order)})");
                 }
 
                 builder.Append($"        new(typeof({plugin.TypeName}), ");
@@ -89,7 +89,7 @@ internal static class PluginsCodeGenerator
                 }
 
                 // Order
-                builder.AppendLine($"{plugin.Order}),");
+                builder.AppendLine($"{GeneratorHelpers.Literal(plugin.Order)}),");
             }
         }
 

--- a/src/NexusLabs.Needlr.Generators/CodeGen/RecordConstructorOverloadCodeGenerator.cs
+++ b/src/NexusLabs.Needlr.Generators/CodeGen/RecordConstructorOverloadCodeGenerator.cs
@@ -21,7 +21,7 @@ internal static class RecordConstructorOverloadCodeGenerator
         var baseName = model.ContainingNamespace.Length > 0
             ? $"{model.ContainingNamespace}.{model.ContainingTypeName}"
             : model.ContainingTypeName;
-        return $"{GeneratorHelpers.SanitizeIdentifier(baseName)}_T{model.Arity}{GeneratedFileSuffix}";
+        return $"{GeneratorHelpers.SanitizeIdentifier(baseName)}_T{GeneratorHelpers.Literal(model.Arity)}{GeneratedFileSuffix}";
     }
 
     /// <summary>
@@ -50,7 +50,7 @@ internal static class RecordConstructorOverloadCodeGenerator
         breadcrumbs.WriteInlineComment(
             builder,
             string.Empty,
-            $"Constructor overload generated from {model.PropertyParameters.Length} marked property parameter(s)");
+            $"Constructor overload generated from {GeneratorHelpers.Literal(model.PropertyParameters.Length)} marked property parameter(s)");
         builder.AppendLine(
             $"partial record class {model.EscapedContainingTypeName}{model.TypeParameterList}");
         builder.AppendLine("{");

--- a/src/NexusLabs.Needlr.Generators/CodeGen/ServiceCatalogCodeGenerator.cs
+++ b/src/NexusLabs.Needlr.Generators/CodeGen/ServiceCatalogCodeGenerator.cs
@@ -29,7 +29,7 @@ internal static class ServiceCatalogCodeGenerator
         builder.AppendLine($"namespace {safeAssemblyName}.Generated;");
         builder.AppendLine();
         
-        breadcrumbs.WriteInlineComment(builder, "", $"ServiceCatalog: {discoveryResult.InjectableTypes.Count} services, {discoveryResult.Decorators.Count} decorators, {discoveryResult.HostedServices.Count} hosted services");
+        breadcrumbs.WriteInlineComment(builder, "", $"ServiceCatalog: {GeneratorHelpers.Literal(discoveryResult.InjectableTypes.Count)} services, {GeneratorHelpers.Literal(discoveryResult.Decorators.Count)} decorators, {GeneratorHelpers.Literal(discoveryResult.HostedServices.Count)} hosted services");
 
         builder.AppendLine("/// <summary>");
         builder.AppendLine("/// Compile-time service catalog containing all discovered registrations.");
@@ -100,7 +100,7 @@ internal static class ServiceCatalogCodeGenerator
                 var ifaceFilePathLiteral = ifaceFilePath != null 
                     ? $"\"{GeneratorHelpers.EscapeStringLiteral(ifaceFilePath)}\"" 
                     : "null";
-                interfaceEntriesBuilder.Append($"new global::NexusLabs.Needlr.Catalog.InterfaceEntry(\"{GeneratorHelpers.EscapeStringLiteral(ifaceInfo.FullName)}\", {ifaceFilePathLiteral}, {ifaceInfo.SourceLine}), ");
+                interfaceEntriesBuilder.Append($"new global::NexusLabs.Needlr.Catalog.InterfaceEntry(\"{GeneratorHelpers.EscapeStringLiteral(ifaceInfo.FullName)}\", {ifaceFilePathLiteral}, {GeneratorHelpers.Literal(ifaceInfo.SourceLine)}), ");
             }
             interfaceEntriesBuilder.Append('}');
             
@@ -120,7 +120,7 @@ internal static class ServiceCatalogCodeGenerator
             // Build service keys array
             var serviceKeysArray = $"new string[] {{ {string.Join(", ", type.ServiceKeys.Select(k => $"\"{GeneratorHelpers.EscapeStringLiteral(k)}\""))} }}";
 
-            builder.AppendLine($"        new global::NexusLabs.Needlr.Catalog.ServiceCatalogEntry(\"{GeneratorHelpers.EscapeStringLiteral(type.TypeName)}\", \"{GeneratorHelpers.EscapeStringLiteral(shortName)}\", \"{GeneratorHelpers.EscapeStringLiteral(type.AssemblyName)}\", {lifetimeStr}, {interfacesArray}, {constructorParamsBuilder}, {serviceKeysArray}, {sourceFilePathLiteral}, {type.SourceLine}, {interfaceEntriesBuilder}),");
+            builder.AppendLine($"        new global::NexusLabs.Needlr.Catalog.ServiceCatalogEntry(\"{GeneratorHelpers.EscapeStringLiteral(type.TypeName)}\", \"{GeneratorHelpers.EscapeStringLiteral(shortName)}\", \"{GeneratorHelpers.EscapeStringLiteral(type.AssemblyName)}\", {lifetimeStr}, {interfacesArray}, {constructorParamsBuilder}, {serviceKeysArray}, {sourceFilePathLiteral}, {GeneratorHelpers.Literal(type.SourceLine)}, {interfaceEntriesBuilder}),");
         }
 
         builder.AppendLine("    };");
@@ -144,7 +144,7 @@ internal static class ServiceCatalogCodeGenerator
                 ? $"\"{GeneratorHelpers.EscapeStringLiteral(sourceFilePath)}\"" 
                 : "null";
 
-            builder.AppendLine($"        new global::NexusLabs.Needlr.Catalog.DecoratorCatalogEntry(\"{GeneratorHelpers.EscapeStringLiteral(decorator.DecoratorTypeName)}\", \"{GeneratorHelpers.EscapeStringLiteral(shortName)}\", \"{GeneratorHelpers.EscapeStringLiteral(decorator.ServiceTypeName)}\", {decorator.Order}, \"{GeneratorHelpers.EscapeStringLiteral(decorator.AssemblyName)}\", {sourceFilePathLiteral}),");
+            builder.AppendLine($"        new global::NexusLabs.Needlr.Catalog.DecoratorCatalogEntry(\"{GeneratorHelpers.EscapeStringLiteral(decorator.DecoratorTypeName)}\", \"{GeneratorHelpers.EscapeStringLiteral(shortName)}\", \"{GeneratorHelpers.EscapeStringLiteral(decorator.ServiceTypeName)}\", {GeneratorHelpers.Literal(decorator.Order)}, \"{GeneratorHelpers.EscapeStringLiteral(decorator.AssemblyName)}\", {sourceFilePathLiteral}),");
         }
 
         builder.AppendLine("    };");
@@ -268,7 +268,7 @@ internal static class ServiceCatalogCodeGenerator
 
             var interfacesArray = $"new string[] {{ {string.Join(", ", plugin.InterfaceNames.Select(i => $"\"{GeneratorHelpers.EscapeStringLiteral(i)}\""))} }}";
 
-            builder.AppendLine($"        new global::NexusLabs.Needlr.Catalog.PluginCatalogEntry(\"{GeneratorHelpers.EscapeStringLiteral(plugin.TypeName)}\", \"{GeneratorHelpers.EscapeStringLiteral(shortName)}\", {interfacesArray}, \"{GeneratorHelpers.EscapeStringLiteral(plugin.AssemblyName)}\", {plugin.Order}, {sourceFilePathLiteral}),");
+            builder.AppendLine($"        new global::NexusLabs.Needlr.Catalog.PluginCatalogEntry(\"{GeneratorHelpers.EscapeStringLiteral(plugin.TypeName)}\", \"{GeneratorHelpers.EscapeStringLiteral(shortName)}\", {interfacesArray}, \"{GeneratorHelpers.EscapeStringLiteral(plugin.AssemblyName)}\", {GeneratorHelpers.Literal(plugin.Order)}, {sourceFilePathLiteral}),");
         }
 
         builder.AppendLine("    };");

--- a/src/NexusLabs.Needlr.Generators/DiagnosticsGenerator.cs
+++ b/src/NexusLabs.Needlr.Generators/DiagnosticsGenerator.cs
@@ -98,7 +98,7 @@ internal static class DiagnosticsGenerator
             sb.AppendLine("Types from referenced assemblies with `[GenerateTypeRegistry]`:");
             sb.AppendLine();
 
-            foreach (var kvp in referencedAssemblyTypes.OrderBy(kv => kv.Key))
+            foreach (var kvp in referencedAssemblyTypes.OrderBy(kv => kv.Key, StringComparer.Ordinal))
             {
                 var refAsm = kvp.Key;
                 var refTypes = kvp.Value;
@@ -182,7 +182,7 @@ internal static class DiagnosticsGenerator
                 // Show summary table for this assembly
                 sb.AppendLine($"| Service | Lifetime | Interfaces |");
                 sb.AppendLine($"|---------|----------|------------|");
-                foreach (var type in refTypes.OrderBy(t => t.ShortName))
+                foreach (var type in refTypes.OrderBy(t => t.ShortName, StringComparer.Ordinal))
                 {
                     var interfaces = type.Interfaces.Any() ? string.Join(", ", type.Interfaces.Select(GeneratorHelpers.GetShortTypeName)) : "-";
                     sb.AppendLine($"| {type.ShortName} | {type.Lifetime} | {interfaces} |");
@@ -260,7 +260,7 @@ internal static class DiagnosticsGenerator
             // Host decorators - group by service type
             var decoratorsByService = decorators
                 .GroupBy(d => d.ServiceTypeName)
-                .OrderBy(g => g.Key);
+                .OrderBy(g => g.Key, StringComparer.Ordinal);
 
             foreach (var serviceGroup in decoratorsByService)
             {
@@ -299,7 +299,7 @@ internal static class DiagnosticsGenerator
             }
 
             // Plugin decorators (we don't have chain order info, just show the decorator types)
-            foreach (var (assembly, type) in pluginDecorators.OrderBy(x => x.Type.ShortName))
+            foreach (var (assembly, type) in pluginDecorators.OrderBy(x => x.Type.ShortName, StringComparer.Ordinal))
             {
                 var decoratorId = GeneratorHelpers.GetMermaidNodeId(type.FullName);
                 var decoratorName = type.ShortName;
@@ -324,7 +324,7 @@ internal static class DiagnosticsGenerator
             sb.AppendLine("graph LR");
 
             // Host intercepted services
-            foreach (var service in interceptedServices.OrderBy(s => s.TypeName))
+            foreach (var service in interceptedServices.OrderBy(s => s.TypeName, StringComparer.Ordinal))
             {
                 var targetId = GeneratorHelpers.GetMermaidNodeId(service.TypeName);
                 var targetName = GeneratorHelpers.GetShortTypeName(service.TypeName);
@@ -349,7 +349,7 @@ internal static class DiagnosticsGenerator
             }
 
             // Plugin intercepted services
-            foreach (var (assembly, type) in pluginInterceptors.OrderBy(x => x.Type.ShortName))
+            foreach (var (assembly, type) in pluginInterceptors.OrderBy(x => x.Type.ShortName, StringComparer.Ordinal))
             {
                 var targetId = GeneratorHelpers.GetMermaidNodeId(type.FullName);
                 var targetName = type.ShortName;
@@ -378,13 +378,13 @@ internal static class DiagnosticsGenerator
             var typesByKey = keyedTypes
                 .SelectMany(t => t.ServiceKeys.Select(k => (Key: k, Type: t)))
                 .GroupBy(x => x.Key)
-                .OrderBy(g => g.Key);
+                .OrderBy(g => g.Key, StringComparer.Ordinal);
 
             foreach (var keyGroup in typesByKey)
             {
                 var safeKey = GeneratorHelpers.SanitizeMermaidId(keyGroup.Key);
                 sb.AppendLine($"    subgraph key_{safeKey}[\"{GeneratorHelpers.EscapeMermaidLabel(keyGroup.Key)}\"]");
-                foreach (var item in keyGroup.OrderBy(x => x.Type.TypeName))
+                foreach (var item in keyGroup.OrderBy(x => x.Type.TypeName, StringComparer.Ordinal))
                 {
                     var nodeId = GeneratorHelpers.GetMermaidNodeId(item.Type.TypeName);
                     var nodeName = GeneratorHelpers.GetShortTypeName(item.Type.TypeName);
@@ -409,14 +409,14 @@ internal static class DiagnosticsGenerator
             // Group plugins by assembly
             var pluginsByAssembly = plugins
                 .GroupBy(p => p.AssemblyName)
-                .OrderBy(g => g.Key);
+                .OrderBy(g => g.Key, StringComparer.Ordinal);
 
             foreach (var asmGroup in pluginsByAssembly)
             {
                 var safeAsm = GeneratorHelpers.SanitizeMermaidId(asmGroup.Key);
                 var shortAsm = GeneratorHelpers.GetShortTypeName(asmGroup.Key);
                 sb.AppendLine($"    subgraph asm_{safeAsm}[\"{GeneratorHelpers.EscapeMermaidLabel(shortAsm)}\"]");
-                foreach (var plugin in asmGroup.OrderBy(p => p.TypeName))
+                foreach (var plugin in asmGroup.OrderBy(p => p.TypeName, StringComparer.Ordinal))
                 {
                     var nodeId = GeneratorHelpers.GetMermaidNodeId(plugin.TypeName);
                     var nodeName = GeneratorHelpers.GetShortTypeName(plugin.TypeName);
@@ -444,7 +444,7 @@ internal static class DiagnosticsGenerator
             sb.AppendLine("graph LR");
 
             // Host factories
-            foreach (var factory in factories.OrderBy(f => f.TypeName))
+            foreach (var factory in factories.OrderBy(f => f.TypeName, StringComparer.Ordinal))
             {
                 var sourceNodeId = GeneratorHelpers.GetMermaidNodeId(factory.TypeName);
                 var sourceName = GeneratorHelpers.GetShortTypeName(factory.TypeName);
@@ -460,7 +460,7 @@ internal static class DiagnosticsGenerator
             }
 
             // Plugin factories
-            foreach (var (assembly, type) in pluginFactories.OrderBy(f => f.Type.ShortName))
+            foreach (var (assembly, type) in pluginFactories.OrderBy(f => f.Type.ShortName, StringComparer.Ordinal))
             {
                 var sourceNodeId = GeneratorHelpers.GetMermaidNodeId(type.FullName);
                 var sourceName = type.ShortName;
@@ -488,7 +488,7 @@ internal static class DiagnosticsGenerator
             sb.AppendLine("```mermaid");
             sb.AppendLine("graph LR");
 
-            foreach (var type in typesWithInterfaces.OrderBy(t => t.TypeName))
+            foreach (var type in typesWithInterfaces.OrderBy(t => t.TypeName, StringComparer.Ordinal))
             {
                 var implId = GeneratorHelpers.GetMermaidNodeId(type.TypeName);
                 var implName = GeneratorHelpers.GetShortTypeName(type.TypeName);
@@ -514,7 +514,7 @@ internal static class DiagnosticsGenerator
         sb.AppendLine("| Metric | Value |");
         sb.AppendLine("|--------|-------|");
 
-        sb.AppendLine($"| Total Services | {types.Count} |");
+        sb.AppendLine($"| Total Services | {GeneratorHelpers.Literal(types.Count)} |");
 
         // Calculate max dependency depth using BFS
         var maxDepth = CalculateMaxDependencyDepth(types);
@@ -522,7 +522,7 @@ internal static class DiagnosticsGenerator
 
         // Calculate hub services (services that appear as dependencies in 3+ other services)
         var hubServices = CalculateHubServices(types, 3);
-        sb.AppendLine($"| Hub Services (≥3 dependents) | {hubServices.Count} |");
+        sb.AppendLine($"| Hub Services (≥3 dependents) | {GeneratorHelpers.Literal(hubServices.Count)} |");
 
         if (hubServices.Any())
         {
@@ -538,7 +538,7 @@ internal static class DiagnosticsGenerator
         sb.AppendLine("| Service | Lifetime | Dependencies |");
         sb.AppendLine("|---------|----------|--------------|");
 
-        foreach (var type in types.OrderBy(t => t.TypeName))
+        foreach (var type in types.OrderBy(t => t.TypeName, StringComparer.Ordinal))
         {
             var deps = type.ConstructorParameterTypes.Any()
                 ? string.Join(", ", type.ConstructorParameterTypes.Select(GeneratorHelpers.GetShortTypeName))
@@ -572,7 +572,7 @@ internal static class DiagnosticsGenerator
             sb.AppendLine("## Referenced Plugin Assemblies");
             sb.AppendLine();
 
-            foreach (var kvp in referencedAssemblyTypes.OrderBy(kv => kv.Key))
+            foreach (var kvp in referencedAssemblyTypes.OrderBy(kv => kv.Key, StringComparer.Ordinal))
             {
                 var refAsm = kvp.Key;
                 var refTypes = kvp.Value;
@@ -600,9 +600,9 @@ internal static class DiagnosticsGenerator
 
         if (total > 0)
         {
-            sb.AppendLine($"| Singleton | {singletons.Count} | {GeneratorHelpers.Percentage(singletons.Count, total)}% |");
-            sb.AppendLine($"| Scoped | {scopeds.Count} | {GeneratorHelpers.Percentage(scopeds.Count, total)}% |");
-            sb.AppendLine($"| Transient | {transients.Count} | {GeneratorHelpers.Percentage(transients.Count, total)}% |");
+            sb.AppendLine($"| Singleton | {GeneratorHelpers.Literal(singletons.Count)} | {GeneratorHelpers.Percentage(singletons.Count, total)}% |");
+            sb.AppendLine($"| Scoped | {GeneratorHelpers.Literal(scopeds.Count)} | {GeneratorHelpers.Percentage(scopeds.Count, total)}% |");
+            sb.AppendLine($"| Transient | {GeneratorHelpers.Literal(transients.Count)} | {GeneratorHelpers.Percentage(transients.Count, total)}% |");
             sb.AppendLine($"| **Total** | **{total}** | 100% |");
         }
         else
@@ -615,27 +615,27 @@ internal static class DiagnosticsGenerator
         // List by category
         if (singletons.Any())
         {
-            sb.AppendLine($"## Singleton ({singletons.Count})");
+            sb.AppendLine($"## Singleton ({GeneratorHelpers.Literal(singletons.Count)})");
             sb.AppendLine();
-            foreach (var type in singletons.OrderBy(t => t.TypeName))
+            foreach (var type in singletons.OrderBy(t => t.TypeName, StringComparer.Ordinal))
                 sb.AppendLine($"- {GeneratorHelpers.GetShortTypeName(type.TypeName)}");
             sb.AppendLine();
         }
 
         if (scopeds.Any())
         {
-            sb.AppendLine($"## Scoped ({scopeds.Count})");
+            sb.AppendLine($"## Scoped ({GeneratorHelpers.Literal(scopeds.Count)})");
             sb.AppendLine();
-            foreach (var type in scopeds.OrderBy(t => t.TypeName))
+            foreach (var type in scopeds.OrderBy(t => t.TypeName, StringComparer.Ordinal))
                 sb.AppendLine($"- {GeneratorHelpers.GetShortTypeName(type.TypeName)}");
             sb.AppendLine();
         }
 
         if (transients.Any())
         {
-            sb.AppendLine($"## Transient ({transients.Count})");
+            sb.AppendLine($"## Transient ({GeneratorHelpers.Literal(transients.Count)})");
             sb.AppendLine();
-            foreach (var type in transients.OrderBy(t => t.TypeName))
+            foreach (var type in transients.OrderBy(t => t.TypeName, StringComparer.Ordinal))
                 sb.AppendLine($"- {GeneratorHelpers.GetShortTypeName(type.TypeName)}");
             sb.AppendLine();
         }
@@ -663,18 +663,18 @@ internal static class DiagnosticsGenerator
             sb.AppendLine("## Referenced Plugin Assemblies");
             sb.AppendLine();
 
-            foreach (var kvp in referencedAssemblyTypes.OrderBy(kv => kv.Key))
+            foreach (var kvp in referencedAssemblyTypes.OrderBy(kv => kv.Key, StringComparer.Ordinal))
             {
                 var refAsm = kvp.Key;
                 var refTypes = kvp.Value;
 
-                sb.AppendLine($"### {refAsm} ({refTypes.Count} services)");
+                sb.AppendLine($"### {refAsm} ({GeneratorHelpers.Literal(refTypes.Count)} services)");
                 sb.AppendLine();
                 sb.AppendLine("| # | Interface | Implementation | Lifetime |");
                 sb.AppendLine("|---|-----------|----------------|----------|");
 
                 var index = 1;
-                foreach (var type in refTypes.OrderBy(t => t.ShortName))
+                foreach (var type in refTypes.OrderBy(t => t.ShortName, StringComparer.Ordinal))
                 {
                     var iface = type.Interfaces.FirstOrDefault() ?? "-";
                     sb.AppendLine($"| {index} | {GeneratorHelpers.GetShortTypeName(iface)} | {type.ShortName} | {type.Lifetime} |");
@@ -685,7 +685,7 @@ internal static class DiagnosticsGenerator
         }
 
         // Services table
-        sb.AppendLine($"## Services ({types.Count})");
+        sb.AppendLine($"## Services ({GeneratorHelpers.Literal(types.Count)})");
         sb.AppendLine();
 
         if (types.Any())
@@ -694,7 +694,7 @@ internal static class DiagnosticsGenerator
             sb.AppendLine("|---|-----------|----------------|----------|--------|");
 
             var index = 1;
-            foreach (var type in types.OrderBy(t => t.TypeName))
+            foreach (var type in types.OrderBy(t => t.TypeName, StringComparer.Ordinal))
             {
                 var iface = type.InterfaceNames.FirstOrDefault() ?? "-";
                 var source = BreadcrumbWriter.GetRelativeSourcePath(type.SourceFilePath, projectDirectory);
@@ -725,7 +725,7 @@ internal static class DiagnosticsGenerator
             // Host decorators
             var decoratorsByTarget = decorators
                 .GroupBy(d => d.ServiceTypeName)
-                .OrderBy(g => g.Key);
+                .OrderBy(g => g.Key, StringComparer.Ordinal);
 
             foreach (var group in decoratorsByTarget)
             {
@@ -736,7 +736,7 @@ internal static class DiagnosticsGenerator
             }
 
             // Plugin decorators
-            foreach (var (assembly, type) in pluginDecorators.OrderBy(x => x.Type.ShortName))
+            foreach (var (assembly, type) in pluginDecorators.OrderBy(x => x.Type.ShortName, StringComparer.Ordinal))
             {
                 // For plugin decorators, we show them individually since we don't have chain info
                 var serviceName = type.Interfaces.FirstOrDefault() ?? "-";
@@ -760,7 +760,7 @@ internal static class DiagnosticsGenerator
             sb.AppendLine("|---------|--------------|-------|----------|");
 
             // Host intercepted services
-            foreach (var service in interceptedServices.OrderBy(s => s.TypeName))
+            foreach (var service in interceptedServices.OrderBy(s => s.TypeName, StringComparer.Ordinal))
             {
                 var serviceName = GeneratorHelpers.GetShortTypeName(service.TypeName);
                 var interceptors = string.Join(", ", service.AllInterceptorTypeNames.Select(GeneratorHelpers.GetShortTypeName));
@@ -769,7 +769,7 @@ internal static class DiagnosticsGenerator
             }
 
             // Plugin intercepted services
-            foreach (var (assembly, type) in pluginIntercepted.OrderBy(x => x.Type.ShortName))
+            foreach (var (assembly, type) in pluginIntercepted.OrderBy(x => x.Type.ShortName, StringComparer.Ordinal))
             {
                 var proxyName = type.ShortName + "_InterceptorProxy";
                 sb.AppendLine($"| {type.ShortName} | (see plugin) | {proxyName} | {assembly} |");
@@ -792,7 +792,7 @@ internal static class DiagnosticsGenerator
             sb.AppendLine("|-------------|-------------------|-------------------|----------|");
 
             // Host factories
-            foreach (var factory in factories.OrderBy(f => f.TypeName))
+            foreach (var factory in factories.OrderBy(f => f.TypeName, StringComparer.Ordinal))
             {
                 var sourceName = factory.SimpleTypeName;
                 var factoryInterface = "I" + sourceName + "Factory";
@@ -801,7 +801,7 @@ internal static class DiagnosticsGenerator
             }
 
             // Plugin factories
-            foreach (var (assembly, type) in pluginFactories.OrderBy(x => x.Type.ShortName))
+            foreach (var (assembly, type) in pluginFactories.OrderBy(x => x.Type.ShortName, StringComparer.Ordinal))
             {
                 var factoryInterface = "I" + type.ShortName + "Factory";
                 var factoryImpl = type.ShortName + "Factory";
@@ -813,9 +813,9 @@ internal static class DiagnosticsGenerator
         // Plugins section
         if (plugins.Any())
         {
-            var orderedPlugins = plugins.OrderBy(p => p.Order).ThenBy(p => p.TypeName);
+            var orderedPlugins = plugins.OrderBy(p => p.Order).ThenBy(p => p.TypeName, StringComparer.Ordinal);
 
-            sb.AppendLine($"## Plugins ({plugins.Count})");
+            sb.AppendLine($"## Plugins ({GeneratorHelpers.Literal(plugins.Count)})");
             sb.AppendLine();
             sb.AppendLine("| Order | Plugin | Interfaces |");
             sb.AppendLine("|-------|--------|------------|");
@@ -823,7 +823,7 @@ internal static class DiagnosticsGenerator
             foreach (var plugin in orderedPlugins)
             {
                 var interfaces = string.Join(", ", plugin.InterfaceNames.Select(GeneratorHelpers.GetShortTypeName));
-                sb.AppendLine($"| {plugin.Order} | {GeneratorHelpers.GetShortTypeName(plugin.TypeName)} | {interfaces} |");
+                sb.AppendLine($"| {GeneratorHelpers.Literal(plugin.Order)} | {GeneratorHelpers.GetShortTypeName(plugin.TypeName)} | {interfaces} |");
             }
             sb.AppendLine();
         }
@@ -837,7 +837,7 @@ internal static class DiagnosticsGenerator
             sb.AppendLine("| Key | Interface | Implementation | Lifetime |");
             sb.AppendLine("|-----|-----------|----------------|----------|");
 
-            foreach (var type in keyedTypes.OrderBy(t => t.TypeName))
+            foreach (var type in keyedTypes.OrderBy(t => t.TypeName, StringComparer.Ordinal))
             {
                 foreach (var key in type.ServiceKeys)
                 {
@@ -1093,7 +1093,7 @@ internal static class DiagnosticsGenerator
         sb.AppendLine();
         sb.AppendLine($"| Metric | Count |");
         sb.AppendLine($"|:-------|------:|");
-        sb.AppendLine($"| Total Options Classes | {options.Count} |");
+        sb.AppendLine($"| Total Options Classes | {GeneratorHelpers.Literal(options.Count)} |");
         sb.AppendLine($"| Named Options | {options.Count(o => o.IsNamed)} |");
         sb.AppendLine($"| With Validation | {options.Count(o => o.ValidateOnStart)} |");
         sb.AppendLine($"| With External Validator | {options.Count(o => o.HasExternalValidator)} |");
@@ -1105,7 +1105,7 @@ internal static class DiagnosticsGenerator
         sb.AppendLine("| Class | Section | Name | ValidateOnStart | Validator |");
         sb.AppendLine("|:------|:--------|:-----|:---------------:|:----------|");
 
-        foreach (var opt in options.OrderBy(o => o.SectionName).ThenBy(o => o.TypeName))
+        foreach (var opt in options.OrderBy(o => o.SectionName, StringComparer.Ordinal).ThenBy(o => o.TypeName, StringComparer.Ordinal))
         {
             var shortName = GeneratorHelpers.GetShortTypeName(opt.TypeName);
             var namedLabel = opt.IsNamed ? opt.Name : "-";
@@ -1118,7 +1118,7 @@ internal static class DiagnosticsGenerator
         sb.AppendLine();
 
         // Detailed breakdown by section
-        var sectionGroups = options.GroupBy(o => o.SectionName).OrderBy(g => g.Key);
+        var sectionGroups = options.GroupBy(o => o.SectionName).OrderBy(g => g.Key, StringComparer.Ordinal);
         
         sb.AppendLine("## Configuration Sections");
         sb.AppendLine();
@@ -1128,7 +1128,7 @@ internal static class DiagnosticsGenerator
             sb.AppendLine($"### `{group.Key}`");
             sb.AppendLine();
 
-            foreach (var opt in group.OrderBy(o => o.TypeName))
+            foreach (var opt in group.OrderBy(o => o.TypeName, StringComparer.Ordinal))
             {
                 var shortName = GeneratorHelpers.GetShortTypeName(opt.TypeName);
                 sb.AppendLine($"**{shortName}**");

--- a/src/NexusLabs.Needlr.Generators/Export/GraphExporter.cs
+++ b/src/NexusLabs.Needlr.Generators/Export/GraphExporter.cs
@@ -402,16 +402,16 @@ internal static class GraphExporter
         
         // Statistics object
         sb.AppendLine("  \"statistics\": {");
-        sb.AppendLine($"    \"totalServices\": {graph.Statistics.TotalServices},");
-        sb.AppendLine($"    \"singletons\": {graph.Statistics.Singletons},");
-        sb.AppendLine($"    \"scoped\": {graph.Statistics.Scoped},");
-        sb.AppendLine($"    \"transient\": {graph.Statistics.Transient},");
-        sb.AppendLine($"    \"decorators\": {graph.Statistics.Decorators},");
-        sb.AppendLine($"    \"interceptors\": {graph.Statistics.Interceptors},");
-        sb.AppendLine($"    \"factories\": {graph.Statistics.Factories},");
-        sb.AppendLine($"    \"options\": {graph.Statistics.Options},");
-        sb.AppendLine($"    \"hostedServices\": {graph.Statistics.HostedServices},");
-        sb.AppendLine($"    \"plugins\": {graph.Statistics.Plugins}");
+        sb.AppendLine($"    \"totalServices\": {GeneratorHelpers.Literal(graph.Statistics.TotalServices)},");
+        sb.AppendLine($"    \"singletons\": {GeneratorHelpers.Literal(graph.Statistics.Singletons)},");
+        sb.AppendLine($"    \"scoped\": {GeneratorHelpers.Literal(graph.Statistics.Scoped)},");
+        sb.AppendLine($"    \"transient\": {GeneratorHelpers.Literal(graph.Statistics.Transient)},");
+        sb.AppendLine($"    \"decorators\": {GeneratorHelpers.Literal(graph.Statistics.Decorators)},");
+        sb.AppendLine($"    \"interceptors\": {GeneratorHelpers.Literal(graph.Statistics.Interceptors)},");
+        sb.AppendLine($"    \"factories\": {GeneratorHelpers.Literal(graph.Statistics.Factories)},");
+        sb.AppendLine($"    \"options\": {GeneratorHelpers.Literal(graph.Statistics.Options)},");
+        sb.AppendLine($"    \"hostedServices\": {GeneratorHelpers.Literal(graph.Statistics.HostedServices)},");
+        sb.AppendLine($"    \"plugins\": {GeneratorHelpers.Literal(graph.Statistics.Plugins)}");
         sb.AppendLine("  }");
         
         sb.AppendLine("}");
@@ -439,8 +439,8 @@ internal static class GraphExporter
             {
                 sb.AppendLine("          \"location\": {");
                 sb.AppendLine($"            \"filePath\": {NullableString(iface.Location.FilePath)},");
-                sb.AppendLine($"            \"line\": {iface.Location.Line},");
-                sb.AppendLine($"            \"column\": {iface.Location.Column}");
+                sb.AppendLine($"            \"line\": {GeneratorHelpers.Literal(iface.Location.Line)},");
+                sb.AppendLine($"            \"column\": {GeneratorHelpers.Literal(iface.Location.Column)}");
                 sb.AppendLine("          }");
             }
             else
@@ -458,8 +458,8 @@ internal static class GraphExporter
         {
             sb.AppendLine("      \"location\": {");
             sb.AppendLine($"        \"filePath\": {NullableString(service.Location.FilePath)},");
-            sb.AppendLine($"        \"line\": {service.Location.Line},");
-            sb.AppendLine($"        \"column\": {service.Location.Column}");
+            sb.AppendLine($"        \"line\": {GeneratorHelpers.Literal(service.Location.Line)},");
+            sb.AppendLine($"        \"column\": {GeneratorHelpers.Literal(service.Location.Column)}");
             sb.AppendLine("      },");
         }
         else
@@ -491,7 +491,7 @@ internal static class GraphExporter
         {
             var dec = service.Decorators[i];
             var comma = i < service.Decorators.Count - 1 ? "," : "";
-            sb.AppendLine($"        {{ \"typeName\": \"{Escape(dec.TypeName)}\", \"order\": {dec.Order} }}{comma}");
+            sb.AppendLine($"        {{ \"typeName\": \"{Escape(dec.TypeName)}\", \"order\": {GeneratorHelpers.Literal(dec.Order)} }}{comma}");
         }
         sb.AppendLine("      ],");
         
@@ -533,8 +533,8 @@ internal static class GraphExporter
         {
             sb.AppendLine("      \"location\": {");
             sb.AppendLine($"        \"filePath\": {NullableString(diagnostic.Location.FilePath)},");
-            sb.AppendLine($"        \"line\": {diagnostic.Location.Line},");
-            sb.AppendLine($"        \"column\": {diagnostic.Location.Column}");
+            sb.AppendLine($"        \"line\": {GeneratorHelpers.Literal(diagnostic.Location.Line)},");
+            sb.AppendLine($"        \"column\": {GeneratorHelpers.Literal(diagnostic.Location.Column)}");
             sb.AppendLine("      },");
         }
         else

--- a/src/NexusLabs.Needlr.Generators/GeneratorHelpers.cs
+++ b/src/NexusLabs.Needlr.Generators/GeneratorHelpers.cs
@@ -16,6 +16,21 @@ namespace NexusLabs.Needlr.Generators;
 internal static class GeneratorHelpers
 {
     /// <summary>
+    /// Formats an integer for emission into generated source or JSON.
+    /// </summary>
+    /// <remarks>
+    /// String interpolation uses the ambient culture, and several locales render a
+    /// negative number with U+2212 MINUS SIGN, which is not valid C#. Every number that
+    /// reaches generated output must go through this method. A generator cannot pin the
+    /// ambient culture instead: <c>RS1035</c> bans analyzers from touching
+    /// <c>CultureInfo.CurrentCulture</c>.
+    /// </remarks>
+    public static string Literal(int value)
+    {
+        return value.ToString(System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>
     /// Sanitizes an assembly name to be a valid C# identifier for use in namespaces.
     /// </summary>
     public static string SanitizeIdentifier(string name)


### PR DESCRIPTION
Addresses two of the three defects in #141. Stacked on #142 — **review that first**; this PR's diff includes it until #142 merges.

## What was broken

Generated source inherited the build machine's culture in two ways. One of them was not a determinism problem at all — it produced C# that does not compile.

### 1. Negative numbers used the locale's minus sign — a build break

Numbers reached emitted output through string interpolation, which formats with `CultureInfo.CurrentCulture`:

```
en-US  => new PluginCatalogEntry("X", -100),
sv-SE  => new PluginCatalogEntry("X", −100),
fi-FI  => new PluginCatalogEntry("X", −100),
```

`−100` is U+2212 MINUS SIGN and is not valid C#. Negative `Order` values are supported and exercised (`PluginOrderingTypes.cs` uses `Order = -100` and `-50`), so **any consumer building on an affected locale with a negatively ordered plugin or decorator got generated code that failed to compile.**

### 2. String ordering was culture-sensitive

`OrderBy(x => x.TypeName)` with no comparer uses `Comparer<string>.Default`, which is culture-sensitive. Same machine, same ICU, only the locale changed:

```
en-US : _Cache, BackgroundWorker, IUserservice, IUserService, my_type, MyType
da-DK : _Cache, BackgroundWorker, IUserService, IUserservice, my_type, MyType
```

## Why both are in one PR

They share one root cause — ambient culture leaking into emitted output — and one guard test. The cross-culture comparison **only reaches green when both are fixed**, so splitting them would ship a knowingly-red test. The `lt-LT` case is what proved this: after fixing the numbers, `NeedlrDiagnostics.g.cs` still differed under Lithuanian collation, which is what demonstrated the ordering defect was real rather than theoretical.

## Two central fixes were tried and rejected on evidence

I did not pick the per-site approach by preference. I tried the systemic options first and measured them:

- **`CA1305` (Specify `IFormatProvider`) cannot enforce this.** Enabled against the *defective* code with `AnalysisMode=AllEnabledByDefault`, it produced **zero hits** — it does not flag interpolated strings here. I had flagged this as needing verification in #141 rather than assuming it; the verification came back negative.
- **Pinning the culture centrally is banned outright.** I implemented an `InvariantCultureScope` around each `RegisterSourceOutput` callback. It failed the build: `EnforceExtendedAnalyzerRules` raises `error RS1035: The symbol 'CultureInfo.CurrentCulture' is banned for use by analyzers`. Roslyn explicitly prohibits this. That approach was reverted.

So per-site formatting plus a whole-output test is what remains available, not what I would have chosen first.

## Red → green

**Red** — the test was written before the fix and observed failing:

```
Failed!  - Failed: 6, Passed: 0

Assert.DoesNotContain() Failure: Item found in collection
                            ↓ (pos 282845)
Collection: [···, ',', ' ', '−', '1', '0', ···]
Found:      '−'
```

Then, after fixing the numbers only, the remaining failure named the second defect precisely:

```
'NeedlrDiagnostics.g.cs' differs between en-US and lt-LT.
Generated source must not depend on the build machine's culture.
```

**Green** — after both fixes, no change to the test:

```
Passed!  - Failed: 0, Passed: 6, Total: 6
```

## The guard

`GeneratedSourceCultureInvarianceTests` runs generation under `en-US` and under `sv-SE`, `fi-FI`, and `lt-LT`, then compares **every generated file** byte-for-byte — not just the file I knew was broken. That is deliberate: it covers emitters added later, which is the coverage the unavailable analyzers would have provided.

The narrower assertion (no U+2212 anywhere, and `, -100,` present in the catalog) stays alongside it so a failure names the actual defect rather than just reporting a diff.

## Changes

- `GeneratorHelpers.Literal(int)` — invariant numeric formatting; **48 emission sites** routed through it across `CodeGen/`, `Export/`, and `DiagnosticsGenerator.cs`.
- `StringComparer.Ordinal` added to **38 string-keyed sorts**. Numeric sort keys were deliberately left alone — a `StringComparer` on `Order` would not compile.
- `generator-determinism.instructions.md` gains an "Ambient culture is ambient state" section recording the rules, both failed enforcement routes, and the instruction to extend the guard test's source sample when adding an emitter.

## Verification

- 1,083 generator tests pass (up from 1,077 — the 6 new ones).
- 519 integration tests pass. This mattered more than usual: reordering emission could have broken tests asserting registration order, and none did.

## Disclosures

- **Not fixed here:** path separators (defect 3 of #141) — `ServiceCatalog.g.cs` still emits `Options\\Foo.cs` where every other emitter emits `Options/Foo.cs`. That is the next PR in the stack.
- **Ordinal ordering changes emitted order** versus the previous culture-sensitive order on any machine. Behaviour is unchanged — plugin and decorator execution order is driven by `Order`, with the name only a tiebreak — but the generated text differs from the previous output on the same machine. Expected and desirable; noting it because it is a visible diff in generated files.
- The replacements were applied by script over an explicit member allowlist, then verified by the whole-file cross-culture comparison rather than by inspection. A site the script missed and the test sample does not exercise would still be wrong. The test sample covers decorators, diagnostics, and graph export; it does **not** exercise factories, interceptors, options, or hosted services, so numeric emission in those emitters is fixed but not covered.
- Roslyn's ICU-version sensitivity across operating systems remains unproven either way, as stated in #141. Ordinal ordering makes the question moot for ordering; it does not address the newline difference already documented.
