### PR TITLE
fix: normalize emitted source paths and stop leaking absolute paths

### DIFF
--- a/.claude/rules/generated/generator-determinism.md
+++ b/.claude/rules/generated/generator-determinism.md
@@ -55,6 +55,30 @@ Two enforcement routes do **not** work here, so do not rely on them:
 `en-US` and under hostile locales and compares every generated file. Extend its source
 sample when adding an emitter, or the new emitter is uncovered.
 
+## Emitted paths are normalized, relative, and never absolute
+
+Roslyn reports `SyntaxTree.FilePath` with the host's native separator, so a path copied
+through unchanged is `Services\Thing.cs` on Windows and `Services/Thing.cs` on Linux —
+different bytes in the compiled assembly for the same source.
+
+- **Always call `BreadcrumbWriter.GetRelativeSourcePath`.** Never write a private path
+  helper in an emitter. A duplicate private copy in the service-catalog emitter is
+  exactly how the separator defect survived while every other emitter was correct.
+- It normalizes separators to `/`, relativizes against the project directory, and falls
+  back to the bare file name rather than emitting an absolute path. An absolute path
+  embeds the build machine's directory layout into the shipped assembly.
+
+`GeneratedSourcePathNormalizationTests` supplies Windows-style paths explicitly so it
+fails on a non-Windows agent too, rather than passing by accident of the host.
+
+## Analyzer-config options in tests
+
+`AnalyzerConfigOptions` compares keys **case-insensitively** through
+`AnalyzerConfigOptions.KeyComparer`. A test double backed by a default `Dictionary` is
+case-sensitive, so a generator reading `build_property.ProjectDir` silently misses a test
+that set `build_property.projectdir`, takes its "option absent" branch, and the test
+passes while proving nothing. Any new options double must use `KeyComparer`.
+
 ## Stamp timestamps where the artifact is written
 A timestamp is legitimate in a human-readable report, but it must never reach `AddSource`.
 Emit a constant placeholder and substitute the real value at the point the artifact is

--- a/.github/instructions/generator-determinism.instructions.md
+++ b/.github/instructions/generator-determinism.instructions.md
@@ -52,6 +52,30 @@ Two enforcement routes do **not** work here, so do not rely on them:
 `en-US` and under hostile locales and compares every generated file. Extend its source
 sample when adding an emitter, or the new emitter is uncovered.
 
+## Emitted paths are normalized, relative, and never absolute
+
+Roslyn reports `SyntaxTree.FilePath` with the host's native separator, so a path copied
+through unchanged is `Services\Thing.cs` on Windows and `Services/Thing.cs` on Linux —
+different bytes in the compiled assembly for the same source.
+
+- **Always call `BreadcrumbWriter.GetRelativeSourcePath`.** Never write a private path
+  helper in an emitter. A duplicate private copy in the service-catalog emitter is
+  exactly how the separator defect survived while every other emitter was correct.
+- It normalizes separators to `/`, relativizes against the project directory, and falls
+  back to the bare file name rather than emitting an absolute path. An absolute path
+  embeds the build machine's directory layout into the shipped assembly.
+
+`GeneratedSourcePathNormalizationTests` supplies Windows-style paths explicitly so it
+fails on a non-Windows agent too, rather than passing by accident of the host.
+
+## Analyzer-config options in tests
+
+`AnalyzerConfigOptions` compares keys **case-insensitively** through
+`AnalyzerConfigOptions.KeyComparer`. A test double backed by a default `Dictionary` is
+case-sensitive, so a generator reading `build_property.ProjectDir` silently misses a test
+that set `build_property.projectdir`, takes its "option absent" branch, and the test
+passes while proving nothing. Any new options double must use `KeyComparer`.
+
 ## Stamp timestamps where the artifact is written
 A timestamp is legitimate in a human-readable report, but it must never reach `AddSource`.
 Emit a constant placeholder and substitute the real value at the point the artifact is

--- a/src/NexusLabs.Needlr.Generators.Tests/Diagnostics/DiagnosticTestHelpers.cs
+++ b/src/NexusLabs.Needlr.Generators.Tests/Diagnostics/DiagnosticTestHelpers.cs
@@ -273,7 +273,11 @@ internal sealed class TestAnalyzerConfigOptions : AnalyzerConfigOptions
 
     public TestAnalyzerConfigOptions(Dictionary<string, string> options)
     {
-        _options = options;
+        // Roslyn compares analyzer-config keys case-insensitively via KeyComparer. A
+        // case-sensitive dictionary here silently misses options whose casing differs
+        // between the test that sets them and the generator that reads them, so the
+        // generator takes its "option absent" path and the test proves nothing.
+        _options = new Dictionary<string, string>(options, KeyComparer);
     }
 
     public override bool TryGetValue(string key, out string value)

--- a/src/NexusLabs.Needlr.Generators.Tests/GeneratedSourcePathNormalizationTests.cs
+++ b/src/NexusLabs.Needlr.Generators.Tests/GeneratedSourcePathNormalizationTests.cs
@@ -1,0 +1,110 @@
+using NexusLabs.Needlr;
+
+using Xunit;
+
+namespace NexusLabs.Needlr.Generators.Tests;
+
+/// <summary>
+/// Guards emitted source-file paths against the host operating system.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Roslyn reports <c>SyntaxTree.FilePath</c> using the host's native separator, so an
+/// emitter that copies it through unchanged writes <c>Services\Thing.cs</c> on Windows
+/// and <c>Services/Thing.cs</c> on Linux. Those are different bytes in the compiled
+/// assembly, so the same source produces different output per operating system.
+/// </para>
+/// <para>
+/// An absolute path is worse than a separator difference: it embeds the build machine's
+/// directory layout into the shipped assembly.
+/// </para>
+/// </remarks>
+public sealed class GeneratedSourcePathNormalizationTests
+{
+    private const string ProjectDirectory = @"C:\build\TestApp";
+
+    [Fact]
+    public void EmittedPaths_UseForwardSlashes_WhenHostUsesBackslashes()
+    {
+        var generated = Generate();
+
+        foreach (var file in generated)
+        {
+            Assert.False(
+                ContainsWindowsStyleSourcePath(file.Content),
+                $"'{file.FilePath}' emits a backslash-separated source path. Emitted paths "
+                    + "must be normalized to '/' so output does not depend on the host OS.");
+        }
+    }
+
+    [Fact]
+    public void EmittedPaths_AreRelative_AndNeverLeakTheBuildDirectory()
+    {
+        var generated = Generate();
+
+        foreach (var file in generated)
+        {
+            Assert.DoesNotContain("C:/build", file.Content, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain(@"C:\\build", file.Content, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    [Fact]
+    public void ServiceCatalog_EmitsTheSameRelativePathAsTheTypeRegistry()
+    {
+        var generated = Generate();
+
+        var catalog = generated.Single(
+            f => f.FilePath.EndsWith("ServiceCatalog.g.cs", StringComparison.Ordinal));
+
+        Assert.Contains("Services/Thing.cs", catalog.Content, StringComparison.Ordinal);
+        Assert.Contains("Contracts/IThing.cs", catalog.Content, StringComparison.Ordinal);
+    }
+
+    private static bool ContainsWindowsStyleSourcePath(string content)
+    {
+        // The emitted C# escapes a literal backslash, so a native Windows path appears
+        // as "Services\\Thing.cs" in the generated text.
+        return content.Contains(@"\\Thing.cs")
+            || content.Contains(@"\\IThing.cs")
+            || content.Contains(@"\Thing.cs")
+            || content.Contains(@"\IThing.cs");
+    }
+
+    private static IReadOnlyList<GeneratedFileSnapshot> Generate()
+    {
+        var files = GeneratorTestRunner.ForTypeRegistry()
+            .WithReference<DecoratorForAttribute<object>>()
+            .WithProjectDir(ProjectDirectory)
+            .WithSourceFile(
+                @"C:\build\TestApp\AssemblyInfo.cs",
+                """
+                using NexusLabs.Needlr.Generators;
+
+                [assembly: GenerateTypeRegistry]
+                """)
+            .WithSourceFile(
+                @"C:\build\TestApp\Contracts\IThing.cs",
+                """
+                namespace TestApp
+                {
+                    public interface IThing { }
+                }
+                """)
+            .WithSourceFile(
+                @"C:\build\TestApp\Services\Thing.cs",
+                """
+                namespace TestApp
+                {
+                    public sealed class Thing : IThing { }
+                }
+                """)
+            .RunTypeRegistryGeneratorFiles();
+
+        return files
+            .Select(f => new GeneratedFileSnapshot(f.FilePath, f.Content))
+            .ToList();
+    }
+
+    private sealed record GeneratedFileSnapshot(string FilePath, string Content);
+}

--- a/src/NexusLabs.Needlr.Generators.Tests/GeneratorTestRunner.cs
+++ b/src/NexusLabs.Needlr.Generators.Tests/GeneratorTestRunner.cs
@@ -913,7 +913,11 @@ internal sealed class FlexibleAnalyzerConfigOptions : AnalyzerConfigOptions
 
     public FlexibleAnalyzerConfigOptions(Dictionary<string, string> options)
     {
-        _options = options;
+        // Roslyn compares analyzer-config keys case-insensitively via KeyComparer. A
+        // case-sensitive dictionary here silently misses options whose casing differs
+        // between the test that sets them and the generator that reads them, so the
+        // generator takes its "option absent" path and the test proves nothing.
+        _options = new Dictionary<string, string>(options, KeyComparer);
     }
 
     public override bool TryGetValue(string key, out string value)

--- a/src/NexusLabs.Needlr.Generators/CodeGen/ServiceCatalogCodeGenerator.cs
+++ b/src/NexusLabs.Needlr.Generators/CodeGen/ServiceCatalogCodeGenerator.cs
@@ -276,15 +276,14 @@ internal static class ServiceCatalogCodeGenerator
 
     private static string? GetRelativeSourcePath(string? fullPath, string? projectDirectory)
     {
-        if (fullPath == null || projectDirectory == null)
-            return fullPath;
-
-        if (fullPath.StartsWith(projectDirectory, StringComparison.OrdinalIgnoreCase))
+        if (string.IsNullOrEmpty(fullPath))
         {
-            var relative = fullPath.Substring(projectDirectory.Length);
-            return relative.TrimStart('/', '\\');
+            return null;
         }
 
-        return fullPath;
+        // Delegates to the shared helper so the catalog cannot drift from every other
+        // emitter. The shared helper normalizes separators to '/' and falls back to the
+        // bare file name rather than leaking an absolute build-machine path.
+        return BreadcrumbWriter.GetRelativeSourcePath(fullPath, projectDirectory);
     }
 }


### PR DESCRIPTION
Closes #141 (final defect). Stacked on #143 — **review #142 then #143 first**; this diff includes both until they merge.

## What was broken

The service catalog carried its own **private copy** of `GetRelativeSourcePath` that trimmed only *leading* separators, so interior separators passed through in the host's native form. Every other emitter used the shared `BreadcrumbWriter.GetRelativeSourcePath`, which normalizes to `/`.

One Windows build produced both of these simultaneously:

```
TypeRegistry.g.cs   ->  Options/ApiClientOptions.cs      (shared helper)
ServiceCatalog.g.cs ->  Options\\ApiClientOptions.cs     (private copy)
```

On Linux the catalog emits forward slashes, so the compiled assembly differs by operating system. The catalog is emitted **unconditionally**, so every consumer with at least one discovered type was affected.

The private copy had two further problems:

- it returned the **absolute path** when a source file lay outside the project directory, embedding the build machine's directory layout into the shipped assembly;
- it matched the project prefix with `OrdinalIgnoreCase`, which is wrong on case-sensitive filesystems where two genuinely distinct paths differing only in case are treated as one.

## The fix

The catalog now delegates to the shared helper, keeping only its own null handling so an unknown path still emits a `null` literal rather than the shared helper's `"[unknown]"` sentinel. One implementation, no drift.

## The red test exposed a second, worse defect

Writing the failing test surfaced a bug in the **test harness** that explains why this survived.

Roslyn compares analyzer-config keys **case-insensitively** via `AnalyzerConfigOptions.KeyComparer`. Both test doubles (`FlexibleAnalyzerConfigOptions` and `TestAnalyzerConfigOptions`) used a default `Dictionary`, which is case-sensitive. `WithProjectDir` writes `build_property.projectdir`; the generator reads `build_property.ProjectDir`. The lookup missed, the generator took its "no project directory" branch, and **no test in the repository could observe path relativization at all** — they were asserting against the filename fallback.

That is the real lesson here: the repository *had* tests covering relative source paths, and they were exercising a different code path than the one they claimed to. Both doubles now use `KeyComparer`.

## Red → green

**Red** — test written first, against current code:

```
Failed!  - Failed: 3, Passed: 0
```

After the emitter fix, two passed and the third named the harness bug precisely:

```
Assert.Contains() Failure: Sub-string not found
Not found: "Services/Thing.cs"
```

**Green** — after the harness fix, no change to the test:

```
Passed!  - Failed: 0, Passed: 3, Total: 3
```

The test supplies Windows-style paths **explicitly** rather than relying on the host, so it fails on a Linux agent too. A test that used whatever separator the host produced would pass everywhere and detect nothing.

## Verification

- 1,086 generator tests pass (up from 1,083 — the 3 new ones). **This run mattered:** the harness fix means options that were previously being silently missed now resolve, so any test that had been accidentally exercising a default branch could have flipped. None did.
- 519 integration tests pass.

## Instruction updates

`generator-determinism.instructions.md` gains two sections:

- **Emitted paths** — always use the shared helper, never write a private path helper in an emitter, and never emit an absolute path. It names the duplicate-private-copy mistake explicitly, since that is how this defect survived.
- **Analyzer-config options in tests** — any new options double must use `KeyComparer`, with the failure mode spelled out: the generator silently takes its "option absent" branch and the test passes while proving nothing.

## Disclosures

- **`OrdinalIgnoreCase` prefix matching is unchanged, deliberately.** An earlier draft of this PR described it as an unresolved cross-OS issue. That was wrong: the same comparison runs on every platform and yields the same output for the same inputs, so it is not a determinism concern at all.

  It is a narrow correctness trade. On a case-sensitive filesystem, `/src/app` and `/src/App` are different directories, and `OrdinalIgnoreCase` will treat a file in one as living under the other, emitting `Sub/Thing.cs` and implying project membership that does not exist. Reaching it needs two directories differing only by case with source split across both.

  Switching to `Ordinal` would be a regression. Drive-letter and directory case drift between MSBuild's `$(ProjectDir)` and Roslyn's `SyntaxTree.FilePath` is real on Windows, and `Ordinal` degrades a correct `Services/Thing.cs` to a bare `Thing.cs`, losing the subdirectory the catalog and IDE graph depend on. Making the comparison platform-conditional would be worse still — it would reintroduce precisely the cross-OS output difference this stack removed. `OrdinalIgnoreCase` uniformly is the determinism-preserving choice.
- **The cross-OS newline difference remains**, as documented in `docs/development/deterministic-generators.md`. `AppendLine` uses `Environment.NewLine`, so output stays CRLF on Windows and LF on Linux. That is now the last known cross-OS difference in generated output, and it is not covered by any issue yet.
- I have **not** verified byte-identical output between a real Windows build and a real Linux build. No .NET SDK is available in WSL on this machine, so the cross-OS claims rest on code analysis plus the explicit-path test rather than an end-to-end comparison. A CI job building on both and diffing generated files would settle it properly.
