### PR TITLE
fix: normalize generated line endings to LF at the AddSource boundary

### DIFF
--- a/.claude/rules/generated/generator-determinism.md
+++ b/.claude/rules/generated/generator-determinism.md
@@ -71,8 +71,27 @@ different bytes in the compiled assembly for the same source.
 `GeneratedSourcePathNormalizationTests` supplies Windows-style paths explicitly so it
 fails on a non-Windows agent too, rather than passing by accident of the host.
 
-## Analyzer-config options in tests
+## Line endings are normalized at the AddSource boundary
 
+`StringBuilder.AppendLine` emits `Environment.NewLine`, so emitters naturally produce
+CRLF on Windows and LF elsewhere.
+
+- **Always create source text with `GeneratedSourceText.Create`.** It normalizes to LF
+  and wraps the result as UTF-8 `SourceText`.
+- **`SourceText.From` is banned** in `BannedSymbols.txt`. The single sanctioned call
+  lives inside the helper behind a documented `#pragma warning disable RS0030`. Do not
+  add a second suppression — route the emitter through the helper instead.
+
+The boundary is the right place: there are roughly 1,272 `AppendLine` call sites against
+16 `AddSource` boundaries, so normalizing at the emitters would be unmaintainable and
+would silently regress.
+
+Tests that assert on multi-line generated output must normalize their expected value
+with `.ReplaceLineEndings("\n")`. A raw string literal carries the *test file's* line
+endings, which are CRLF in a Windows checkout, so an un-normalized expectation compares
+CRLF against the generator's LF and fails on Windows only.
+
+## Analyzer-config options in tests
 `AnalyzerConfigOptions` compares keys **case-insensitively** through
 `AnalyzerConfigOptions.KeyComparer`. A test double backed by a default `Dictionary` is
 case-sensitive, so a generator reading `build_property.ProjectDir` silently misses a test

--- a/.github/instructions/generator-determinism.instructions.md
+++ b/.github/instructions/generator-determinism.instructions.md
@@ -68,8 +68,27 @@ different bytes in the compiled assembly for the same source.
 `GeneratedSourcePathNormalizationTests` supplies Windows-style paths explicitly so it
 fails on a non-Windows agent too, rather than passing by accident of the host.
 
-## Analyzer-config options in tests
+## Line endings are normalized at the AddSource boundary
 
+`StringBuilder.AppendLine` emits `Environment.NewLine`, so emitters naturally produce
+CRLF on Windows and LF elsewhere.
+
+- **Always create source text with `GeneratedSourceText.Create`.** It normalizes to LF
+  and wraps the result as UTF-8 `SourceText`.
+- **`SourceText.From` is banned** in `BannedSymbols.txt`. The single sanctioned call
+  lives inside the helper behind a documented `#pragma warning disable RS0030`. Do not
+  add a second suppression — route the emitter through the helper instead.
+
+The boundary is the right place: there are roughly 1,272 `AppendLine` call sites against
+16 `AddSource` boundaries, so normalizing at the emitters would be unmaintainable and
+would silently regress.
+
+Tests that assert on multi-line generated output must normalize their expected value
+with `.ReplaceLineEndings("\n")`. A raw string literal carries the *test file's* line
+endings, which are CRLF in a Windows checkout, so an un-normalized expectation compares
+CRLF against the generator's LF and fails on Windows only.
+
+## Analyzer-config options in tests
 `AnalyzerConfigOptions` compares keys **case-insensitively** through
 `AnalyzerConfigOptions.KeyComparer`. A test double backed by a default `Dictionary` is
 case-sensitive, so a generator reading `build_property.ProjectDir` silently misses a test

--- a/docs/development/deterministic-generators.md
+++ b/docs/development/deterministic-generators.md
@@ -33,6 +33,19 @@ example, formatting a `DateTime` constructed by hand).
     defect is present and fails only when a run happens to straddle a second boundary.
     Assert the invariant structurally instead.
 
+## Determinism is per-machine, per-OS, and per-locale
+
+A rebuild that is byte-identical on one machine is not sufficient. Generated output must
+also not depend on the host's operating system or the build machine's locale:
+
+- **Numbers** go through `GeneratorHelpers.Literal`. Locales including `sv-SE`, `fi-FI`,
+  and `lt-LT` format a negative number with U+2212 MINUS SIGN, which is not valid C#.
+- **String sorts** take an explicit `StringComparer.Ordinal`. The default comparer is
+  culture-sensitive, so emission order changes with the machine's locale.
+- **Source paths** go through `BreadcrumbWriter.GetRelativeSourcePath`, which normalizes
+  separators to `/` and never emits an absolute path.
+- **Line endings** are normalized to LF at the `AddSource` boundary.
+
 ## Keeping a timestamp you actually want
 
 A timestamp is legitimate in a human-readable report. Stamp it where the artifact is
@@ -57,9 +70,15 @@ Get-FileHash src\Examples\SourceGen\CarterSourceGen\bin\Release\net10.0\CarterSo
 
 Two runs must produce the same SHA-256.
 
-## Known limitation
+## Line endings
 
-`StringBuilder.AppendLine` uses `Environment.NewLine`, so generated source uses CRLF on
-Windows and LF on Linux. Output is deterministic *per operating system* but not identical
-across them. Fixing that requires pinning the newline for every emitter and is tracked
-separately.
+`StringBuilder.AppendLine` uses `Environment.NewLine`, so emitters naturally produce CRLF
+on Windows and LF elsewhere. Emitted text is normalized to LF once at the `AddSource`
+boundary by `GeneratedSourceText.Create`, which every generator routes through.
+
+`SourceText.From` is banned in `BannedSymbols.txt` so a new generator cannot bypass the
+helper; the single sanctioned call inside the helper carries a documented
+`#pragma warning disable RS0030`.
+
+Fixing this at the emitters was not viable: there are roughly 1,272 `AppendLine` call
+sites against 16 `AddSource` boundaries.

--- a/src/NexusLabs.Needlr.Generators.Tests/GeneratedConstructorGeneratorTests.cs
+++ b/src/NexusLabs.Needlr.Generators.Tests/GeneratedConstructorGeneratorTests.cs
@@ -114,7 +114,7 @@ public sealed class GeneratedConstructorGeneratorTests
                 /// <exception cref="global::System.ArgumentNullException">
                 /// <paramref name="repository"/> is <see langword="null"/>.
                 /// </exception>
-            """,
+            """.ReplaceLineEndings("\n"),
             generatedCode);
         Assert.Contains("_repository = repository;", generatedCode);
     }
@@ -378,7 +378,7 @@ public sealed class GeneratedConstructorGeneratorTests
                 /// <exception cref="global::System.ArgumentException">
                 /// <paramref name="displayName"/> is empty; or <paramref name="tenantName"/> is empty or consists only of white-space characters.
                 /// </exception>
-            """,
+            """.ReplaceLineEndings("\n"),
             generatedCode);
     }
 

--- a/src/NexusLabs.Needlr.Generators.Tests/GeneratedSourceLineEndingTests.cs
+++ b/src/NexusLabs.Needlr.Generators.Tests/GeneratedSourceLineEndingTests.cs
@@ -1,0 +1,81 @@
+using NexusLabs.Needlr;
+using NexusLabs.Needlr.Generators.Tests.Diagnostics;
+
+using Xunit;
+
+namespace NexusLabs.Needlr.Generators.Tests;
+
+/// <summary>
+/// Guards generated source against the host operating system's line ending.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="System.Text.StringBuilder.AppendLine()"/> emits
+/// <see cref="System.Environment.NewLine"/>, which is CRLF on Windows and LF elsewhere.
+/// Generated source therefore differed byte-for-byte between a Windows build and a Linux
+/// build of identical input, which is the last cross-platform gap in generator output.
+/// </para>
+/// <para>
+/// Fixing this at the roughly 1,272 <c>AppendLine</c> call sites is not viable. Emitted
+/// text is normalized once at the <c>AddSource</c> boundary instead, so this test asserts
+/// the invariant at that same boundary: no generated file may contain a carriage return.
+/// </para>
+/// <para>
+/// The assertion is deliberately "no CR at all" rather than a Windows-versus-Linux
+/// comparison. It is a single invariant that holds on every platform, so it stays
+/// meaningful on a Linux agent where the defect could never have reproduced.
+/// </para>
+/// </remarks>
+public sealed class GeneratedSourceLineEndingTests
+{
+    private const string Source = """
+        using NexusLabs.Needlr;
+        using NexusLabs.Needlr.Generators;
+
+        [assembly: GenerateTypeRegistry]
+
+        namespace TestApp
+        {
+            public interface IThing { }
+
+            public sealed class Thing : IThing { }
+
+            [DecoratorFor<IThing>(Order = 1)]
+            public sealed class ThingDecorator : IThing
+            {
+                public ThingDecorator(IThing inner) { }
+            }
+        }
+        """;
+
+    [Fact]
+    public void GeneratedFiles_ContainNoCarriageReturn()
+    {
+        foreach (var file in Generate())
+        {
+            Assert.False(
+                file.Content.IndexOf('\r') >= 0,
+                $"'{file.FilePath}' contains a carriage return. Emitted text is normalized to "
+                    + "LF at the AddSource boundary so output does not depend on the host OS.");
+        }
+    }
+
+    [Fact]
+    public void GeneratedFiles_AreNonEmpty()
+    {
+        var generated = Generate();
+
+        Assert.NotEmpty(generated);
+        Assert.All(generated, f => Assert.False(string.IsNullOrWhiteSpace(f.Content)));
+    }
+
+    private static GeneratedFile[] Generate()
+    {
+        return GeneratorTestRunner.ForTypeRegistry()
+            .WithReference<DecoratorForAttribute<object>>()
+            .WithSource(Source)
+            .WithDiagnosticsEnabled()
+            .WithGraphExportEnabled()
+            .RunTypeRegistryGeneratorFiles();
+    }
+}

--- a/src/NexusLabs.Needlr.Generators/BannedSymbols.txt
+++ b/src/NexusLabs.Needlr.Generators/BannedSymbols.txt
@@ -14,3 +14,4 @@ P:System.Environment.MachineName;Host identity makes generated output non-determ
 P:System.Environment.UserName;Host identity makes generated output non-deterministic and leaks build-machine details.
 P:System.Environment.TickCount;Ambient timing makes generated output non-deterministic.
 P:System.Environment.ProcessId;Ambient process state makes generated output non-deterministic.
+M:Microsoft.CodeAnalysis.Text.SourceText.From(System.String,System.Text.Encoding,Microsoft.CodeAnalysis.Text.SourceHashAlgorithm);Use GeneratedSourceText.Create so emitted line endings are normalized to LF and do not depend on the host OS.

--- a/src/NexusLabs.Needlr.Generators/GeneratedConstructorGenerator.cs
+++ b/src/NexusLabs.Needlr.Generators/GeneratedConstructorGenerator.cs
@@ -65,7 +65,7 @@ public sealed class GeneratedConstructorGenerator : IIncrementalGenerator
             var (model, emitContext) = source;
             var breadcrumbs = new BreadcrumbWriter(emitContext.BreadcrumbLevel);
             var generatedSource = GeneratedConstructorCodeGenerator.GenerateConstructorSource(model, emitContext.AssemblyName, breadcrumbs);
-            spc.AddSource(GeneratedConstructorCodeGenerator.BuildHintName(model), SourceText.From(generatedSource, Encoding.UTF8));
+            spc.AddSource(GeneratedConstructorCodeGenerator.BuildHintName(model), GeneratedSourceText.Create(generatedSource));
         });
     }
 }

--- a/src/NexusLabs.Needlr.Generators/GeneratedSourceText.cs
+++ b/src/NexusLabs.Needlr.Generators/GeneratedSourceText.cs
@@ -1,0 +1,49 @@
+using System.Text;
+
+using Microsoft.CodeAnalysis.Text;
+
+namespace NexusLabs.Needlr.Generators;
+
+/// <summary>
+/// Creates <see cref="SourceText"/> for <c>AddSource</c> with line endings normalized
+/// to LF.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="StringBuilder.AppendLine()"/> emits <see cref="System.Environment.NewLine"/>,
+/// which is CRLF on Windows and LF elsewhere. Generated source therefore differed
+/// byte-for-byte between a Windows build and a Linux build of identical input.
+/// </para>
+/// <para>
+/// Normalizing here rather than at the emitters is deliberate: there are roughly 1,272
+/// <c>AppendLine</c> call sites and 16 <c>AddSource</c> boundaries. Every emitter routes
+/// through this one choke point, so an emitter added later inherits the guarantee
+/// without knowing about it.
+/// </para>
+/// </remarks>
+internal static class GeneratedSourceText
+{
+    /// <summary>
+    /// Normalizes line endings and wraps the result as UTF-8 <see cref="SourceText"/>.
+    /// </summary>
+    internal static SourceText Create(string generatedText)
+    {
+        // The only sanctioned SourceText.From in this project. BannedSymbols.txt routes
+        // every other emitter here so normalization cannot be bypassed.
+#pragma warning disable RS0030
+        return SourceText.From(NormalizeLineEndings(generatedText), Encoding.UTF8);
+#pragma warning restore RS0030
+    }
+
+    private static string NormalizeLineEndings(string text)
+    {
+        if (text.IndexOf('\r') < 0)
+        {
+            return text;
+        }
+
+        return text
+            .Replace("\r\n", "\n")
+            .Replace("\r", "\n");
+    }
+}

--- a/src/NexusLabs.Needlr.Generators/RecordConstructorOverloadGenerator.cs
+++ b/src/NexusLabs.Needlr.Generators/RecordConstructorOverloadGenerator.cs
@@ -70,7 +70,7 @@ public sealed class RecordConstructorOverloadGenerator : IIncrementalGenerator
                     breadcrumbs);
             sourceContext.AddSource(
                 RecordConstructorOverloadCodeGenerator.BuildHintName(model),
-                SourceText.From(generatedSource, Encoding.UTF8));
+                GeneratedSourceText.Create(generatedSource));
         });
     }
 }

--- a/src/NexusLabs.Needlr.Generators/TypeRegistryGenerator.cs
+++ b/src/NexusLabs.Needlr.Generators/TypeRegistryGenerator.cs
@@ -85,10 +85,10 @@ public sealed class TypeRegistryGenerator : IIncrementalGenerator
             if (nothingDiscovered)
             {
                 var emptyRegistrySource = CodeGen.EmptyTypeRegistryCodeGenerator.GenerateTypeRegistrySource(assemblyName, breadcrumbs);
-                spc.AddSource("TypeRegistry.g.cs", SourceText.From(emptyRegistrySource, Encoding.UTF8));
+                spc.AddSource("TypeRegistry.g.cs", GeneratedSourceText.Create(emptyRegistrySource));
 
                 var emptyBootstrapSource = CodeGen.EmptyTypeRegistryCodeGenerator.GenerateBootstrapSource(assemblyName, breadcrumbs);
-                spc.AddSource("NeedlrSourceGenBootstrap.g.cs", SourceText.From(emptyBootstrapSource, Encoding.UTF8));
+                spc.AddSource("NeedlrSourceGenBootstrap.g.cs", GeneratedSourceText.Create(emptyBootstrapSource));
                 return;
             }
 
@@ -141,23 +141,23 @@ public sealed class TypeRegistryGenerator : IIncrementalGenerator
             }
 
             var sourceText = GenerateTypeRegistrySource(discoveryResult, assemblyName, breadcrumbs, projectDirectory, isAotProject);
-            spc.AddSource("TypeRegistry.g.cs", SourceText.From(sourceText, Encoding.UTF8));
+            spc.AddSource("TypeRegistry.g.cs", GeneratedSourceText.Create(sourceText));
 
             var bootstrapText = CodeGen.BootstrapCodeGenerator.GenerateModuleInitializerBootstrapSource(assemblyName, referencedAssemblies, breadcrumbs, discoveryResult.Factories.Count > 0, discoveryResult.Options.Count > 0 || discoveryResult.HttpClients.Count > 0, discoveryResult.Providers.Count > 0);
-            spc.AddSource("NeedlrSourceGenBootstrap.g.cs", SourceText.From(bootstrapText, Encoding.UTF8));
+            spc.AddSource("NeedlrSourceGenBootstrap.g.cs", GeneratedSourceText.Create(bootstrapText));
 
             // Generate interceptor proxy classes if any were discovered
             if (discoveryResult.InterceptedServices.Count > 0)
             {
                 var interceptorProxiesText = CodeGen.InterceptorCodeGenerator.GenerateInterceptorProxiesSource(discoveryResult.InterceptedServices, assemblyName, breadcrumbs, projectDirectory);
-                spc.AddSource("InterceptorProxies.g.cs", SourceText.From(interceptorProxiesText, Encoding.UTF8));
+                spc.AddSource("InterceptorProxies.g.cs", GeneratedSourceText.Create(interceptorProxiesText));
             }
 
             // Generate factory classes if any were discovered
             if (discoveryResult.Factories.Count > 0)
             {
                 var factoriesText = CodeGen.FactoryCodeGenerator.GenerateFactoriesSource(discoveryResult.Factories, assemblyName, breadcrumbs, projectDirectory);
-                spc.AddSource("Factories.g.cs", SourceText.From(factoriesText, Encoding.UTF8));
+                spc.AddSource("Factories.g.cs", GeneratedSourceText.Create(factoriesText));
             }
 
             // Generate provider classes if any were discovered
@@ -168,7 +168,7 @@ public sealed class TypeRegistryGenerator : IIncrementalGenerator
                 if (interfaceProviders.Count > 0)
                 {
                     var providersText = CodeGen.ProviderCodeGenerator.GenerateProvidersSource(interfaceProviders, assemblyName, breadcrumbs, projectDirectory);
-                    spc.AddSource("Providers.g.cs", SourceText.From(providersText, Encoding.UTF8));
+                    spc.AddSource("Providers.g.cs", GeneratedSourceText.Create(providersText));
                 }
 
                 // Shorthand class providers need to be generated in their original namespace
@@ -176,7 +176,7 @@ public sealed class TypeRegistryGenerator : IIncrementalGenerator
                 foreach (var provider in classProviders)
                 {
                     var providerText = CodeGen.ProviderCodeGenerator.GenerateShorthandProviderSource(provider, assemblyName, breadcrumbs, projectDirectory);
-                    spc.AddSource($"Provider.{provider.SimpleTypeName}.g.cs", SourceText.From(providerText, Encoding.UTF8));
+                    spc.AddSource($"Provider.{provider.SimpleTypeName}.g.cs", GeneratedSourceText.Create(providerText));
                 }
             }
 
@@ -185,7 +185,7 @@ public sealed class TypeRegistryGenerator : IIncrementalGenerator
             if (optionsWithValidators.Count > 0)
             {
                 var validatorsText = CodeGen.OptionsCodeGenerator.GenerateOptionsValidatorsSource(optionsWithValidators, assemblyName, breadcrumbs, projectDirectory);
-                spc.AddSource("OptionsValidators.g.cs", SourceText.From(validatorsText, Encoding.UTF8));
+                spc.AddSource("OptionsValidators.g.cs", GeneratedSourceText.Create(validatorsText));
             }
 
             // Generate DataAnnotations validator classes if any have DataAnnotation attributes
@@ -193,7 +193,7 @@ public sealed class TypeRegistryGenerator : IIncrementalGenerator
             if (optionsWithDataAnnotations.Count > 0)
             {
                 var dataAnnotationsValidatorsText = CodeGen.OptionsCodeGenerator.GenerateDataAnnotationsValidatorsSource(optionsWithDataAnnotations, assemblyName, breadcrumbs, projectDirectory);
-                spc.AddSource("OptionsDataAnnotationsValidators.g.cs", SourceText.From(dataAnnotationsValidatorsText, Encoding.UTF8));
+                spc.AddSource("OptionsDataAnnotationsValidators.g.cs", GeneratedSourceText.Create(dataAnnotationsValidatorsText));
             }
 
             // Generate parameterless constructors for partial positional records with [Options]
@@ -201,12 +201,12 @@ public sealed class TypeRegistryGenerator : IIncrementalGenerator
             if (optionsNeedingConstructors.Count > 0)
             {
                 var constructorsText = CodeGen.OptionsCodeGenerator.GeneratePositionalRecordConstructorsSource(optionsNeedingConstructors, assemblyName, breadcrumbs, projectDirectory);
-                spc.AddSource("OptionsConstructors.g.cs", SourceText.From(constructorsText, Encoding.UTF8));
+                spc.AddSource("OptionsConstructors.g.cs", GeneratedSourceText.Create(constructorsText));
             }
 
             // Generate ServiceCatalog for runtime introspection
             var catalogText = CodeGen.ServiceCatalogCodeGenerator.GenerateServiceCatalogSource(discoveryResult, assemblyName, projectDirectory, breadcrumbs);
-            spc.AddSource("ServiceCatalog.g.cs", SourceText.From(catalogText, Encoding.UTF8));
+            spc.AddSource("ServiceCatalog.g.cs", GeneratedSourceText.Create(catalogText));
 
             // Generate diagnostic output files if configured
             var diagnosticOptions = GetDiagnosticOptions(configOptions);
@@ -214,7 +214,7 @@ public sealed class TypeRegistryGenerator : IIncrementalGenerator
             {
                 var referencedAssemblyTypes = AssemblyDiscoveryHelper.DiscoverReferencedAssemblyTypesForDiagnostics(compilation);
                 var diagnosticsText = DiagnosticsGenerator.GenerateDiagnosticsSource(discoveryResult, assemblyName, projectDirectory, diagnosticOptions, referencedAssemblies, referencedAssemblyTypes);
-                spc.AddSource("NeedlrDiagnostics.g.cs", SourceText.From(diagnosticsText, Encoding.UTF8));
+                spc.AddSource("NeedlrDiagnostics.g.cs", GeneratedSourceText.Create(diagnosticsText));
             }
 
             // Generate IDE graph export if configured
@@ -233,7 +233,7 @@ public sealed class TypeRegistryGenerator : IIncrementalGenerator
                 // Embed graph as a comment in a generated file so it's accessible
                 // The actual JSON is written to obj folder via the generated code
                 var graphSourceText = Export.GraphExporter.GenerateGraphExportSource(graphJson, assemblyName, breadcrumbs, projectDirectory);
-                spc.AddSource("NeedlrGraph.g.cs", SourceText.From(graphSourceText, Encoding.UTF8));
+                spc.AddSource("NeedlrGraph.g.cs", GeneratedSourceText.Create(graphSourceText));
             }
         });
     }


### PR DESCRIPTION
Closes the cross-OS newline gap deferred from #139. Final PR in the stack — **review #142, #143, #144 first**; this diff includes them until they merge.

## What was broken

`StringBuilder.AppendLine` emits `Environment.NewLine`, which is CRLF on Windows and LF elsewhere. Identical input produced different bytes depending on which operating system built it.

This was the item I flagged as a known limitation in #139 and did not take on, then left open while the path and locale defects were fixed. This closes it.

## Why the boundary, not the emitters

| Approach | Sites |
|---|---:|
| Normalize at every `AppendLine` | **~1,272** |
| Normalize at every `AddSource` | **16** |

A per-site fix would be unmaintainable and would regress the first time an emitter was added. `GeneratedSourceText.Create` normalizes to LF and wraps the result as UTF-8 `SourceText`; all 16 boundaries route through it.

## Guard rail

`SourceText.From` is now banned in `BannedSymbols.txt`, so a new generator cannot bypass the helper. The single sanctioned call lives inside the helper behind a documented `#pragma warning disable RS0030`.

**Proven, not assumed** — reintroducing a direct call fails the build:

```
TypeRegistryGenerator.cs(209,50): error RS0030: The symbol
'SourceText.From(string, Encoding?, SourceHashAlgorithm)' is banned in this project:
Use GeneratedSourceText.Create so emitted line endings are normalized to LF and do
not depend on the host OS.
```

## Red → green

**Red** — test written first, against current code:

```
Failed!  - Failed: 1, Passed: 1, Total: 2
'...ServiceCatalog.g.cs' contains a carriage return.
```

**Green** — after normalization, no change to the test:

```
Passed!  - Failed: 0, Passed: 2, Total: 2
```

The assertion is **"no CR at all"**, not a Windows-versus-Linux comparison. That is a single invariant that holds on every platform, so it stays meaningful on a Linux agent where the defect could never have reproduced. A test comparing two OS outputs would need two machines and would be vacuous on either one alone.

## Two existing tests broke — fixed, not relaxed

`GeneratedConstructorGeneratorTests` compared generated output against multi-line raw string literals. A raw string literal carries **the test file's own line endings**: CRLF in a Windows checkout, LF in a Linux checkout. The generator's output varied the same way, so both sides moved together and the assertions matched **by coincidence on each platform** rather than by asserting anything about the generator.

Now that generated output is always LF, the CRLF expectation on Windows no longer matches. The expected values are normalized with `.ReplaceLineEndings("\n")`, which is what they should always have done.

This is the third time in this stack that a real defect was masked by tests that appeared to cover it — the same pattern as the analyzer-config casing bug in #144.

## Verification

- 1,088 generator tests pass (up from 1,086 — the 2 new ones).
- 519 integration tests pass.
- `mkdocs build --strict` passes.

## Documentation

- `docs/development/deterministic-generators.md` — the "Known limitation" section is **deleted** because it is no longer true, and replaced with a "Line endings" section plus a consolidated "Determinism is per-machine, per-OS, and per-locale" summary covering all four defects fixed across this stack.
- `generator-determinism.instructions.md` gains a line-endings section, including the rule that tests asserting on multi-line generated output must normalize their expected value — the exact trap that broke the two tests above.

## Disclosures

- **Diagnostic markdown and graph JSON now emit LF too**, since they are embedded in generated source and pass through the same boundary. The `.md` reports written by the MSBuild task will have LF line endings on Windows where they previously had CRLF. This is intended and consistent, but it is a visible change to a build output, not only to compiled source.
- **Still not verified end-to-end.** I have not built the same project on Windows and Linux and compared bytes; no .NET SDK is available in WSL on this machine. The claim rests on the invariant test plus code analysis. A CI job building on both and diffing generated files would settle every cross-OS claim in this stack properly — I'd suggest that as the real closure, and can open an issue for it.
- The `OrdinalIgnoreCase` path-prefix comparison noted in #144 is still unaddressed.
